### PR TITLE
RecvFromPost Sparse

### DIFF
--- a/pv-core/src/connections/HyPerConn.cpp
+++ b/pv-core/src/connections/HyPerConn.cpp
@@ -2996,8 +2996,15 @@ int HyPerConn::deliverPresynapticPerspective(PVLayerCube const * activity, int a
 }
 
 
+int HyPerConn::deliverPostsynapticPerspective(PVLayerCube const * activity, int arborID, int* numActive, int** activeList) {
+   //Make sure numActive and activeList are either both null or both valid pointers
+   if(numActive){
+      assert(activeList);
+   }
+   else{
+      assert(!activeList);
+   }
 
-int HyPerConn::deliverPostsynapticPerspective(PVLayerCube const * activity, int arborID) {
    //Check channel number for noupdate
    if(getChannel() == CHANNEL_NOUPDATE){
       return PV_SUCCESS;
@@ -3042,11 +3049,29 @@ int HyPerConn::deliverPostsynapticPerspective(PVLayerCube const * activity, int 
       exit(EXIT_FAILURE);
    }
 
-#ifdef PV_USE_OPENMP_THREADS
-#pragma omp parallel for schedule(static) collapse(2)
-#endif
+   bool recvPostSparse = numActive;
+
    for(int b = 0; b < nbatch; b++){
-      for (int kTargetRes = 0; kTargetRes < numPostRestricted; kTargetRes++){
+      int numLoop;
+      if(recvPostSparse){
+         numLoop = numActive[b];
+      }
+      else{
+         numLoop = numPostRestricted;
+      }
+#ifdef PV_USE_OPENMP_THREADS
+#pragma omp parallel for schedule(static)
+#endif
+      for (int iLoop = 0; iLoop < numLoop; iLoop++){
+         int kTargetRes;
+         if(recvPostSparse){
+            kTargetRes = activeList[b][iLoop];
+         }
+         else{
+            kTargetRes = iLoop;
+         }
+         
+
          pvdata_t * activityBatch = activity->data + b * (sourceNx + sourceHalo->rt + sourceHalo->lt) * (sourceNy + sourceHalo->up + sourceHalo->dn) * sourceNf;
          pvdata_t * gSynPatchHeadBatch = gSynPatchHead + b * targetNx * targetNy * targetNf;
          //Change restricted to extended post neuron
@@ -3066,6 +3091,7 @@ int HyPerConn::deliverPostsynapticPerspective(PVLayerCube const * activity, int 
    }
    return PV_SUCCESS;
 }
+
 
 
 #if defined(PV_USE_CUDA)

--- a/pv-core/src/connections/HyPerConn.cpp
+++ b/pv-core/src/connections/HyPerConn.cpp
@@ -3049,6 +3049,7 @@ int HyPerConn::deliverPostsynapticPerspective(PVLayerCube const * activity, int 
       exit(EXIT_FAILURE);
    }
 
+   //If numActive is a valid pointer, we're recv from post sparse
    bool recvPostSparse = numActive;
 
    for(int b = 0; b < nbatch; b++){

--- a/pv-core/src/connections/HyPerConn.hpp
+++ b/pv-core/src/connections/HyPerConn.hpp
@@ -873,7 +873,7 @@ protected:
    void connOutOfMemory(const char* funcname);
 
    virtual int deliverPresynapticPerspective(PVLayerCube const * activity, int arborID);
-   virtual int deliverPostsynapticPerspective(PVLayerCube const * activity, int arborID);
+   virtual int deliverPostsynapticPerspective(PVLayerCube const * activity, int arborID, int* numActive = NULL, int** activeList = NULL);
 #if defined(PV_USE_OPENCL) || defined(PV_USE_CUDA)
    virtual int deliverPresynapticPerspectiveGPU(PVLayerCube const * activity, int arborID);
    virtual int deliverPostsynapticPerspectiveGPU(PVLayerCube const * activity, int arborID);


### PR DESCRIPTION
I added optional arguments to recvfrompost to prepare for recv from post sparse on the CPU. Here, we pass in 2 new arguments: int\* numActive (array of size [nbatch]) and int*\* activeList (array of size [nbatch, numActive]. If the pointers are NULL (which they default to), recvFromPost will behave like before. Unfortunately, I had to remove threading over batches because of this change, so I wanted to see if you guys had a better idea for adding this in while still threading over batches.

Sheng
