### PR TITLE
Moved wrapper utility preprocessor definitions out of namespaces

### DIFF
--- a/pv-core/src/utils/PVAlloc.hpp
+++ b/pv-core/src/utils/PVAlloc.hpp
@@ -23,38 +23,38 @@
 #include <stdlib.h>
 #include "utils/PVLog.hpp"
 
-namespace PV {
-
 /**
  * pvMalloc(size_t size);
  * 
  * replaces standard malloc()
  */
-#define pvMalloc(size) pv_malloc(__FILE__, __LINE__, size)
+#define pvMalloc(size) PV::pv_malloc(__FILE__, __LINE__, size)
 /**
  * pvCalloc(count, size)
  *
  * replaces standard calloc()
  */
-#define pvCalloc(count, size) pv_calloc(__FILE__, __LINE__, count, size)
+#define pvCalloc(count, size) PV::pv_calloc(__FILE__, __LINE__, count, size)
 /**
  * pvMallocError(size, fmt, ...)
  *
  * Adds an error message if the allocation fails.
  */
-#define pvMallocError(size, fmt, ...) pv_malloc(__FILE__, __LINE__, size, fmt, ##__VA_ARGS__)
+#define pvMallocError(size, fmt, ...) PV::pv_malloc(__FILE__, __LINE__, size, fmt, ##__VA_ARGS__)
 /**
  * pvCallocError(count, size, fmt, ...)
  *
  * Adds an error message if the allocation fails.
  */
-#define pvCallocError(count, size, fmt, ...) pv_calloc(__FILE__, __LINE__, count, size, fmt, ##__VA_ARGS__)
+#define pvCallocError(count, size, fmt, ...) PV::pv_calloc(__FILE__, __LINE__, count, size, fmt, ##__VA_ARGS__)
 /**
  * Wraps a call to delete
  *
  * Verifies that the pointer is not NULL for calling delete. 
  */
-#define pvDelete(ptr) pv_delete(__FILE__, __LINE__, ptr)
+#define pvDelete(ptr) PV::pv_delete(__FILE__, __LINE__, ptr)
+
+namespace PV {
 
 void *pv_malloc(const char *file, int line, size_t size);
 void *pv_malloc(const char *file, int line, size_t size, const char *fmt, ...);

--- a/pv-core/src/utils/PVAssert.hpp
+++ b/pv-core/src/utils/PVAssert.hpp
@@ -22,7 +22,6 @@
 #include <stdlib.h>
 #include "utils/PVLog.hpp"
 
-namespace PV {
    
 #ifdef NDEBUG
 #define pvAssert(c)
@@ -33,13 +32,14 @@ namespace PV {
  * Works just like assert(), except it is not compiled out in Release versions and provides a stack trace and
  * prints out the failed condition and the filename:line number of the failure
  */
-#define pvAssert(c) if (!(c)) { pv_assert_failed(__FILE__, __LINE__, #c); }
+#define pvAssert(c) if (!(c)) { PV::pv_assert_failed(__FILE__, __LINE__, #c); }
 /**
  * Like pvAssert(). Adds an additional error message to the output.
  */
-#define pvAssertMessage(c, fmt, ...) if (!(c)) { pv_assert_failed_message(__FILE__, __LINE__, #c, fmt, ##__VA_ARGS__); }
+#define pvAssertMessage(c, fmt, ...) if (!(c)) { PV::pv_assert_failed_message(__FILE__, __LINE__, #c, fmt, ##__VA_ARGS__); }
 #endif
 
+namespace PV {
 void pv_assert_failed(const char *file, int line, const char *condition);
 void pv_assert_failed_message(const char *file, int line, const char *condition, const char *fmt, ...);
 

--- a/pv-core/src/utils/PVLog.hpp
+++ b/pv-core/src/utils/PVLog.hpp
@@ -6,7 +6,6 @@
 #include <type_traits>
 #include <string>
 
-namespace PV {
 
 #ifdef NDEBUG
     // Not DEBUG build
@@ -47,6 +46,27 @@ namespace PV {
 #define DEBUG_LOG_TEST_CONDITION        false
 #endif
 
+// Because __LINE__ and __FILE__ evaluate to *this* file, not
+// the file where the inline function is called. This is different
+// from Clang, which puts in the __FILE__ and __LINE__ of the caller
+#ifdef __GNUC__
+#define Debug() PV::_Debug(__FILE__, __LINE__)
+#define Info() PV::_Info(__FILE__, __LINE__)
+#define Error() PV::_Error(__FILE__, __LINE__)
+#define StackTrace() PV::_StackTrace(__FILE__, __LINE__)
+#endif
+
+#ifdef _PV_DEBUG_OUTPUT
+#define logDebug(fmt, ...) PV::pv_log_debug(__FILE__, __LINE__, fmt, ##__VA_ARGS__)
+#else
+#define logDebug(fmt, ...)
+#endif
+
+#define logError(fmt, ...) PV::pv_log_error(__FILE__, __LINE__, fmt, ##__VA_ARGS__)
+#define logInfo(fmt, ...) PV::pv_log_info(__FILE__, __LINE__, fmt, ##__VA_ARGS__)
+#define exitFailure(fmt, ...) PV::pv_exit_failure(__FILE__, __LINE__, fmt, ##__VA_ARGS__)
+
+namespace PV {
 enum LogTypeEnum {
    _LogInfo, _LogError, _LogDebug, _LogStackTrace
 };
@@ -150,6 +170,7 @@ private:
 };
 
 #ifdef __GNUC__
+//Macros that call these functions defined outside of namespace
 typedef _Log<char,    LogDebugType>      _Debug;
 typedef _Log<char,    LogInfoType>       _Info;
 typedef _Log<char,    LogErrorType>      _Error;
@@ -159,14 +180,6 @@ typedef _Log<wchar_t, LogDebugType>      _WDebug;
 typedef _Log<wchar_t, LogInfoType>       _WInfo;
 typedef _Log<wchar_t, LogErrorType>      _WError;
 typedef _Log<wchar_t, LogStackTraceType> _WStackTrace;
-
-// Because __LINE__ and __FILE__ evaluate to *this* file, not
-// the file where the inline function is called. This is different
-// from Clang, which puts in the __FILE__ and __LINE__ of the caller
-#define Debug() _Debug(__FILE__, __LINE__)
-#define Info() _Info(__FILE__, __LINE__)
-#define Error() _Error(__FILE__, __LINE__)
-#define StackTrace() _StackTrace(__FILE__, __LINE__)
 
 #else
 // Clang __FILE__ and __LINE__ evalaute to the caller of the function
@@ -200,15 +213,6 @@ typedef _Log<wchar_t, LogStackTraceType> WStackTrace;
  * These macros provide an opportunity to handle sending debug, error and info messages to other MPI ranks
  */
 
-#ifdef _PV_DEBUG_OUTPUT
-#define logDebug(fmt, ...) pv_log_debug(__FILE__, __LINE__, fmt, ##__VA_ARGS__)
-#else
-#define logDebug(fmt, ...)
-#endif
-
-#define logError(fmt, ...) pv_log_error(__FILE__, __LINE__, fmt, ##__VA_ARGS__)
-#define logInfo(fmt, ...) pv_log_info(__FILE__, __LINE__, fmt, ##__VA_ARGS__)
-#define exitFailure(fmt, ...) pv_exit_failure(__FILE__, __LINE__, fmt, ##__VA_ARGS__)
 
 void pv_log_error(const char *file, int line, const char *fmt, ...);
 void pv_log_debug(const char *file, int line, const char *fmt, ...);


### PR DESCRIPTION
Previously, calling pvAssert fails when the caller is in a different namespace other than PV. Since pvAssert itself is a macro defined within the PV namespace, calling pvAssert will fail when trying to call pv_assert_failed, as the function is not defined in the current namespace. On the contrary, if we call PV::pvAssert, the file will fail to compile as the PV:: prefix will apply to the if statement when pvAssert gets expanded. I've created a pull request to move all preprocessor definitions of various utility functions outside of namespace definitions, and instead explicitly adding PV:: prefix to various inner functions (such as pv_assert_failed) to fix this problem.
