### PR TITLE
bug fix for building on Ubuntu Linux (and possibly elsewhere)

### DIFF
--- a/pv-core/src/columns/PV_Arguments.cpp
+++ b/pv-core/src/columns/PV_Arguments.cpp
@@ -7,6 +7,7 @@
 
 #include <cstdlib>
 #include <omp.h>
+#include <string.h>
 #include "PV_Arguments.hpp"
 #include "../io/io.h"
 


### PR DESCRIPTION
PV_Arguments.cpp was using the strerror command, which requires standard library string.h. Adding the include line resolved the error.
