### PR TITLE
IdentConn and TransposeConn no longer checkpoint

### DIFF
--- a/pv-core/src/connections/IdentConn.hpp
+++ b/pv-core/src/connections/IdentConn.hpp
@@ -58,6 +58,10 @@ protected:
 
    virtual int setWeightInitializer();
 
+   // IdentConn does not need to checkpoint
+   virtual int checkpointRead(const char * cpDir, double* timef) { return PV_SUCCESS; }
+   virtual int checkpointWrite(const char * cpDir) { return PV_SUCCESS; }
+
    virtual void handleDefaultSelfFlag();
 
    virtual int deliverPresynapticPerspective(PVLayerCube const * activity, int arborID);

--- a/pv-core/src/connections/TransposeConn.hpp
+++ b/pv-core/src/connections/TransposeConn.hpp
@@ -100,6 +100,10 @@ protected:
     virtual int constructWeights();
     virtual int allocatePostConn();
 
+    // TransposeConn does not need to checkpoint; instead it gets its weights from the originalConn.
+    virtual int checkpointWrite(const char * cpDir){return PV_SUCCESS;};
+    virtual int checkpointRead(const char * cpDir, double *timef){return PV_SUCCESS;};
+
 private:
     //int transposeSharedWeights(int arborId);
     //int transposeNonsharedWeights(int arborId);


### PR DESCRIPTION
In response to https://github.com/PetaVision/OpenPV/issues/28, it looks like all we need to do for TransposeConn is to override checkpointRead and checkpointWrite to do nothing: the system tests all pass.  I also turned off checkpointing for IdentConn.
