### PR TITLE
Removes references to pooling values of pvpatchAccumulateType from HyPerConn

### DIFF
--- a/src/connections/HyPerConn.hpp
+++ b/src/connections/HyPerConn.hpp
@@ -67,8 +67,13 @@ public:
    friend class PlasticCloneConn;
    friend class TransposeConn;
    friend class privateTransposeConn;
+//#ifdef OBSOLETE // Marked obsolete May 3, 2016.  All pooling-dependent behavior should be in PoolingConn
    friend class TransposePoolingConn;
+//#endif // OBSOLETE // Marked obsolete May 3, 2016.  All pooling-dependent behavior should be in PoolingConn
    
+   enum AccumulateType {UNDEFINED, CONVOLVE, STOCHASTIC};
+   // Subclasses that need different accumulate types should define their own enums
+
    HyPerConn(const char * name, HyPerCol * hc, InitWeights * weightInitializer=NULL, NormalizeBase * weightNormalizer=NULL);
    virtual ~HyPerConn();
 //#ifdef PV_USE_OPENCL
@@ -108,7 +113,7 @@ public:
    virtual void deliverOnePreNeuronActivity(int patchIndex, int arbor, pvadata_t a, pvgsyndata_t * postBufferStart, void * auxPtr);
    virtual void deliverOnePostNeuronActivity(int arborID, int kTargetExt, int inSy, float* activityStartBuf, pvdata_t* gSynPatchPos, float dt_factor, taus_uint4 * rngPtr);
     
-   GSynAccumulateType getPvpatchAccumulateType() { return pvpatchAccumulateType; }
+   AccumulateType getPvpatchAccumulateType() { return pvpatchAccumulateType; }
    int (*accumulateFunctionPointer)(int kPreRes, int nk, float* v, float a, pvwdata_t* w, void* auxPtr, int sf);
    int (*accumulateFunctionFromPostPointer)(int kPreRes, int nk, float* v, float* a, pvwdata_t* w, float dt_factor, void* auxPtr, int sf);
 
@@ -478,7 +483,7 @@ protected:
    char * weightInitTypeString;
    InitWeights* weightInitializer;
    char * pvpatchAccumulateTypeString;
-   GSynAccumulateType pvpatchAccumulateType;
+   AccumulateType pvpatchAccumulateType;
    bool normalizeTotalToPost; // if false, normalize the sum of weights from each presynaptic neuron.  If true, normalize the sum of weights into a postsynaptic neuron.
    float dWMax;  // dW scale factor
    bool useListOfArborFiles;
@@ -496,8 +501,6 @@ protected:
    long ** numKernelActivations;
    bool keepKernelsSynchronized_flag;
 
-   // unsigned int rngSeedBase; // The starting seed for rng.  The parent HyPerCol reserves {rngSeedbase, rngSeedbase+1,...rngSeedbase+neededRNGSeeds-1} for use by this layer
-   // taus_uint4 * rnd_state; // An array of RNGs.
    Random * randState;
 
 
@@ -1048,21 +1051,19 @@ protected:
    PVCuda::CudaBuffer * d_WData;
 #ifdef PV_USE_CUDNN
    PVCuda::CudaBuffer * cudnn_WData;
-#endif
+#endif // PV_USE_CUDNN
    PVCuda::CudaBuffer * d_Patches;
    PVCuda::CudaBuffer * d_GSynPatchStart;
    PVCuda::CudaBuffer * d_PostToPreActivity;
    PVCuda::CudaBuffer * d_Patch2DataLookupTable;
    PVCuda::CudaRecvPost* krRecvPost;        // Cuda kernel for update state call
    PVCuda::CudaRecvPre* krRecvPre;        // Cuda kernel for update state call
-#endif
+#endif // PV_USE_CUDA
    int gpuGroupIdx;
    bool preDataLocal;
    int numXLocal;
    int numYLocal;
    int numFLocal;
