### PR TITLE
Output params file is generated before a bad -t argument causes PV to exit

### DIFF
--- a/pv-core/src/columns/HyPerCol.hpp
+++ b/pv-core/src/columns/HyPerCol.hpp
@@ -485,10 +485,19 @@ private:
    int writeTimers(FILE* stream);
 
    int outputParams(char const * path);
+   int outputParamsHeadComments(FILE* fp, char const * commentToken);
 
    double* adaptTimeScale();
    double* adaptTimeScaleExp1stOrder();
    int calcTimeScaleTrue();
+
+   /**
+    * Sets the numThreads member variable based on whether PV_USE_OPENMP is set
+    * and the -t option in the PV_Arguments object.
+    * If printMessagesFlag is true, it may print to stdout and stderr.
+    * If printMessagesFlag is false, these messages are suppressed.
+    */
+   int setNumThreads(bool printMessagesFlag);
 
    long int currentStep;
    long int initialStep;

--- a/pv-core/src/columns/PV_Arguments.cpp
+++ b/pv-core/src/columns/PV_Arguments.cpp
@@ -88,7 +88,7 @@ void PV_Arguments::freeArgs(int argc, char ** argv) {
    return;
 }
 
-char ** PV_Arguments::getArgsCopy() {
+char ** PV_Arguments::getArgsCopy() const {
    return copyArgs(numArgs, args);
 }
 

--- a/pv-core/src/columns/PV_Arguments.hpp
+++ b/pv-core/src/columns/PV_Arguments.hpp
@@ -75,13 +75,13 @@ public:
     * Returns the string passed as argv[0] to the constructor,
     * typically the name of the program being run.
     */
-   char const * getProgramName() { return args ? args[0] : NULL; }
+   char const * getProgramName() const { return args ? args[0] : NULL; }
 
    /**
     * getArgument(i) returns the string passed as argv[i] to the constructor.
     * If i is out of bounds, returns null.
     */
-   char const * getArgument(int i) { return (i>=0 && i<numArgs) ? args[i] : NULL; }
+   char const * getArgument(int i) const { return (i>=0 && i<numArgs) ? args[i] : NULL; }
 
    /**
     * Returns a read-only pointer to the args array.
@@ -89,7 +89,7 @@ public:
     * this method does not provide a way to modify the args array.
     */
 
-   char const * const * getArgsConst() { return args; }
+   char const * const * getArgsConst() const { return args; }
    /**
     * Returns a copy of the args array.  It uses malloc and strdup, so the caller
     * is responsible for freeing getArgs()[k] for each k and for freeing getArgs()
@@ -97,7 +97,7 @@ public:
     * static method PV_Argument::freeArgs)
     * The length of the returned array is argc+1, and getArgs()[argc] is NULL.
     */
-   char ** getArgsCopy();
+   char ** getArgsCopy() const;
 
    /**
     * Deallocates an array, assuming it was created by a call to getArgs().
@@ -108,82 +108,82 @@ public:
    /**
     * Returns the length of the array returned by getUnusedArgArray(); i.e. the argc argument passed to the constructor.
     */
-   int getNumArgs() { return numArgs; }
+   int getNumArgs() const { return numArgs; }
 
    /**
     * Returns true if the require-return flag was set.
     */
-   bool getRequireReturnFlag() { return requireReturnFlag; }
+   bool getRequireReturnFlag() const { return requireReturnFlag; }
 
    /**
     * Returns the output path string.
     */
-   char const * getOutputPath() { return outputPath; }
+   char const * getOutputPath() const { return outputPath; }
 
    /**
     * Returns the params file string.
     */
-   char const * getParamsFile() { return paramsFile; }
+   char const * getParamsFile() const { return paramsFile; }
 
    /**
     * Returns the log file string.
     */
-   char const * getLogFile() { return logFile; }
+   char const * getLogFile() const { return logFile; }
 
    /**
     * Returns the gpu devices string.
     */
-   char const * getGPUDevices() { return gpuDevices; }
+   char const * getGPUDevices() const { return gpuDevices; }
 
    /**
     * Returns the random seed.
     */
-   unsigned int getRandomSeed() { return randomSeed; }
+   unsigned int getRandomSeed() const { return randomSeed; }
 
    /**
     * Returns the working directory string.
     */
-   char const * getWorkingDir() { return workingDir; }
+   char const * getWorkingDir() const { return workingDir; }
 
    /**
     * Returns true if the restart flag was set.
     */
-   bool getRestartFlag() { return restartFlag; }
+   bool getRestartFlag() const { return restartFlag; }
 
    /**
     * Returns the checkpointRead directory string.
     */
-   char const * getCheckpointReadDir() { return checkpointReadDir; }
+   char const * getCheckpointReadDir() const { return checkpointReadDir; }
 
    /**
     * Returns the useDefaultNumThreads flag.
     */
-   bool getUseDefaultNumThreads() { return useDefaultNumThreads; }
+   bool getUseDefaultNumThreads() const { return useDefaultNumThreads; }
 
    /**
     * Returns the number of threads.
     */
-   int getNumThreads() { return numThreads; }
+   int getNumThreads() const { return numThreads; }
 
    /**
     * Returns the number of rows.
     */
-   int getNumRows() { return numRows; }
+   int getNumRows() const { return numRows; }
 
    /**
     * Returns the number of columns.
     */
-   int getNumColumns() { return numColumns; }
+   int getNumColumns() const { return numColumns; }
 
    /**
     * Returns the batch width.
     */
-   int getBatchWidth() { return batchWidth; }
+   int getBatchWidth() const { return batchWidth; }
 
    /**
     * Returns true if the dry-run flag was set.
     */
-   bool getDryRunFlag() { return dryRunFlag; }
+   bool getDryRunFlag() const { return dryRunFlag; }
 
    /**
     * Sets the value of the require-return flag.

--- a/pv-core/src/columns/buildandrun.cpp
+++ b/pv-core/src/columns/buildandrun.cpp
@@ -281,7 +281,9 @@ int buildandrun1paramset(PV_Init * initObj,
    return status;
 }
 
+// Deprecated April 14, 2016.
 int outputParams(int argc, char * argv[], char const * path, ParamGroupHandler ** groupHandlerList, int numGroupHandlers) {
+   printf("\nWarning: outputParams is deprecated.  Instead use the -n option on the command line or the dryRunFlag in PV_Arguments.\n\n");
    PV::PV_Init * initObj = new PV::PV_Init(&argc, &argv, false/*allowUnrecognizedArguments*/);
    initObj->initialize();
    if (initObj->isExtraProc()) { return EXIT_SUCCESS; }

