### PR TITLE
Cleaning up unused directives in pv_common.h

### DIFF
--- a/src/columns/HyPerCol.cpp
+++ b/src/columns/HyPerCol.cpp
@@ -6,7 +6,8 @@
  */
 
 #define TIMER_ON
-#define TIMESTEP_OUTPUT
+#define DEFAULT_OUTPUT_PATH "output/"
+#define DEFAULT_DELTA_T 1.0 //time step size (msec)
 
 #include "HyPerCol.hpp"
 #include <columns/InterColComm.hpp>
@@ -207,7 +208,7 @@ int HyPerCol::initialize_base() {
    simTime = 0.0;
    startTime = 0.0;
    stopTime = 0.0;
-   deltaTime = DELTA_T;
+   deltaTime = DEFAULT_DELTA_T;
    dtAdaptFlag = false;
    writeTimeScaleFieldnames = true;
    useAdaptMethodExp1stOrder = false;
@@ -216,7 +217,7 @@ int HyPerCol::initialize_base() {
    dtAdaptTriggerLayerName = NULL;
    dtAdaptTriggerLayer = NULL;
    dtAdaptTriggerOffset = 0.0;
-   deltaTimeBase = DELTA_T;
+   deltaTimeBase = DEFAULT_DELTA_T;
    timeScale = NULL;
    timeScaleMax = NULL;
    timeScaleMax2 = NULL;
@@ -1027,10 +1028,10 @@ void HyPerCol::ioParam_outputPath(enum ParamsIOFlag ioFlag) {
             assert(outputPath != NULL);
          }
          else {
-            outputPath = strdup(OUTPUT_PATH);
+            outputPath = strdup(DEFAULT_OUTPUT_PATH);
             assert(outputPath != NULL);
             printf("Output path specified neither in command line nor in params file.\n"
-                   "Output path set to default \"%s\"\n", OUTPUT_PATH);
+                   "Output path set to default \"%s\"\n", DEFAULT_OUTPUT_PATH);
          }
       }
       break;

--- a/src/include/pv_common.h
+++ b/src/include/pv_common.h
@@ -28,42 +28,12 @@
 // For debugging/control:
 #undef  DEBUG_OUTPUT
 #undef  DEBUG_WEIGHTS
-#define LIF_STATS 1
 #define DEBUG 0
-
-// TODO: move to HyPerCol, set as runtime param, link each layer back to its HyPerCol
-// numerical integration parameters
-#define DELTA_T 1.0 //time step size (msec)
-#define MIRROR_BC_FLAG true
 
 #define MAX_FILESYSTEMCALL_TRIES 5
 
-//// control dynamics
-//#define STATIC_DYNAMICS   0
-//#define RATE_DYNAMICS     1
-//#define FIRING_DYNAMICS   2
-//#define WMAX_DYNAMICS     STATIC_DYNAMICS
-//#define VTHREST_DYNAMICS  FIRING_DYNAMICS
-
 // Misc:
-#define eventtype_t float
-#define RAD_TO_DEG_x2   (2.0*180.0/PI)
-#define RAD_TO_DEG      (180. / PI)
-#define DEG_TO_RAD      (PI/180.0)
 #define PI              3.1415926535897932
-
-//channels
-#define MAX_CHANNELS 3
-#define PHI0    0       // which phi buffer to use
-#define PHI1    1       // which phi buffer to use
-#define PHI_EXC 0       // which phi buffer to use
-#define PHI_INH 1       // which phi buffer to use
-#define PHI_INHB 2
-
-#define RMIN 0.0
-#define RMAX (NX*1.414/4)
-#define R2MAX (RMAX*RMAX)
-#define VEL (2.0*RMAX)
 
 // Limits:
 #define MAX_NEIGHBORS                   8
@@ -76,14 +46,6 @@
 
 #define DISPLAY_PERIOD 1.0
 
-// TODO: As soon as the interfaces stabilize, use the type-checked/safer prototypes
-//#define UPDATE_FN int (*)( int numNeurons, float *V, float *phi, float *f, void *params)
-#define UPDATE_FN  void*
-//#define RECV_FN int (*)( PVLayer* pre, PVLayer* post, int nActivity, float *fActivity, void *params);
-#define RECV_FN  void*
-//#define INIT_FN int (*)( PVConnection *);
-#define INIT_FN  void*
-
 // This probably depends on the gnu preprocessor
 #ifdef DEBUG_OUTPUT
 #  define pv_debug_info(format, args...)  \
@@ -93,9 +55,5 @@
 #else
 #  define pv_debug_info(format, args...)
 #endif
-
-#define INPUT_PATH  "input/"
-#define OUTPUT_PATH "output/"
-#define PARAMS_FILE "params.txt"
 
 #endif /* PV_COMMON_H */

--- a/src/io/io.c
+++ b/src/io/io.c
@@ -292,59 +292,6 @@ char * expandLeadingTilde(char const * path) {
    return newpath;
 }
 
-#ifdef OBSOLETE // Marked obsolete Jul 16, 2015.  Only probe that was using readFile was marked obsolete long ago
-/**
- * @filename
- * @buf
- * @nx
- * @ny
- */
-int readFile(const char * filename, float * buf, int * nx, int * ny)
-{
-   int result, nItems;
-   int status = 0;
-   FILE * fp;
-   const char * altfile = INPUT_PATH "const_one_64x64.bin";
-
-   if (filename == NULL) {
-      filename = altfile;
-      fprintf(stderr, "[ ]: Warning: Input file is NULL -- using %s.\n", filename);
-   }
-
-   if (filetype(filename) == TIFF_FILE_TYPE) {
-      return tiff_read_file(filename, buf, nx, ny);
-   }
-
-   fp = fopen(filename, "rb");
-
-   if (fp == NULL) {
-      fprintf(stderr, "[ ]: readFile: ERROR opening input file %s: %s\n", filename, strerror(errno));
-      return 1;
-   }
-   else {
-      nItems = (*nx) * (*ny);
-
-      // assume binary file
-      assert(filetype(filename) == BINARY_FILE_TYPE);
-      result = fread(buf, sizeof(float), nItems, fp);
-      fclose(fp);
-
-      if (result != nItems) {
-         fprintf(stderr, "[ ]: Warning: readFile %s, expected %d, got %d.\n",
-                filename, nItems, result);
-         status = 1;
-      }
-      else {
-#ifdef DEBUG_OUTPUT
-         printf("[ ]: readFile: Successfully read %d items from %s\n", nItems, filename);  fflush(stdout);
-#endif // DEBUG_OUTPUT
-      }
-   }
-
-   return status;
-}
-#endif // OBSOLETE // Marked obsolete Jul 16, 2015.  Only probe that was using readFile was marked obsolete long
-
 /**
  * @fd
  * @patch


### PR DESCRIPTION
This pull request removes several #define statements from pv_common.h whose macros are never used, and moves two #define statements, where the macros were only used in HyPerCol.cpp, into that file.