-
-
 
 //   bool gpuAccelerateFlag; // Whether to accelerate the connection on a GPU
 //   bool ignoreGPUflag;     // Don't use GPU (overrides gpuAccelerateFlag)

--- a/src/connections/IdentConn.cpp
+++ b/src/connections/IdentConn.cpp
@@ -94,9 +94,10 @@ void IdentConn::ioParam_plasticityFlag(enum ParamsIOFlag ioFlag) {
 }
 
 void IdentConn::ioParam_pvpatchAccumulateType(enum ParamsIOFlag ioFlag) {
+   // IdentConn does not use the pvpatchAccumulateType parameter
    if (ioFlag == PARAMS_IO_READ) {
       pvpatchAccumulateTypeString = strdup("convolve");
-      pvpatchAccumulateType = ACCUMULATE_CONVOLVE;
+      pvpatchAccumulateType = CONVOLVE;
       parent->parameters()->handleUnnecessaryStringParameter(name, "pvpatchAccumulateType", "convolve", true/*case insensitive*/);
    }
 }

--- a/src/connections/PoolingConn.hpp
+++ b/src/connections/PoolingConn.hpp
@@ -15,6 +15,7 @@ namespace PV {
 class PoolingConn: public HyPerConn {
 
 public:
+   enum AccumulateType {UNDEFINED, MAX, SUM, AVG};
    PoolingConn();
    PoolingConn(const char * name, HyPerCol * hc);
    virtual ~PoolingConn();
@@ -27,12 +28,14 @@ public:
    virtual int finalizeUpdate(double time, double dt);
    PoolingIndexLayer* getPostIndexLayer(){return postIndexLayer;}
    bool needPostIndex(){return needPostIndexLayer;}
+   inline AccumulateType getPoolingType() const { return poolingType; }
 
 protected:
    int initialize(const char * name, HyPerCol * hc, InitWeights * weightInitializer, NormalizeBase * weightNormalizer);
    virtual int ioParamsFillGroup(enum ParamsIOFlag ioFlag);
    void ioParam_plasticityFlag(enum ParamsIOFlag ioFlag);
    void ioParam_weightInitType(enum ParamsIOFlag ioFlag);
+   void ioParam_pvpatchAccumulateType(enum ParamsIOFlag ioFlag);
    void ioParam_needPostIndexLayer(enum ParamsIOFlag ioFlag);
    void ioParam_postIndexLayerName(enum ParamsIOFlag ioFlag);
    void ioParam_normalizeMethod(enum ParamsIOFlag ioFlag);
@@ -60,13 +63,12 @@ protected:
 
 private:
    int initialize_base();
+   void unsetAccumulateType();
    int ** thread_gateIdxBuffer;
-   //float ** thread_gateIdxBuffer;
    bool needPostIndexLayer;
    char* postIndexLayerName;
    PoolingIndexLayer* postIndexLayer;
-
-
+   AccumulateType poolingType;
 }; // end class PoolingConn
 
 BaseObject * createPoolingConn(char const * name, HyPerCol * hc);

--- a/src/connections/TransposePoolingConn.hpp
+++ b/src/connections/TransposePoolingConn.hpp
@@ -26,7 +26,6 @@ public:
    virtual bool needUpdate(double timed, double dt);
    virtual int updateState(double time, double dt);
    virtual double computeNewWeightUpdateTime(double time, double currentUpdateTime);
-   //virtual int finalizeUpdate(double time, double dt);
    virtual int deliverPresynapticPerspective(PVLayerCube const * activity, int arborID);
    virtual int deliverPostsynapticPerspective(PVLayerCube const * activity, int arborID);
 #if defined(PV_USE_OPENCL) || defined(PV_USE_CUDA)
@@ -52,6 +51,7 @@ protected:
     virtual void ioParam_numAxonalArbors(enum ParamsIOFlag ioFlag);
     virtual void ioParam_plasticityFlag(enum ParamsIOFlag ioFlag);
     virtual void ioParam_triggerLayerName(enum ParamsIOFlag ioFlag);
+    virtual void ioParam_pvpatchAccumulateType(enum ParamsIOFlag ioFlag);
     virtual void ioParam_combine_dW_with_W_flag(enum ParamsIOFlag ioFlag);
     virtual void ioParam_nxp(enum ParamsIOFlag ioFlag);
     virtual void ioParam_nyp(enum ParamsIOFlag ioFlag);
@@ -65,30 +65,20 @@ protected:
     virtual void ioParam_originalConnName(enum ParamsIOFlag ioFlag);
     virtual int setPatchSize();
     virtual int setNeededRNGSeeds() {return 0;}
-#ifdef OBSOLETE // Marked obsolete Mar 20, 2015.  Not used since creating the InitWeights object was taken out of HyPerConn.
-    virtual InitWeights * handleMissingInitWeights(PVParams * params);
-#endif // OBSOLETE // Marked obsolete Mar 20, 2015.  Not used since creating the InitWeights object was taken out of HyPerConn.
     virtual int setInitialValues();
     virtual PVPatch *** initializeWeights(PVPatch *** arbors, pvwdata_t ** dataStart);
-    //int transpose(int arborId);
     virtual int calc_dW(int arborId){return PV_BREAK;};
-    //virtual int reduceKernels(int arborID);
     virtual int constructWeights();
 
 private:
-    //int transposeSharedWeights(int arborId);
-    //int transposeNonsharedWeights(int arborId);
     int deleteWeights();
+    void unsetAccumulateType();
 
-    /**
-     * Calculates the parameters of the the region that needs to be sent to adjoining processes using MPI.
-     * Used only in the sharedWeights=false case, because in that case an individual weight's pre and post neurons can live in different processes.
-     */
-    //int mpiexchangesize(int neighbor, int * size, int * startx, int * stopx, int * starty, int * stopy, int * blocksize, size_t * buffersize);
 // Member variables
 protected:
     char * originalConnName;
     PoolingConn * originalConn;
+    PoolingConn::AccumulateType poolingType;
 }; // end class TransposePoolingConn
 
 BaseObject * createTransposePoolingConn(char const * name, HyPerCol * hc);