--- a/pv-core/src/columns/buildandrun.hpp
+++ b/pv-core/src/columns/buildandrun.hpp
@@ -63,6 +63,7 @@ int buildandrun1paramset(PV_Init* initObj,
                          int (*customexit)(HyPerCol *, int, char **),
                          ParamGroupHandler ** groupHandlerList, int numGroupHandlers);
 
+// Deprecated April 14, 2016, in favor of using the dryRunFlag in PV_Arguments and the -n flag on the command line.
 int outputParams(int argc, char * argv[], char const * path, ParamGroupHandler ** groupHandlerList, int numGroupHandlers);
 
 HyPerCol * build(PV_Init * initObj,


### PR DESCRIPTION
This pull request addresses issue https://github.com/PetaVision/OpenPV/issues/43.

I moved the calculation of numThreads from HyPerCol::initialize to HyPerCol::run, where processParams is called.  However, the calculation of numThreads needs to be before the call to processParams, so that the result can be in the generated params file; while any error messages in case of a bad -t option need to be printed the call to processParams (processParams prints a lot of messages since it handles the communicateInitInfo stage, and error messages should be at the end where they're easy to find.)

To work around this issue, numThreads is calculated twice, once before and once after the processParams call.  Only the second call prints messages.

The header comments in the generated params files say what the number of threads are if the -t setting is good, and the nature of the error if the -t setting is bad.  I also eliminated duplicate code for the header comments of the .params and .params.lua files by creating a HyPerCol method, outputParamsHeadComments, which takes the file pointer and the comment token ("//" versus "--") as arguments.
