### PR TITLE
Removes references to pooling values of pvpatchAccumulateType from HyPerConn

### DIFF
--- a/pv-core/src/connections/HyPerConn.cpp
+++ b/pv-core/src/connections/HyPerConn.cpp
@@ -179,7 +179,7 @@ int HyPerConn::initialize_base()
    thread_gSyn = NULL;
 
    pvpatchAccumulateTypeString = NULL;
-   pvpatchAccumulateType = ACCUMULATE_CONVOLVE;
+   pvpatchAccumulateType = CONVOLVE;
 
    initInfoCommunicatedFlag = false;
    dataStructuresAllocatedFlag = false;
@@ -411,14 +411,15 @@ int HyPerConn::initialize(const char * name, HyPerCol * hc, InitWeights * weight
    //set accumulateFunctionPointer
    pvAssert(!inputParams->presentAndNotBeenRead(name, "pvpatchAccumulateType"));
    switch (pvpatchAccumulateType) {
-   case ACCUMULATE_CONVOLVE:
+   case CONVOLVE:
       accumulateFunctionPointer  = &pvpatch_accumulate;
       accumulateFunctionFromPostPointer = &pvpatch_accumulate_from_post;
       break;
-   case ACCUMULATE_STOCHASTIC:
+   case STOCHASTIC:
       accumulateFunctionPointer = &pvpatch_accumulate_stochastic;
       accumulateFunctionFromPostPointer = &pvpatch_accumulate_stochastic_from_post;
       break;
+#ifdef OBSOLETE // Marked obsolete May 3, 2016.  HyPerConn defines AccumulateType and PoolingConn defines PoolingType
    case ACCUMULATE_MAXPOOLING:
       exitFailure("ACCUMULATE_MAXPOOLING not allowed in HyPerConn, use PoolingConn instead");
       //accumulateFunctionPointer = &pvpatch_max_pooling;
@@ -434,6 +435,7 @@ int HyPerConn::initialize(const char * name, HyPerCol * hc, InitWeights * weight
       //accumulateFunctionPointer = &pvpatch_sum_pooling;
       //accumulateFunctionFromPostPointer = &pvpatch_accumulate_from_post;
       break;
+#endif // OBSOLETE // Marked obsolete May 3, 2016.  HyPerConn defines AccumulateType and PoolingConn defines PoolingType
    default:
       pvAssert(0);
       break;
@@ -826,12 +828,12 @@ void HyPerConn::ioParam_pvpatchAccumulateType(enum ParamsIOFlag ioFlag) {
       }
 
       if (strcmp(pvpatchAccumulateTypeString,"convolve")==0) {
-         pvpatchAccumulateType = ACCUMULATE_CONVOLVE;
+         pvpatchAccumulateType = CONVOLVE;
       }
       else if (strcmp(pvpatchAccumulateTypeString,"stochastic")==0) {
-         pvpatchAccumulateType = ACCUMULATE_STOCHASTIC;
+         pvpatchAccumulateType = STOCHASTIC;
       }
-      //IOParam for different pooling types is still handled here, TODO, move this to PoolingConn
+#ifdef OBSOLETE // Marked obsolete May 3, 2016.  HyPerConn defines HyPerConnAccumulateType and PoolingConn defines PoolingType
       else if ((strcmp(pvpatchAccumulateTypeString,"maxpooling")==0) ||
 	       (strcmp(pvpatchAccumulateTypeString,"max_pooling")==0) ||
 	       (strcmp(pvpatchAccumulateTypeString,"max pooling")==0)) {
@@ -847,6 +849,7 @@ void HyPerConn::ioParam_pvpatchAccumulateType(enum ParamsIOFlag ioFlag) {
 	       (strcmp(pvpatchAccumulateTypeString,"avg pooling")==0)) {
          pvpatchAccumulateType = ACCUMULATE_AVGPOOLING;
       }
+#endif // OBSOLETE // Marked obsolete May 3, 2016.  HyPerConn defines HyPerConnAccumulateType and PoolingConn defines PoolingType
       else {
          unsetAccumulateType();
       }
@@ -863,7 +866,7 @@ void HyPerConn::unsetAccumulateType() {
          logError("%s \"%s\" error: pvpatchAccumulateType NULL is unrecognized.",
                getKeyword(), name);
       }
-      logError("  Allowed values are \"convolve\", \"stochastic\", or \"maxpooling\".");
+      logError("  Allowed values are \"convolve\" or \"stochastic\".");
    }
    MPI_Barrier(parent->icCommunicator()->communicator());
    exitFailure("");
@@ -1220,7 +1223,7 @@ int HyPerConn::communicateInitInfo() {
    }
 
 
-   if (getPvpatchAccumulateType()==ACCUMULATE_STOCHASTIC && (getConvertRateToSpikeCount() || pre->activityIsSpiking())) {
+   if (getPvpatchAccumulateType()==STOCHASTIC && (getConvertRateToSpikeCount() || pre->activityIsSpiking())) {
       if (parent->columnId()==0) {
          logError("Connection \"%s\": stochastic accumulation function is not consistent with ", getName());
          if (getConvertRateToSpikeCount()) {
@@ -1489,7 +1492,7 @@ int HyPerConn::allocateDataStructures() {
    initNumDataPatches();
    initPatchToDataLUT();
 
-   if (pvpatchAccumulateType == ACCUMULATE_STOCHASTIC) {
+   if (pvpatchAccumulateType == STOCHASTIC) {
       bool from_post = getUpdateGSynFromPostPerspective();
       if (from_post) {
          randState = new Random(parent, postSynapticLayer()->getLayerLoc(), false/*isExtended*/);
@@ -1573,7 +1576,7 @@ void HyPerConn::initPatchToDataLUT() {
 
 taus_uint4 * HyPerConn::getRandState(int index) {
    taus_uint4 * state = NULL;
-   if (pvpatchAccumulateType==ACCUMULATE_STOCHASTIC) {
+   if (pvpatchAccumulateType==STOCHASTIC) {
       state = randState->getRNG(index);
    }
    return state;
@@ -2912,7 +2915,7 @@ int HyPerConn::deliverPresynapticPerspective(PVLayerCube const * activity, int a
    pvAssert(post->getChannel(getChannel()));
 
    float dt_factor;
-   if (getPvpatchAccumulateType()==ACCUMULATE_STOCHASTIC) {
+   if (getPvpatchAccumulateType()==STOCHASTIC) {
       dt_factor = getParent()->getDeltaTime();
    }
    else {
@@ -3036,7 +3039,7 @@ int HyPerConn::deliverPostsynapticPerspective(PVLayerCube const * activity, int 
    const int numPostRestricted = post->getNumNeurons();
 
    float dt_factor;
-   if (getPvpatchAccumulateType()==ACCUMULATE_STOCHASTIC) {
+   if (getPvpatchAccumulateType()==STOCHASTIC) {
       dt_factor = getParent()->getDeltaTime();
    }
    else {
@@ -3159,10 +3162,10 @@ int HyPerConn::deliverPresynapticPerspectiveGPU(PVLayerCube const * activity, in
    pvAssert(post->getChannel(getChannel())); // pvAssert(GSyn && GSyn[conn->getChannel()]);
 
    float dt_factor;
-   if (getPvpatchAccumulateType()==ACCUMULATE_STOCHASTIC) {
+   if (getPvpatchAccumulateType()==STOCHASTIC) {
       dt_factor = getParent()->getDeltaTime();
    }
-   else if (getPvpatchAccumulateType()==ACCUMULATE_CONVOLVE) {
+   else if (getPvpatchAccumulateType()==CONVOLVE) {
       dt_factor = getConvertToRateDeltaTimeFactor();
    }
    else{
@@ -3277,15 +3280,14 @@ int HyPerConn::deliverPostsynapticPerspectiveGPU(PVLayerCube const * activity, i
    const int numRestricted = post->getNumNeurons();
 
    float dt_factor;
-   if (getPvpatchAccumulateType()==ACCUMULATE_STOCHASTIC) {
+   if (getPvpatchAccumulateType()==STOCHASTIC) {
       dt_factor = getParent()->getDeltaTime();
    }
-   else if (getPvpatchAccumulateType()==ACCUMULATE_CONVOLVE) {
+   else if (getPvpatchAccumulateType()==CONVOLVE) {
       dt_factor = getConvertToRateDeltaTimeFactor();
    }
    else{
-      std::cout << "Pooling accumulate not implemented for GPUs";
-      exit(-1);
+      pvAssert(0); // Only STOCHASTIC and CONVOLVE are defined in HyPerConn; other methods should be handled in subclasses.
    }
 
    pvAssert(krRecvPost);

--- a/pv-core/src/connections/HyPerConn.hpp
+++ b/pv-core/src/connections/HyPerConn.hpp
@@ -67,8 +67,13 @@ public:
    friend class PlasticCloneConn;
    friend class TransposeConn;
    friend class privateTransposeConn;
+//#ifdef OBSOLETE // Marked obsolete May 3, 2016.  All pooling-dependent behavior should be in PoolingConn
    friend class TransposePoolingConn;
+//#endif // OBSOLETE // Marked obsolete May 3, 2016.  All pooling-dependent behavior should be in PoolingConn
    
+   enum AccumulateType {UNDEFINED, CONVOLVE, STOCHASTIC};
+   // Subclasses that need different accumulate types should define their own enums
+
    HyPerConn(const char * name, HyPerCol * hc, InitWeights * weightInitializer=NULL, NormalizeBase * weightNormalizer=NULL);
    virtual ~HyPerConn();
 //#ifdef PV_USE_OPENCL
@@ -108,7 +113,7 @@ public:
    virtual void deliverOnePreNeuronActivity(int patchIndex, int arbor, pvadata_t a, pvgsyndata_t * postBufferStart, void * auxPtr);
    virtual void deliverOnePostNeuronActivity(int arborID, int kTargetExt, int inSy, float* activityStartBuf, pvdata_t* gSynPatchPos, float dt_factor, taus_uint4 * rngPtr);
     
-   GSynAccumulateType getPvpatchAccumulateType() { return pvpatchAccumulateType; }
+   AccumulateType getPvpatchAccumulateType() { return pvpatchAccumulateType; }
    int (*accumulateFunctionPointer)(int kPreRes, int nk, float* v, float a, pvwdata_t* w, void* auxPtr, int sf);
    int (*accumulateFunctionFromPostPointer)(int kPreRes, int nk, float* v, float* a, pvwdata_t* w, float dt_factor, void* auxPtr, int sf);
 
@@ -478,7 +483,7 @@ protected:
    char * weightInitTypeString;
    InitWeights* weightInitializer;
    char * pvpatchAccumulateTypeString;
-   GSynAccumulateType pvpatchAccumulateType;
+   AccumulateType pvpatchAccumulateType;
    bool normalizeTotalToPost; // if false, normalize the sum of weights from each presynaptic neuron.  If true, normalize the sum of weights into a postsynaptic neuron.
    float dWMax;  // dW scale factor
    bool useListOfArborFiles;
@@ -496,8 +501,6 @@ protected:
    long ** numKernelActivations;
    bool keepKernelsSynchronized_flag;
 
-   // unsigned int rngSeedBase; // The starting seed for rng.  The parent HyPerCol reserves {rngSeedbase, rngSeedbase+1,...rngSeedbase+neededRNGSeeds-1} for use by this layer
-   // taus_uint4 * rnd_state; // An array of RNGs.
    Random * randState;
 
 
@@ -1048,21 +1051,19 @@ protected:
    PVCuda::CudaBuffer * d_WData;
 #ifdef PV_USE_CUDNN
    PVCuda::CudaBuffer * cudnn_WData;
-#endif
+#endif // PV_USE_CUDNN
    PVCuda::CudaBuffer * d_Patches;
    PVCuda::CudaBuffer * d_GSynPatchStart;
    PVCuda::CudaBuffer * d_PostToPreActivity;
    PVCuda::CudaBuffer * d_Patch2DataLookupTable;
    PVCuda::CudaRecvPost* krRecvPost;        // Cuda kernel for update state call
    PVCuda::CudaRecvPre* krRecvPre;        // Cuda kernel for update state call
-#endif
+#endif // PV_USE_CUDA
    int gpuGroupIdx;
    bool preDataLocal;
    int numXLocal;
    int numYLocal;
    int numFLocal;
-
-
 
 //   bool gpuAccelerateFlag; // Whether to accelerate the connection on a GPU
 //   bool ignoreGPUflag;     // Don't use GPU (overrides gpuAccelerateFlag)

--- a/pv-core/src/connections/IdentConn.cpp
+++ b/pv-core/src/connections/IdentConn.cpp
@@ -94,9 +94,10 @@ void IdentConn::ioParam_plasticityFlag(enum ParamsIOFlag ioFlag) {
 }
 
 void IdentConn::ioParam_pvpatchAccumulateType(enum ParamsIOFlag ioFlag) {
+   // IdentConn does not use the pvpatchAccumulateType parameter
    if (ioFlag == PARAMS_IO_READ) {
       pvpatchAccumulateTypeString = strdup("convolve");
-      pvpatchAccumulateType = ACCUMULATE_CONVOLVE;
+      pvpatchAccumulateType = CONVOLVE;
       parent->parameters()->handleUnnecessaryStringParameter(name, "pvpatchAccumulateType", "convolve", true/*case insensitive*/);
    }
 }

--- a/pv-core/src/connections/PoolingConn.cpp
+++ b/pv-core/src/connections/PoolingConn.cpp
@@ -8,6 +8,9 @@
 #include "PoolingConn.hpp"
 #include <cstring>
 #include <cmath>
+#include "utils/PVLog.hpp"
+#include "utils/PVAlloc.hpp"
+#include "utils/PVAssert.hpp"
 
 namespace PV {
 
@@ -37,10 +40,12 @@ PoolingConn::~PoolingConn() {
 
 int PoolingConn::initialize_base() {
    //gateIdxBuffer = NULL;
+   pvpatchAccumulateType = HyPerConn::UNDEFINED;
    thread_gateIdxBuffer = NULL;
    needPostIndexLayer = false;
    postIndexLayerName = NULL;
    postIndexLayer = NULL;
+   poolingType = UNDEFINED;
 
    return PV_SUCCESS;
 }
@@ -64,6 +69,57 @@ void PoolingConn::ioParam_weightInitType(enum ParamsIOFlag ioFlag) {
    if (ioFlag==PARAMS_IO_READ) {
       parent->parameters()->handleUnnecessaryStringParameter(name, "weightInitType", NULL);
    }
+}
+
+void PoolingConn::ioParam_pvpatchAccumulateType(enum ParamsIOFlag ioFlag) {
+   PVParams * params = parent->parameters();
+
+   parent->ioParamStringRequired(ioFlag, name, "pvpatchAccumulateType", &pvpatchAccumulateTypeString);
+   if (ioFlag==PARAMS_IO_READ) {
+      if (pvpatchAccumulateTypeString==NULL) {
+         unsetAccumulateType();
+         return;
+      }
+      // Convert string to lowercase so that capitalization doesn't matter.
+      for (char * c = pvpatchAccumulateTypeString; *c!='\0'; c++) {
+         *c = (char) tolower((int) *c);
+      }
+
+      if ((strcmp(pvpatchAccumulateTypeString,"maxpooling")==0) ||
+           (strcmp(pvpatchAccumulateTypeString,"max_pooling")==0) ||
+           (strcmp(pvpatchAccumulateTypeString,"max pooling")==0)) {
+         poolingType = MAX;
+      }
+      else if ((strcmp(pvpatchAccumulateTypeString,"sumpooling")==0) ||
+           (strcmp(pvpatchAccumulateTypeString,"sum_pooling")==0)  ||
+           (strcmp(pvpatchAccumulateTypeString,"sum pooling")==0)) {
+         poolingType = SUM;
+      }
+      else if ((strcmp(pvpatchAccumulateTypeString,"avgpooling")==0) ||
+           (strcmp(pvpatchAccumulateTypeString,"avg_pooling")==0)  ||
+           (strcmp(pvpatchAccumulateTypeString,"avg pooling")==0)) {
+         poolingType = AVG;
+      }
+      else {
+         unsetAccumulateType();
+      }
+   }
+}
+
+void PoolingConn::unsetAccumulateType() {
+   if (parent->columnId()==0) {
+      if (pvpatchAccumulateTypeString) {
+         logError("%s \"%s\" error: pvpatchAccumulateType \"%s\" is unrecognized.",
+               getKeyword(), name, pvpatchAccumulateTypeString);
+      }
+      else {
+         logError("%s \"%s\" error: pvpatchAccumulateType NULL is unrecognized.",
+               getKeyword(), name);
+      }
+      logError("  Allowed values are \"maxpooling\", \"sumpooling\", or \"avgpooling\".");
+   }
+   MPI_Barrier(parent->icCommunicator()->communicator());
+   exitFailure("");
 }
 
 void PoolingConn::ioParam_needPostIndexLayer(enum ParamsIOFlag ioFlag){
@@ -98,7 +154,8 @@ int PoolingConn::initialize(const char * name, HyPerCol * hc, InitWeights * weig
 
    //set accumulateFunctionPointer
    assert(!inputParams->presentAndNotBeenRead(name, "pvpatchAccumulateType"));
-   switch (pvpatchAccumulateType) {
+   switch (poolingType) {
+#ifdef OBSOLETE // Marked obsolete May 3, 2016.  HyPerConn defines HyPerConnAccumulateType and PoolingConn defines PoolingType
    case ACCUMULATE_CONVOLVE:
       std::cout << "ACCUMULATE_CONVOLVE not allowed in pooling conn\n";
       exit(-1);
@@ -107,20 +164,21 @@ int PoolingConn::initialize(const char * name, HyPerCol * hc, InitWeights * weig
       std::cout << "ACCUMULATE_STOCASTIC not allowed in pooling conn\n";
       exit(-1);
       break;
-   case ACCUMULATE_MAXPOOLING:
+#endif // OBSOLETE // Marked obsolete May 3, 2016.  HyPerConn defines HyPerConnAccumulateType and PoolingConn defines PoolingType
+   case MAX:
       accumulateFunctionPointer = &pvpatch_max_pooling;
       accumulateFunctionFromPostPointer = &pvpatch_max_pooling_from_post;
       break;
-   case ACCUMULATE_SUMPOOLING:
+   case SUM:
       accumulateFunctionPointer = &pvpatch_sum_pooling;
       accumulateFunctionFromPostPointer = &pvpatch_sumpooling_from_post;
       break;
-   case ACCUMULATE_AVGPOOLING:
+   case AVG:
       accumulateFunctionPointer = &pvpatch_sum_pooling;
       accumulateFunctionFromPostPointer = &pvpatch_sumpooling_from_post;
       break;
    default:
-      assert(0);
+      pvAssert(0); // Only MAX, SUM, and AVG are defined in PoolingConn; other methods should be handled in other classes.
       break;
    }
 
@@ -312,13 +370,13 @@ int PoolingConn::checkpointWrite(const char * cpDir) {
 }
 
 float PoolingConn::minWeight(int arborId){
-   if(getPvpatchAccumulateType() == ACCUMULATE_MAXPOOLING){
+   if(getPoolingType() == MAX){
      return 1.0;
    }
-   else if(getPvpatchAccumulateType() == ACCUMULATE_SUMPOOLING){
+   else if(getPoolingType() == SUM){
      return 1;
    }
-   else if(getPvpatchAccumulateType() == ACCUMULATE_AVGPOOLING){
+   else if(getPoolingType() == AVG){
      int relative_XScale = (int) pow(2, pre->getXScale() - post->getXScale());
      int relative_YScale = (int) pow(2, pre->getYScale() - post->getYScale());
      return (1.0/(nxp*nyp*relative_XScale*relative_YScale));
@@ -330,13 +388,13 @@ float PoolingConn::minWeight(int arborId){
 }
 
 float PoolingConn::maxWeight(int arborId){
-   if(getPvpatchAccumulateType() == ACCUMULATE_MAXPOOLING){
+   if(getPoolingType() == MAX){
      return 1.0;
    }
-   else if(getPvpatchAccumulateType() == ACCUMULATE_SUMPOOLING){
+   else if(getPoolingType() == SUM){
      return 1;
    }
-   else if(getPvpatchAccumulateType() == ACCUMULATE_AVGPOOLING){
+   else if(getPoolingType() == AVG){
      int relative_XScale = (int) pow(2, pre->getXScale() - post->getXScale());
      int relative_YScale = (int) pow(2, pre->getYScale() - post->getYScale());
      return (1.0/(nxp*nyp*relative_XScale*relative_YScale));
@@ -355,13 +413,7 @@ int PoolingConn::deliverPresynapticPerspective(PVLayerCube const * activity, int
    }
    assert(post->getChannel(getChannel()));
 
-   float dt_factor;
-   if (getPvpatchAccumulateType()==ACCUMULATE_STOCHASTIC) {
-      dt_factor = getParent()->getDeltaTime();
-   }
-   else {
-      dt_factor = getConvertToRateDeltaTimeFactor();
-   }
+   float dt_factor = getConvertToRateDeltaTimeFactor();
 
    const PVLayerLoc * preLoc = preSynapticLayer()->getLayerLoc();
    const PVLayerLoc * postLoc = postSynapticLayer()->getLayerLoc();
@@ -370,7 +422,7 @@ int PoolingConn::deliverPresynapticPerspective(PVLayerCube const * activity, int
    const int numExtended = activity->numItems;
 
    float resetVal = 0;
-   if(getPvpatchAccumulateType() == ACCUMULATE_MAXPOOLING){
+   if(getPoolingType() == MAX){
       resetVal = -INFINITY;
       float* gSyn = post->getChannel(getChannel());
       //gSyn is res
@@ -498,10 +550,10 @@ int PoolingConn::deliverPresynapticPerspective(PVLayerCube const * activity, int
          int offset = kfPre;
          int sf = fPatchSize();
          pvwdata_t w = 1.0;
-         if(getPvpatchAccumulateType() == ACCUMULATE_SUMPOOLING){
+         if(getPoolingType() == SUM){
            w = 1.0;
          }
-         else if(getPvpatchAccumulateType() == ACCUMULATE_AVGPOOLING){
+         else if(getPoolingType() == AVG){
            float relative_XScale = pow(2, (post->getXScale() - pre->getXScale()));
            float relative_YScale = pow(2, (post->getYScale() - pre->getYScale()));
            w = 1.0/(nxp*nyp*relative_XScale*relative_YScale);
@@ -528,7 +580,7 @@ int PoolingConn::deliverPresynapticPerspective(PVLayerCube const * activity, int
 #pragma omp parallel for
          for(int ni = 0; ni < numNeurons; ni++){
             //Different for maxpooling
-            if(getPvpatchAccumulateType() == ACCUMULATE_MAXPOOLING){
+            if(getPoolingType() == MAX){
                for(int ti = 0; ti < parent->getNumThreads(); ti++){
                   if(gSynPatchHead[ni] < thread_gSyn[ti][ni]){
                      gSynPatchHead[ni] = thread_gSyn[ti][ni];
@@ -605,7 +657,7 @@ int PoolingConn::deliverPostsynapticPerspective(PVLayerCube const * activity, in
    }
 
    float resetVal = 0;
-   if(getPvpatchAccumulateType() == ACCUMULATE_MAXPOOLING){
+   if(getPoolingType() == MAX){
       resetVal = -INFINITY;
    }
 
@@ -648,10 +700,10 @@ int PoolingConn::deliverPostsynapticPerspective(PVLayerCube const * activity, in
          int offset = kfPost;
 
          pvwdata_t w = 1.0;
-         if(getPvpatchAccumulateType() == ACCUMULATE_SUMPOOLING){
+         if(getPoolingType() == SUM){
            w = 1.0;
          }
-         else if(getPvpatchAccumulateType() == ACCUMULATE_AVGPOOLING){
+         else if(getPoolingType() == AVG){
            float relative_XScale = pow(2, (post->getXScale() - pre->getXScale()));
            float relative_YScale = pow(2, (post->getYScale() - pre->getYScale()));
            w = 1.0/(nxp*nyp*relative_XScale*relative_YScale);

--- a/pv-core/src/connections/PoolingConn.hpp
+++ b/pv-core/src/connections/PoolingConn.hpp
@@ -15,6 +15,7 @@ namespace PV {
 class PoolingConn: public HyPerConn {
 
 public:
+   enum AccumulateType {UNDEFINED, MAX, SUM, AVG};
    PoolingConn();
    PoolingConn(const char * name, HyPerCol * hc);
    virtual ~PoolingConn();
@@ -27,12 +28,14 @@ public:
    virtual int finalizeUpdate(double time, double dt);
    PoolingIndexLayer* getPostIndexLayer(){return postIndexLayer;}
    bool needPostIndex(){return needPostIndexLayer;}
+   inline AccumulateType getPoolingType() const { return poolingType; }
 
 protected:
    int initialize(const char * name, HyPerCol * hc, InitWeights * weightInitializer, NormalizeBase * weightNormalizer);
    virtual int ioParamsFillGroup(enum ParamsIOFlag ioFlag);
    void ioParam_plasticityFlag(enum ParamsIOFlag ioFlag);
    void ioParam_weightInitType(enum ParamsIOFlag ioFlag);
+   void ioParam_pvpatchAccumulateType(enum ParamsIOFlag ioFlag);
    void ioParam_needPostIndexLayer(enum ParamsIOFlag ioFlag);
    void ioParam_postIndexLayerName(enum ParamsIOFlag ioFlag);
    void ioParam_normalizeMethod(enum ParamsIOFlag ioFlag);
@@ -60,13 +63,12 @@ protected:
 
 private:
    int initialize_base();
+   void unsetAccumulateType();
    int ** thread_gateIdxBuffer;
-   //float ** thread_gateIdxBuffer;
    bool needPostIndexLayer;
    char* postIndexLayerName;
    PoolingIndexLayer* postIndexLayer;
-
-
+   AccumulateType poolingType;
 }; // end class PoolingConn
 
 BaseObject * createPoolingConn(char const * name, HyPerCol * hc);

--- a/pv-core/src/connections/TransposePoolingConn.cpp
+++ b/pv-core/src/connections/TransposePoolingConn.cpp
@@ -5,6 +5,9 @@
  */
 
 #include "TransposePoolingConn.hpp"
+#include "utils/PVLog.hpp"
+#include "utils/PVAlloc.hpp"
+#include "utils/PVAssert.hpp"
 
 namespace PV {
 
@@ -61,7 +64,8 @@ int TransposePoolingConn::initialize(const char * name, HyPerCol * hc) {
 
    //set accumulateFunctionPointer
    assert(!inputParams->presentAndNotBeenRead(name, "pvpatchAccumulateType"));
-   switch (pvpatchAccumulateType) {
+   switch (poolingType) {
+#ifdef OBSOLETE // Marked obsolete May 3, 2016.  HyPerConn defines HyPerConnAccumulateType and PoolingConn defines PoolingType
    case ACCUMULATE_CONVOLVE:
       std::cout << "ACCUMULATE_CONVOLVE not allowed in TransposePoolingConn\n";
       exit(-1);
@@ -70,20 +74,21 @@ int TransposePoolingConn::initialize(const char * name, HyPerCol * hc) {
       std::cout << "ACCUMULATE_STOCASTIC not allowed in TransposePoolingConn\n";
       exit(-1);
       break;
-   case ACCUMULATE_MAXPOOLING:
+#endif // OBSOLETE // Marked obsolete May 3, 2016.  HyPerConn defines HyPerConnAccumulateType and PoolingConn defines PoolingType
+   case PoolingConn::MAX:
       accumulateFunctionPointer = &pvpatch_max_pooling;
       accumulateFunctionFromPostPointer = &pvpatch_max_pooling_from_post;
       break;
-   case ACCUMULATE_SUMPOOLING:
+   case PoolingConn::SUM:
       accumulateFunctionPointer = &pvpatch_sum_pooling;
       accumulateFunctionFromPostPointer = &pvpatch_sumpooling_from_post;
       break;
-   case ACCUMULATE_AVGPOOLING:
+   case PoolingConn::AVG:
       accumulateFunctionPointer = &pvpatch_sum_pooling;
       accumulateFunctionFromPostPointer = &pvpatch_sumpooling_from_post;
       break;
    default:
-      assert(0);
+      pvAssert(0);
       break;
    }
 
@@ -151,6 +156,59 @@ void TransposePoolingConn::ioParam_triggerLayerName(enum ParamsIOFlag ioFlag) {
       parent->parameters()->handleUnnecessaryParameter(name, "triggerFlag", triggerFlag);
       parent->parameters()->handleUnnecessaryStringParameter(name, "triggerLayerName", NULL);
    }
+}
+
+// TODO: ioParam_pvpatchAccumulateType and unsetAccumulateType are copied from PV::PoolingConn.
+// Can we make TransposePoolingConn a derived class of PoolingConn?  (TransposeConn is a derived class of HyPerConn.)
+void TransposePoolingConn::ioParam_pvpatchAccumulateType(enum ParamsIOFlag ioFlag) {
+   PVParams * params = parent->parameters();
+
+   parent->ioParamStringRequired(ioFlag, name, "pvpatchAccumulateType", &pvpatchAccumulateTypeString);
+   if (ioFlag==PARAMS_IO_READ) {
+      if (pvpatchAccumulateTypeString==NULL) {
+         unsetAccumulateType();
+         return;
+      }
+      // Convert string to lowercase so that capitalization doesn't matter.
+      for (char * c = pvpatchAccumulateTypeString; *c!='\0'; c++) {
+         *c = (char) tolower((int) *c);
+      }
+
+      if ((strcmp(pvpatchAccumulateTypeString,"maxpooling")==0) ||
+           (strcmp(pvpatchAccumulateTypeString,"max_pooling")==0) ||
+           (strcmp(pvpatchAccumulateTypeString,"max pooling")==0)) {
+         poolingType = PoolingConn::MAX;
+      }
+      else if ((strcmp(pvpatchAccumulateTypeString,"sumpooling")==0) ||
+           (strcmp(pvpatchAccumulateTypeString,"sum_pooling")==0)  ||
+           (strcmp(pvpatchAccumulateTypeString,"sum pooling")==0)) {
+         poolingType = PoolingConn::SUM;
+      }
+      else if ((strcmp(pvpatchAccumulateTypeString,"avgpooling")==0) ||
+           (strcmp(pvpatchAccumulateTypeString,"avg_pooling")==0)  ||
+           (strcmp(pvpatchAccumulateTypeString,"avg pooling")==0)) {
+         poolingType = PoolingConn::AVG;
+      }
+      else {
+         unsetAccumulateType();
+      }
+   }
+}
+
+void TransposePoolingConn::unsetAccumulateType() {
+   if (parent->columnId()==0) {
+      if (pvpatchAccumulateTypeString) {
+         logError("%s \"%s\" error: pvpatchAccumulateType \"%s\" is unrecognized.",
+               getKeyword(), name, pvpatchAccumulateTypeString);
+      }
+      else {
+         logError("%s \"%s\" error: pvpatchAccumulateType NULL is unrecognized.",
+               getKeyword(), name);
+      }
+      logError("  Allowed values are \"maxpooling\", \"sumpooling\", or \"avgpooling\".");
+   }
+   MPI_Barrier(parent->icCommunicator()->communicator());
+   exitFailure("");
 }
 
 void TransposePoolingConn::ioParam_combine_dW_with_W_flag(enum ParamsIOFlag ioFlag) {
@@ -222,13 +280,6 @@ void TransposePoolingConn::ioParam_originalConnName(enum ParamsIOFlag ioFlag) {
    parent->ioParamStringRequired(ioFlag, name, "originalConnName", &originalConnName);
 }
 
-#ifdef OBSOLETE // Marked obsolete Mar 20, 2015.  Not used since creating the InitWeights object was taken out of HyPerConn.
-InitWeights * TransposePoolingConn::handleMissingInitWeights(PVParams * params) {
-   // TransposePoolingConn doesn't use InitWeights; it initializes the weight by transposing the initial weights of originalConn
-   return NULL;
-}
-#endif // OBSOLETE // Marked obsolete Mar 20, 2015.  Not used since creating the InitWeights object was taken out of HyPerConn.
-
 int TransposePoolingConn::communicateInitInfo() {
    int status = PV_SUCCESS;
    BaseConnection * originalConnBase = parent->getConnFromName(this->originalConnName);
@@ -277,7 +328,7 @@ int TransposePoolingConn::communicateInitInfo() {
    status = HyPerConn::communicateInitInfo(); // calls setPatchSize()
    if (status != PV_SUCCESS) return status;
 
-   if(!originalConn->needPostIndex() && pvpatchAccumulateType == ACCUMULATE_MAXPOOLING){
+   if(!originalConn->needPostIndex() && poolingType == PoolingConn::MAX){
       if (parent->columnId()==0) {
          fprintf(stderr, "TransposePoolingConn \"%s\" error: original pooling conn \"%s\" needs to have a postIndexLayer if unmax pooling.\n", name, originalConnName);
          status = PV_FAILURE;
@@ -290,9 +341,9 @@ int TransposePoolingConn::communicateInitInfo() {
       fprintf(stderr, "TransposePoolingConn \"%s\" warning: originalConn's post layer phase is greater or equal than this layer's post. Behavior undefined.\n", name);
    }
 
-   if(originalConn->getPvpatchAccumulateType() != getPvpatchAccumulateType()){
+   if(originalConn->getPoolingType() != poolingType){
       fprintf(stderr, "TransposePoolingConn \"%s\" error: originalConn accumulateType does not match this layer's accumulate type.\n", name);
-      exit(-1);
+      exit(EXIT_FAILURE);
    }
 
    const PVLayerLoc * preLoc = pre->getLayerLoc();
@@ -326,7 +377,7 @@ int TransposePoolingConn::communicateInitInfo() {
    originalConn->postSynapticLayer()->synchronizeMarginWidth(pre);
    pre->synchronizeMarginWidth(originalConn->postSynapticLayer());
 
-   if(pvpatchAccumulateType == ACCUMULATE_MAXPOOLING){
+   if(poolingType == PoolingConn::MAX){
       //Sync pre margins
       //Synchronize margines of this post and the postIndexLayer, and vice versa
       pre->synchronizeMarginWidth(originalConn->getPostIndexLayer());
@@ -498,7 +549,7 @@ int TransposePoolingConn::deliverPresynapticPerspective(PVLayerCube const * acti
 
    //Grab postIdxLayer's data
    int* postIdxData = NULL;
-   if(pvpatchAccumulateType == ACCUMULATE_MAXPOOLING){
+   if(poolingType == PoolingConn::MAX){
       PoolingIndexLayer* postIndexLayer = originalConn->getPostIndexLayer();
       assert(postIndexLayer);
       //Make sure this layer is an integer layer
@@ -514,7 +565,7 @@ int TransposePoolingConn::deliverPresynapticPerspective(PVLayerCube const * acti
       pvdata_t * activityBatch = activity->data + b * (preLoc->nx + preLoc->halo.rt + preLoc->halo.lt) * (preLoc->ny + preLoc->halo.up + preLoc->halo.dn) * preLoc->nf;
       pvdata_t * gSynPatchHeadBatch = post->getChannel(getChannel()) + b * postLoc->nx * postLoc->ny * postLoc->nf;
       int * postIdxDataBatch = NULL;
-      if(pvpatchAccumulateType == ACCUMULATE_MAXPOOLING){
+      if(poolingType == PoolingConn::MAX){
          postIdxDataBatch = postIdxData + b * originalConn->getPostIndexLayer()->getNumExtended();
       }
 
@@ -580,7 +631,7 @@ int TransposePoolingConn::deliverPresynapticPerspective(PVLayerCube const * acti
          const int kyPreExt = kyPos(kPreExt, preLoc->nx + preLoc->halo.lt + preLoc->halo.rt, preLoc->ny + preLoc->halo.dn + preLoc->halo.up, preLoc->nf);
          const int kfPre = featureIndex(kPreExt, preLoc->nx + preLoc->halo.lt + preLoc->halo.rt, preLoc->ny + preLoc->halo.dn + preLoc->halo.up, preLoc->nf);
 
-         if(pvpatchAccumulateType == ACCUMULATE_MAXPOOLING){
+         if(poolingType == PoolingConn::MAX){
             const int kxPreGlobalExt = kxPreExt + preLoc->kx0;
             const int kyPreGlobalExt = kyPreExt + preLoc->ky0;
             if(kxPreGlobalExt < preLoc->halo.lt || kxPreGlobalExt >= preLoc->nxGlobal + preLoc->halo.lt ||
@@ -625,13 +676,13 @@ int TransposePoolingConn::deliverPresynapticPerspective(PVLayerCube const * acti
             int sf = fPatchSize();
 
             pvwdata_t w = 1.0;
-            if(getPvpatchAccumulateType() == ACCUMULATE_SUMPOOLING){
+            if(poolingType == PoolingConn::MAX){
               //float relative_XScale = pow(2, (post->getXScale() - pre->getXScale()));
               //float relative_YScale = pow(2, (post->getYScale() - pre->getYScale()));
               //w = 1.0/(nxp*nyp*relative_XScale*relative_YScale);
               w = 1.0;
             }
-            else if(getPvpatchAccumulateType() == ACCUMULATE_AVGPOOLING){
+            else if(poolingType == PoolingConn::MAX){
               float relative_XScale = pow(2, (post->getXScale() - pre->getXScale()));
               float relative_YScale = pow(2, (post->getYScale() - pre->getYScale()));
               float normVal = nxp*nyp;
@@ -652,7 +703,7 @@ int TransposePoolingConn::deliverPresynapticPerspective(PVLayerCube const * acti
          //Looping over neurons first to be thread safe
 #pragma omp parallel for
          for(int ni = 0; ni < numNeurons; ni++){
-            if(pvpatchAccumulateType == ACCUMULATE_MAXPOOLING){
+            if(poolingType == PoolingConn::MAX){
                //Grab maxumum magnitude of thread_gSyn and set that value
                float maxMag = -INFINITY;
                int maxMagIdx = -1;

--- a/pv-core/src/connections/TransposePoolingConn.hpp
+++ b/pv-core/src/connections/TransposePoolingConn.hpp
@@ -26,7 +26,6 @@ public:
    virtual bool needUpdate(double timed, double dt);
    virtual int updateState(double time, double dt);
    virtual double computeNewWeightUpdateTime(double time, double currentUpdateTime);
-   //virtual int finalizeUpdate(double time, double dt);
    virtual int deliverPresynapticPerspective(PVLayerCube const * activity, int arborID);
    virtual int deliverPostsynapticPerspective(PVLayerCube const * activity, int arborID);
 #if defined(PV_USE_OPENCL) || defined(PV_USE_CUDA)
@@ -52,6 +51,7 @@ protected:
     virtual void ioParam_numAxonalArbors(enum ParamsIOFlag ioFlag);
     virtual void ioParam_plasticityFlag(enum ParamsIOFlag ioFlag);
     virtual void ioParam_triggerLayerName(enum ParamsIOFlag ioFlag);
+    virtual void ioParam_pvpatchAccumulateType(enum ParamsIOFlag ioFlag);
     virtual void ioParam_combine_dW_with_W_flag(enum ParamsIOFlag ioFlag);
     virtual void ioParam_nxp(enum ParamsIOFlag ioFlag);
     virtual void ioParam_nyp(enum ParamsIOFlag ioFlag);
@@ -65,30 +65,20 @@ protected:
     virtual void ioParam_originalConnName(enum ParamsIOFlag ioFlag);
     virtual int setPatchSize();
     virtual int setNeededRNGSeeds() {return 0;}
-#ifdef OBSOLETE // Marked obsolete Mar 20, 2015.  Not used since creating the InitWeights object was taken out of HyPerConn.
-    virtual InitWeights * handleMissingInitWeights(PVParams * params);
-#endif // OBSOLETE // Marked obsolete Mar 20, 2015.  Not used since creating the InitWeights object was taken out of HyPerConn.
     virtual int setInitialValues();
     virtual PVPatch *** initializeWeights(PVPatch *** arbors, pvwdata_t ** dataStart);
-    //int transpose(int arborId);
     virtual int calc_dW(int arborId){return PV_BREAK;};
-    //virtual int reduceKernels(int arborID);
     virtual int constructWeights();
 
 private:
-    //int transposeSharedWeights(int arborId);
-    //int transposeNonsharedWeights(int arborId);
     int deleteWeights();
+    void unsetAccumulateType();
 
-    /**
-     * Calculates the parameters of the the region that needs to be sent to adjoining processes using MPI.
-     * Used only in the sharedWeights=false case, because in that case an individual weight's pre and post neurons can live in different processes.
-     */
-    //int mpiexchangesize(int neighbor, int * size, int * startx, int * stopx, int * starty, int * stopy, int * blocksize, size_t * buffersize);
 // Member variables
 protected:
     char * originalConnName;
     PoolingConn * originalConn;
+    PoolingConn::AccumulateType poolingType;
 }; // end class TransposePoolingConn
 
 BaseObject * createTransposePoolingConn(char const * name, HyPerCol * hc);

--- a/pv-core/src/include/pv_types.h
+++ b/pv-core/src/include/pv_types.h
@@ -40,6 +40,7 @@ enum ChannelType {
   CHANNEL_NOUPDATE = -1
 };
 
+#ifdef OBSOLETE // Marked obsolete May 3, 2016.  HyPerConn defines HyPerConnAccumulateType and PoolingConn defines PoolingType
 enum GSynAccumulateType {
    ACCUMULATE_CONVOLVE = 0,
    ACCUMULATE_STOCHASTIC = 1,
@@ -47,6 +48,7 @@ enum GSynAccumulateType {
    ACCUMULATE_SUMPOOLING = 3,
    ACCUMULATE_AVGPOOLING = 4
 };
+#endif // OBSOLETE // Marked obsolete May 3, 2016.  HyPerConn defines HyPerConnAccumulateType and PoolingConn defines PoolingType
 
 enum PVDataType{
    PV_FLOAT = 0,


### PR DESCRIPTION
In the current code, HyPerConn recognizes five possible values of pvpatchAccumulateType: convolve, stochastic, maxpooling, sumpooling, and avgpooling, but exits with an error for any of the pooling types.  Then PoolingConn overrides methods so that it rejects convolve and stochastic, while accepting any of the pooling types.

In this pull request, the enum for the recognized accumulate types is removed from pv_types.h.  Instead, the HyPerConn class defines an enum that recognizes only convolve and stochastic; while PoolingConn has a second enum that recognizes only the three pooling types.  TransposePoolingConn regularly uses the PoolingConn enum as well.

This provides better separation of the standard HyPerConn functionality and pooling functionality.  It also provides an example for adding a new accumulate mechanism to a subclass without needing to add it to HyPerConn.

There are two possible changes that I left out of this pull request but would also serve to better modularize pooling.  First, TransposePoolingConn is derived from HyPerConn, but it copies PoolingConn's parsing of pvpatchAccumulateType, and makes use of PoolingConn::AccumulateType.  It might be preferable to make TransposePoolingConn a subclass of PoolingConn (just as TransposeConn is a subclass of HyPerConn).  Second, HyPerConn declares TransposePoolingConn as a friend class, because TransposePoolingConn requires access to many of HyPerConn's nonpublic methods and data members.  I think that it would be an improvement for HyPerConn's interface to be changed so that other classes can do the kinds of things that TransposeConn needs to do, without these declarations.