--- a/src/include/pv_types.h
+++ b/src/include/pv_types.h
@@ -40,6 +40,7 @@ enum ChannelType {
   CHANNEL_NOUPDATE = -1
 };
 
+#ifdef OBSOLETE // Marked obsolete May 3, 2016.  HyPerConn defines HyPerConnAccumulateType and PoolingConn defines PoolingType
 enum GSynAccumulateType {
    ACCUMULATE_CONVOLVE = 0,
    ACCUMULATE_STOCHASTIC = 1,
@@ -47,6 +48,7 @@ enum GSynAccumulateType {
    ACCUMULATE_SUMPOOLING = 3,
    ACCUMULATE_AVGPOOLING = 4
 };
+#endif // OBSOLETE // Marked obsolete May 3, 2016.  HyPerConn defines HyPerConnAccumulateType and PoolingConn defines PoolingType
 
 enum PVDataType{
    PV_FLOAT = 0,


### PR DESCRIPTION
This pull request updates #55, taking account recent commits to the develop branch.

In the current code, HyPerConn recognizes five possible values of pvpatchAccumulateType: convolve, stochastic, maxpooling, sumpooling, and avgpooling, but exits with an error for any of the pooling types. Then PoolingConn overrides methods so that it rejects convolve and stochastic, while accepting any of the pooling types.

In this pull request, the enum for the recognized accumulate types is removed from pv_types.h. Instead, the HyPerConn class defines an enum that recognizes only convolve and stochastic; while PoolingConn has a second enum that recognizes only the three pooling types. TransposePoolingConn regularly uses the PoolingConn enum as well.

This provides better separation of the basic HyPerConn functionality and the pooling functionality. It also provides an example for adding a new accumulate mechanism to a subclass without needing to add it to HyPerConn.
