### PR TITLE
LocalizationProbe defines a struct "localization" to hold feature, bounding box, and confidence.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -10,9 +10,18 @@ project(PetaVision)
 # Default PetaVision core library directory
 set(PV_DIR_DEFAULT "${CMAKE_CURRENT_SOURCE_DIR}/src")
 set(PV_TEST_DIR "${CMAKE_CURRENT_SOURCE_DIR}/tests")
+set(PV_DEMOS_DIR "${CMAKE_CURRENT_SOURCE_DIR}/demos")
+
+# Defaults
+set(PV_BUILD_DEMOS_DEFAULT OFF)
+
+# Help strings
+set(PV_BUILD_DEMOS_HELP "Build OpenPV demos")
 
 # Set CMAKE_MODULE_PATH
 set(CMAKE_MODULE_PATH "${PROJECT_SOURCE_DIR}/cmake")
+
+set(PV_BUILD_DEMOS ${PV_BUILD_DEMOS_DEFAULT} CACHE BOOL "${PV_BUILD_DEMOS_HELP}")
 
 include(PVConfigProject)
 pv_config_project()
@@ -28,4 +37,8 @@ if (${PV_BUILD_TEST})
   add_subdirectory(${PV_TEST_DIR})
 else()
    message(STATUS "Only building the OpenPV library. Set PV_BUILD_TEST=On to build the OpenPV test suite.")
+endif()
+
+if (${PV_BUILD_DEMOS})
+   add_subdirectory(${PV_DEMOS_DIR})
 endif()

--- a/cmake/FindCUDNN.cmake
+++ b/cmake/FindCUDNN.cmake
@@ -8,66 +8,56 @@
 #
 # A CUDNN_PATH variable can be set prior find_package(CUDNN)
 # to specify exactly where to search
+#
+# Call FindCUDA before using FindCUDNN
+#
+# That will set the CUDA_FOUND variable and expand the search
+# for cuDNN to the cuda directories
 
 
 include(LibFindMacros)
 
 foreach(PATH_HINT ${CUDNN_PATH})
-  set(CUDNN_HEADER_SEARCH_PATHS ${CUDNN_HEADER_SEARCH_PATHS};${CUDNN_PATH}/include)
-  set(CUDNN_LIBRARY_SEARCH_PATHS ${CUDNN_LIBRARY_SEARCH_PATHS};${CUDNN_PATH}/lib)
-  set(CUDNN_LIBRARY_SEARCH_PATHS ${CUDNN_LIBRARY_SEARCH_PATHS};${CUDNN_PATH}/lib64)
+  list(APPEND CUDNN_HEADER_SEARCH_PATHS ${CUDNN_PATH}/include)
+  list(APPEND CUDNN_LIBRARY_SEARCH_PATHS ${CUDNN_PATH}/lib64)
+  list(APPEND CUDNN_LIBRARY_SEARCH_PATHS ${CUDNN_PATH}/lib)
 
   if(CUDA_FOUND)
-    set(CUDNN_HEADER_SEARCH_PATHS ${CUDNN_HEADER_SEARCH_PATHS};${CUDNN_PATH}/include)
-    set(CUDNN_HEADER_SEARCH_PATHS ${CUDNN_HEADER_SEARCH_PATH};${CUDA_TOOLKIT_ROOT_DIR}/include;${CUDA_TOOLKIT_ROOT_DIR}/targets/x86_64-linux/include)
-    set(CUDNN_LIBRARY_SEARCH_PATHS ${CUDNN_LIBRARY_SEARCH_PATH};${CUDA_TOOLKIT_ROOT_DIR}/lib64;${CUDA_TOOLKIT_ROOT_DIR}/targets/x86_64-linux/lib)
+    list(APPEND CUDNN_HEADER_SEARCH_PATHS ${CUDNN_PATH}/include)
+    list(APPEND CUDNN_HEADER_SEARCH_PATHS ${CUDA_TOOLKIT_ROOT_DIR}/include)
+    list(APPEND CUDNN_HEADER_SEARCH_PATHS ${CUDA_TOOLKIT_ROOT_DIR}/targets/x86_64-linux/include)
+    list(APPEND CUDNN_LIBRARY_SEARCH_PATHS ${CUDA_TOOLKIT_ROOT_DIR}/lib64)
+    list(APPEND CUDNN_LIBRARY_SEARCH_PATHS ${CUDA_TOOLKIT_ROOT_DIR}/targets/x86_64-linux/lib)
   endif()
 endforeach()
 
-foreach(PATH_HINT ${CUDNN_PATH})
-  set(CUDNN_HEADER_SEARCH_PATHS ${CUDNN_HEADER_SEARCH_PATHS};${CUDNN_PATH}/include)
-  set(CUDNN_LIBRARY_SEARCH_PATHS ${CUDNN_LIBRARY_SEARCH_PATHS};${CUDNN_PATH}/lib)
-  set(CUDNN_LIBRARY_SEARCH_PATHS ${CUDNN_LIBRARY_SEARCH_PATHS};${CUDNN_PATH}/lib64)
-endforeach()
-
 if (APPLE)
-  set(CUDNN_HEADER_SEARCH_PATHS
-    ${CUDNN_HEADER_SEARCH_PATHS}
-    /usr/local/cudnn-7.0/include
-    /usr/local/cudnn-6.5/include
-    )
+  list(APPEND CUDNN_HEADER_SEARCH_PATHS /usr/local/cudnn-7.0/include)
+  list(APPEND CUDNN_HEADER_SEARCH_PATHS /usr/local/cudnn-6.5/include)
 
-  set(CUDNN_LIBRARY_SEARCH_PATHS
-    ${CUDNN_LIBRARY_SEARCH_PATHS}
-    /usr/local/cudnn-7.0/lib
-    /usr/local/cudnn-7.0/lib64
-    /usr/local/cudnn-6.5/lib
-    /usr/local/cudnn-6.5/lib64
-    )
+  list(APPEND CUDNN_LIBRARY_SEARCH_PATHS /usr/local/cudnn-7.0/lib)
+  list(APPEND CUDNN_LIBRARY_SEARCH_PATHS /usr/local/cudnn-7.0/lib64)
+  list(APPEND CUDNN_LIBRARY_SEARCH_PATHS /usr/local/cudnn-6.5/lib)
+  list(APPEND CUDNN_LIBRARY_SEARCH_PATHS /usr/local/cudnn-6.5/lib64)
 
 else()
-  set(CUDNN_HEADER_SEARCH_PATHS
-    ${CUDNN_HEADER_SEARCH_PATHS}
-    /nh/compneuro/Data/cuDNN/cudnn-7.0-linux-x64-v4/include
-    /nh/compneuro/Data/cuDNN/cudnn-7.0-linux-x64-v3/include
-    /nh/compneuro/Data/cuDNN/cudnn-6.5-linux-x64-R2-rc1/include
-    )
-  set(CUDNN_LIBRARY_SEARCH_PATHS
-    ${CUDNN_LIBRARY_SEARCH_PATHS}
-    /nh/compneuro/Data/cuDNN/cudnn-7.0-linux-x64-v4/lib
-    /nh/compneuro/Data/cuDNN/cudnn-7.0-linux-x64-v4/lib64
-    /nh/compneuro/Data/cuDNN/cudnn-7.0-linux-x64-v3/lib
-    /nh/compneuro/Data/cuDNN/cudnn-7.0-linux-x64-v3/lib64
-    /nh/compneuro/Data/cuDNN/cudnn-6.5-linux-x64-R2-rc1/lib
-    /nh/compneuro/Data/cuDNN/cudnn-6.5-linux-x64-R2-rc1/lib64
-    )
+  list(APPEND CUDNN_HEADER_SEARCH_PATHS /nh/compneuro/Data/cuDNN/cudnn-7.0-linux-x64-v4/include)
+  list(APPEND CUDNN_HEADER_SEARCH_PATHS /nh/compneuro/Data/cuDNN/cudnn-7.0-linux-x64-v3/include)
+  list(APPEND CUDNN_HEADER_SEARCH_PATHS /nh/compneuro/Data/cuDNN/cudnn-6.5-linux-x64-R2-rc1/include)
+
+  list(APPEND CUDNN_LIBRARY_SEARCH_PATHS /nh/compneuro/Data/cuDNN/cudnn-7.0-linux-x64-v4/lib)
+  list(APPEND CUDNN_LIBRARY_SEARCH_PATHS /nh/compneuro/Data/cuDNN/cudnn-7.0-linux-x64-v4/lib64)
+  list(APPEND CUDNN_LIBRARY_SEARCH_PATHS /nh/compneuro/Data/cuDNN/cudnn-7.0-linux-x64-v3/lib)
+  list(APPEND CUDNN_LIBRARY_SEARCH_PATHS /nh/compneuro/Data/cuDNN/cudnn-7.0-linux-x64-v3/lib64)
+  list(APPEND CUDNN_LIBRARY_SEARCH_PATHS /nh/compneuro/Data/cuDNN/cudnn-6.5-linux-x64-R2-rc1/lib)
+  list(APPEND CUDNN_LIBRARY_SEARCH_PATHS /nh/compneuro/Data/cuDNN/cudnn-6.5-linux-x64-R2-rc1/lib64)
 endif()
 
 find_path(CUDNN_INCLUDE_DIR
   NAMES cudnn.h
   PATHS ${CUDNN_HEADER_SEARCH_PATHS}
   DOC "cuDNN include"
-  )
+)
 
 # Find cudnn library
 find_library(CUDNN_LIBRARY cudnn cudnn_static ${CUDNN_LIBRARY_SEARCH_PATHS} DOC "cuDNN library")

--- a/demos/CMakeLists.txt
+++ b/demos/CMakeLists.txt
@@ -1,0 +1,9 @@
+set(DEMOS 
+    # binocDemo
+   HeatMapLocalization 
+)
+
+foreach(subdir ${DEMOS})
+   message(STATUS "adding subdir ${subdir}")
+   add_subdirectory(${subdir})
+endforeach()

--- a/demos/HeatMapLocalization/CMakeLists.txt
+++ b/demos/HeatMapLocalization/CMakeLists.txt
@@ -2,7 +2,7 @@ include(PVAddExecutable)
 
 get_filename_component(PV_PROJECT_NAME ${CMAKE_CURRENT_SOURCE_DIR} NAME)
 
-include_directories("${CMAKE_CURRENT_SOURCE_DIR}/src")
+#include_directories("${CMAKE_CURRENT_SOURCE_DIR}/src")
 
 set(${PV_PROJECT_NAME}_SRCCPP
   src/ConvertFromTable.cpp
@@ -13,7 +13,7 @@ set(${PV_PROJECT_NAME}_SRCCPP
 
 pv_add_executable(${PV_PROJECT_NAME}
   SRC ${${PV_PROJECT_NAME}_SRCCPP}
-  OUTPUT_PATH "${CMAKE_CURRENT_BINARY_DIR}/${CMAKE_BUILD_TYPE}"
+  #  OUTPUT_PATH "${CMAKE_CURRENT_BINARY_DIR}/${CMAKE_BUILD_TYPE}"
 )
 
 add_dependencies(${PV_PROJECT_NAME} pv)

--- a/demos/HeatMapLocalization/src/BBFind.cpp
+++ b/demos/HeatMapLocalization/src/BBFind.cpp
@@ -307,7 +307,10 @@ BBFind::Map2 BBFind::scale(const Map2 &source, int newWidth, int newHeight, bool
    {
       float xRatio = sourceWidth / (float)(newWidth);
       float yRatio = sourceHeight / (float)(newHeight);
-   
+
+      #ifdef PV_USE_OPENMP_THREADS
+			#pragma omp parallel for
+		#endif   
       for(int j = 0; j < newHeight; j++)
       {
          result[j].resize(newWidth);
@@ -327,7 +330,10 @@ BBFind::Map2 BBFind::applyThreshold(const Map2 confMap, float threshold)
 	int mapWidth = confMap[0].size();
 	int mapHeight = confMap.size();
 	Map2 resultMap = confMap;
-	
+
+   #ifdef PV_USE_OPENMP_THREADS
+		#pragma omp parallel for
+   #endif	
    for(int x = 0; x < mapWidth; x++)
 	{
 		for(int y = 0; y < mapHeight; y++)
@@ -441,6 +447,9 @@ BBFind::Map2 BBFind::makeEdgeDistanceMap(const Map2 confMap)
    
    Map2 resultMap = horizMap;
    
+   #ifdef PV_USE_OPENMP_THREADS
+		#pragma omp parallel for
+   #endif
    for(int y = 0; y < mapHeight; y++)
 	{
 		for(int x = 0; x < mapWidth; x++)
@@ -479,6 +488,9 @@ void BBFind::squash(Map2 &map, float scaleMin, float scaleMax)
       }
    }
    float range = maxVal - minVal;
+   #ifdef PV_USE_OPENMP_THREADS
+      #pragma omp parallel for
+   #endif
    for(int x = 0; x < mapWidth; x++)
    {
       for(int y = 0; y < mapHeight; y++)
@@ -523,7 +535,10 @@ BBFind::Map3 BBFind::increaseContrast(const Map3 fullMap, float contrast, float 
 	int mapWidth = fullMap[0][0].size();
 	int mapHeight = fullMap[0].size();
 	Map3 resultMap = fullMap;
-	
+
+   #ifdef PV_USE_OPENMP_THREADS
+       #pragma omp parallel for
+   #endif	
    for(int c = 0; c < numCategories; c++)
    {
       for(int y = 0; y < mapHeight; y++)
@@ -557,6 +572,9 @@ BBFind::Map3 BBFind::contrastAndAverage(const Map3 fullMap, float contrast, floa
       ((float)mInternalConfidenceWidth * mInternalConfidenceHeight)
            / (mOriginalConfidenceWidth * mOriginalConfidenceHeight));
   
+   #ifdef PV_USE_OPENMP_THREADS
+      #pragma omp parallel for
+   #endif
    for(int c = 0; c < numCategories; c++)
    {
       resultMap[c].resize(mapHeight);
@@ -586,6 +604,9 @@ BBFind::Map3 BBFind::blendMaps(const Map3 &mapA, const Map3 &mapB, float interp)
 
    Map3 interpolatedMap(numCategories);
    
+   #ifdef PV_USE_OPENMP_THREADS
+		#pragma omp parallel for
+   #endif
    for(int c = 0; c < numCategories; c++)
    {
       interpolatedMap[c].resize(mapHeight);
@@ -617,6 +638,9 @@ BBFind::Map3 BBFind::sumMaps(const Map3 &mapA, const Map3 &mapB, float scale)
 
    Map3 summedMap(numCategories);
    
+   #ifdef PV_USE_OPENMP_THREADS
+		#pragma omp parallel for
+   #endif
    for(int c = 0; c < numCategories; c++)
    {
       summedMap[c].resize(mapHeight);
@@ -642,6 +666,9 @@ void BBFind::clip(Map3 &confMap, float minVal, float maxVal)
    int numCategories = confMap.size();
 	int mapHeight = confMap[0].size();
    int mapWidth = confMap[0][0].size();
+   #ifdef PV_USE_OPENMP_THREADS
+      #pragma omp parallel for
+   #endif
    for(int c = 0; c < numCategories; c++)
    {
       for(int y = 0; y < mapHeight; y++)
@@ -682,6 +709,9 @@ void BBFind::squash(Map3 &map, float scaleMin, float scaleMax)
       }
    }
    float range = maxVal - minVal;
+   #ifdef PV_USE_OPENMP_THREADS
+      #pragma omp parallel for
+   #endif
    for(int c = 0; c < numCategories; c++)
    {
       for(int y = 0; y < mapHeight; y++)
@@ -721,6 +751,9 @@ void BBFind::accumulateIntoPrev(Map3 &prevMap, const Map3 &currentMap, float acc
          }
       }
    }
+   #ifdef PV_USE_OPENMP_THREADS
+      #pragma omp parallel for
+   #endif
    for(int c = 0; c < numCategories; c++)
    {
       for(int y = 0; y < mapHeight; y++)
@@ -758,6 +791,9 @@ BBFind::Rectangles BBFind::placePotentialBoxes(const Map3 fullMap)
 	float maxVal = 0.0f;
 	Rectangles boundingBoxes(numCategories);
 
+   #ifdef PV_USE_OPENMP_THREADS
+      #pragma omp parallel for
+   #endif
    for(int c = 0; c < numCategories; c++)
    {
       Map2 distanceMap = applyThreshold(fullMap[c], mMinBlobSize);
@@ -794,6 +830,9 @@ void BBFind::joinBoundingBoxes(Rectangles &boundingBoxes)
    
 	int numCategories = boundingBoxes.size();
 
+   #ifdef PV_USE_OPENMP_THREADS
+      #pragma omp parallel for
+   #endif
 	for(int c = 0; c < numCategories; c++)
 	{
 		bool joinedBox = true;
@@ -833,6 +872,9 @@ void BBFind::smoothBoundingBoxes(Rectangles &boundingBoxes)
    if(mRectSizesPerCategory.size() < numCategories)
       mRectSizesPerCategory.resize(numCategories);
    
+   #ifdef PV_USE_OPENMP_THREADS
+      #pragma omp parallel for
+   #endif
 	for(int c = 0; c < numCategories; c++)
 	{
       if(mRectSizesPerCategory[c].size() > 0)

--- a/demos/HeatMapLocalization/src/LocalizationProbe.cpp
+++ b/demos/HeatMapLocalization/src/LocalizationProbe.cpp
@@ -55,7 +55,7 @@ int LocalizationProbe::initialize_base() {
    montageImageLocal = NULL;
    montageImageComm = NULL;
    imageBlendCoeff = 0.3;
-   maxDetections = 100;
+   maxDetections = 100U;
    boundingBoxLineWidth = 5;
 
    outputFilenameBase = NULL; // Not used by harness since we don't have a filename to use for the base
@@ -120,7 +120,7 @@ void LocalizationProbe::ioParam_displayCategoryIndexEnd(enum ParamsIOFlag ioFlag
 }
 
 void LocalizationProbe::ioParam_detectionThreshold(enum ParamsIOFlag ioFlag) {
-   parent->ioParamArray(ioFlag, name, "detectionThresholds", &detectionThreshold, &numDetectionThresholds);
+   parent->ioParamArray(ioFlag, name, "detectionThreshold", &detectionThreshold, &numDetectionThresholds);
 }
 
 void LocalizationProbe::ioParam_classNamesFile(enum ParamsIOFlag ioFlag) {
@@ -171,7 +171,7 @@ void LocalizationProbe::ioParam_heatMapMontageDir(enum ParamsIOFlag ioFlag) {
 void LocalizationProbe::ioParam_heatMapMaximum(enum ParamsIOFlag ioFlag) {
    assert(!parent->parameters()->presentAndNotBeenRead(this->getName(), "drawMontage"));
    if (drawMontage) {
-      parent->ioParamArray(ioFlag, name, "heatMapMaxima", &heatMapMaximum, &numHeatMapMaxima);
+      parent->ioParamArray(ioFlag, name, "heatMapMaximum", &heatMapMaximum, &numHeatMapMaxima);
    }
 }
 
@@ -202,9 +202,9 @@ void LocalizationProbe::ioParam_displayCommand(enum ParamsIOFlag ioFlag) {
 
 
 int LocalizationProbe::initNumValues() {
-   return setNumValues(6*maxDetections+1);
-   // Each detection has 6 values. winningFeature,maxActivity,boundingBoxLeft,boundingBoxRight,boundingBoxTop,boundingBoxBottom
-   // getValuesBuffer[0] returns the number of realized detections.
+   return setNumValues(1);
+   // numValues is the number of detections.  detections will be a vector of that length.
+   // If we add batching to localization probe, this should change to the batch size.
 }
 
 int LocalizationProbe::communicateInitInfo() {
@@ -276,7 +276,7 @@ int LocalizationProbe::communicateInitInfo() {
    if (numDetectionThresholds==0) {
       detectionThreshold = (float *) malloc(sizeof(*detectionThreshold)*(size_t) numDisplayedCategories);
       if (detectionThreshold==NULL) {
-         fprintf(stderr, "%s \"%s\": Unable to allocate memory for detectionThresholds: %s\n",
+         fprintf(stderr, "%s \"%s\": Unable to allocate memory for detectionThreshold array: %s\n",
                getKeyword(), name, strerror(errno));
          exit(EXIT_FAILURE);
       }
@@ -286,7 +286,7 @@ int LocalizationProbe::communicateInitInfo() {
    else if (numDetectionThresholds==1 && numDisplayedCategories>1) {
       detectionThreshold = (float *) realloc(detectionThreshold, sizeof(*detectionThreshold)*(size_t) numDisplayedCategories);
       if (detectionThreshold==NULL) {
-         fprintf(stderr, "%s \"%s\": Unable to allocate memory for detectionThresholds: %s\n",
+         fprintf(stderr, "%s \"%s\": Unable to allocate memory for detectionThreshold array: %s\n",
                getKeyword(), name, strerror(errno));
          exit(EXIT_FAILURE);
       }
@@ -296,27 +296,27 @@ int LocalizationProbe::communicateInitInfo() {
    }
    else if (numDetectionThresholds != numDisplayedCategories) {
       if (parent->columnId()==0) {
-         fprintf(stderr, "%s \"%s\" error: detectionThresholds array given %d entries, but number of displayed categories is %d.\n",
+         fprintf(stderr, "%s \"%s\" error: detectionThreshold array given %d entries, but number of displayed categories is %d.\n",
                getKeyword(), name, numDetectionThresholds, numDisplayedCategories);
          exit(EXIT_FAILURE);
       }
    }
    if (drawMontage) {
-      // TODO: abstract out similarities between expanding heatMapMaxima array and expanding detectionThresholds array, and perhaps other arrays in pv-core.
+      // TODO: abstract out similarities between expanding heatMapMaximum array and expanding detectionThreshold array, and perhaps other arrays in pv-core.
       if (numHeatMapMaxima==0) {
          heatMapMaximum = (float *) malloc(sizeof(*detectionThreshold)*(size_t) numDisplayedCategories);
          if (heatMapMaximum==NULL) {
-            fprintf(stderr, "%s \"%s\": Unable to allocate memory for heatMapMaxima: %s\n",
+            fprintf(stderr, "%s \"%s\": Unable to allocate memory for heatMapMaximum array: %s\n",
                   getKeyword(), name, strerror(errno));
             exit(EXIT_FAILURE);
          }
-         for (int k=0; k<numDisplayedCategories; k++) { heatMapMaximum[0] = 1.0f; }
+         for (int k=0; k<numDisplayedCategories; k++) { heatMapMaximum[k] = 1.0f; }
          numHeatMapMaxima = numDisplayedCategories;
       }
       else if (numHeatMapMaxima==1 && numDisplayedCategories>1) {
          heatMapMaximum = (float *) realloc(heatMapMaximum, sizeof(*heatMapMaximum)*(size_t) numDisplayedCategories);
          if (heatMapMaximum==NULL) {
-            fprintf(stderr, "%s \"%s\": Unable to allocate memory for heatMapMaxima: %s\n",
+            fprintf(stderr, "%s \"%s\": Unable to allocate memory for heatMapMaximum array: %s\n",
                   getKeyword(), name, strerror(errno));
             exit(EXIT_FAILURE);
          }
@@ -326,7 +326,7 @@ int LocalizationProbe::communicateInitInfo() {
       }
       else if (numHeatMapMaxima != numDisplayedCategories) {
          if (parent->columnId()==0) {
-            fprintf(stderr, "%s \"%s\" error: detectionThresholds array given %d entries, but number of displayed categories is %d.\n",
+            fprintf(stderr, "%s \"%s\" error: detectionThreshold array given %d entries, but number of displayed categories is %d.\n",
                   getKeyword(), name, numDetectionThresholds, numDisplayedCategories);
             exit(EXIT_FAILURE);
          }
@@ -336,7 +336,7 @@ int LocalizationProbe::communicateInitInfo() {
          if (heatMapMaximum[k] < detectionThreshold[k]) {
             status = PV_FAILURE;
             if (parent->columnId()==0) {
-               fprintf(stderr, "%s \"%s\": heatMapMaxima entry %d (%f) cannot be less than corresponding detectionThresholds entry (%f).\n",
+               fprintf(stderr, "%s \"%s\": heatMapMaximum entry %d (%f) cannot be less than corresponding detectionThreshold entry (%f).\n",
                      getKeyword(), name, k, heatMapMaximum[k], detectionThreshold[k]);
             }
          }
@@ -527,6 +527,7 @@ int LocalizationProbe::allocateDataStructures() {
       fprintf(stderr, "%s \"%s\": LocalizationProbe::allocateDataStructures failed.\n", getKeyword(), name);
       exit(EXIT_FAILURE);
    }
+   detections.reserve(maxDetections);
    if (drawMontage) {
       assert(imageLayer);
       PVLayerLoc const * imageLoc = imageLayer->getLayerLoc();
@@ -811,34 +812,26 @@ bool LocalizationProbe::needUpdate(double timed, double dt) {
 }
 
 int LocalizationProbe::calcValues(double timevalue) {
-   double * values = getValuesBuffer();
-   assert(getNumValues()==6*maxDetections+1);
-   values[0] = 0.0;
-   for (int k=0; k<maxDetections; k++) {
-      values[6*k+1] = -1.0;
-      values[6*k+2] = 0.0;
-      values[6*k+3] = -1.0;
-      values[6*k+4] = -1.0;
-      values[6*k+5] = -1.0;
-      values[6*k+6] = -1.0;
-   }
    int const N = targetLayer->getNumNeurons();
    PVLayerLoc const * loc = targetLayer->getLayerLoc();
    PVHalo const * halo = &loc->halo;
    float * targetRes = (float *) malloc(sizeof(float)*N);
-   if (targetRes==NULL) { fprintf(stderr, "Nooooooooooo!\n"); exit(EXIT_FAILURE); }
+   if (targetRes==NULL) {
+      fprintf(stderr, "%s \"%s\" unable to allocate buffer for calcValues\n", getKeyword(), name);
+      exit(EXIT_FAILURE);
+   }
    for (int n=0; n<N; n++) {
       int nExt = kIndexExtended(n, loc->nx, loc->ny, loc->nf, halo->lt, halo->rt, halo->dn, halo->up);
       targetRes[n] = targetLayer->getLayerData()[nExt];
    }
-   values[0] = maxDetections;
-   int detection = 0;
    float minDetectionThreshold = std::numeric_limits<float>::infinity();
    for (int k=0; k<numDisplayedCategories; k++) {
       float a = detectionThreshold[k];
       minDetectionThreshold = a < minDetectionThreshold ? a : minDetectionThreshold;
    }
-   while(detection<maxDetections) {
+   detections.clear();
+   size_t detectionIndex = 0;
+   while(detectionIndex<maxDetections) {
       int winningFeature, winningIndex, xLocation, yLocation;
       float activity;
       findMaxLocation(&winningFeature, &winningIndex, &xLocation, &yLocation, &activity, targetRes, loc);
@@ -866,23 +859,26 @@ int LocalizationProbe::calcValues(double timevalue) {
          MPI_Allreduce(MPI_IN_PLACE, &numpixels, 1, MPI_INT, MPI_SUM, parent->icCommunicator()->communicator());
          score = score/numpixels;
          if (boundingBox[1]-boundingBox[0]>=minBoundingBoxWidth && boundingBox[3]-boundingBox[2]>=minBoundingBoxHeight) {
-            double * thisBox = &values[6*detection+1];
-            thisBox[0] = (double) winningFeature;
-            thisBox[1] = score;
-            double * boundingBoxDbl = &thisBox[2];
-            boundingBoxDbl[0] = (double) boundingBox[0] * imageDilationX;
-            boundingBoxDbl[1] = (double) boundingBox[1] * imageDilationX;
-            boundingBoxDbl[2] = (double) boundingBox[2] * imageDilationY;
-            boundingBoxDbl[3] = (double) boundingBox[3] * imageDilationY;
-            detection++;
+            localization newDetection;
+            newDetection.feature = winningFeature;
+            newDetection.displayedIndex = winningIndex;
+            newDetection.left = boundingBox[0] * imageDilationX;
+            newDetection.right = boundingBox[1] * imageDilationX;
+            newDetection.top = boundingBox[2] * imageDilationY;
+            newDetection.bottom = boundingBox[3] * imageDilationY;
+            newDetection.score = score;
+            detections.push_back(newDetection);
+            detectionIndex++;
          }
       }
       else {
          assert(!(winningFeature >= 0 && activity >= minDetectionThreshold));
-         values[0] = detection;
          break;
       }
    }
+   assert(getNumValues()==1);
+   double * values = getValuesBuffer();
+   *values = detectionIndex;
    free(targetRes);
    return PV_SUCCESS;
 }
@@ -999,25 +995,24 @@ int LocalizationProbe::outputState(double timevalue) {
    }
    if (getTextOutputFlag()) {
       assert(outputstream && outputstream->fp);
-      double * values = getValuesBuffer();
-      int numDetected = (int) nearbyint(values[0]);
-      assert(numDetected>=0 && numDetected<maxDetections && getNumValues()==maxDetections*6+1);
+      size_t numDetected = detections.size();
+      assert(numDetected<maxDetections);
       if (numDetected==0) {
          fprintf(outputstream->fp, "Time %f, no detections.\n", timevalue);
       }
-      for (int d=0; d<numDetected; d++) {
-         double const * thisDetection = &values[6*d+1];
-         int winningFeature = (int) thisDetection[0];
+      for (size_t d=0; d<numDetected; d++) {
+         localization const * thisDetection = &detections.at(d);
+         int winningFeature = thisDetection->feature;
          assert(winningFeature>=0 && winningFeature<targetLayer->getLayerLoc()->nf);
-         double score = thisDetection[1];
+         double score = thisDetection->score;
          fprintf(outputstream->fp, "Time %f, \"%s\", score %f, bounding box x=[%d,%d), y=[%d,%d)\n",
                timevalue,
                getClassName(winningFeature),
                score,
-               (int) thisDetection[2],
-               (int) thisDetection[3],
-               (int) thisDetection[4],
-               (int) thisDetection[5]);
+               (int) thisDetection->left,
+               (int) thisDetection->right,
+               (int) thisDetection->top,
+               (int) thisDetection->bottom);
       }
    }
    if (drawMontage) {
@@ -1050,21 +1045,16 @@ int LocalizationProbe::makeMontage() {
 
    // Draw bounding boxes
    if (boundingBoxLineWidth > 0) {
-      double * values = getValuesBuffer();
-      for (int d=0; d<(int) values[0]; d++) {
-         double * thisBoundingBox = &values[6*d+1];
-         int winningFeature = (int) values[6*d+1];
+      assert(getNumValues()==1);
+      for (size_t d=0; d<detections.size(); d++) {
+         localization const * thisBoundingBox = &detections.at(d);
+         int winningFeature = thisBoundingBox->feature;
          if (winningFeature<0) { continue; }
-         int left = (int) thisBoundingBox[2];
-         int right = (int) thisBoundingBox[3];
-         int top = (int) thisBoundingBox[4];
-         int bottom = (int) thisBoundingBox[5];
-         int winningIndex=-1;
-         for (int k=0; k<numDisplayedCategories; k++) {
-            int category = displayedCategories[k];
-            int feature = category-1;
-            if (feature==winningFeature) { winningIndex=k; break; }
-         }
+         int left = (int) thisBoundingBox->left;
+         int right = (int) thisBoundingBox->right;
+         int top = (int) thisBoundingBox->top;
+         int bottom = (int) thisBoundingBox->bottom;
+         int winningIndex = thisBoundingBox->displayedIndex;
          assert(winningIndex>=0);
          int montageColumn = kxPos(winningIndex, numMontageColumns, numMontageRows, 1);
          int montageRow = kyPos(winningIndex, numMontageColumns, numMontageRows, 1);
@@ -1161,25 +1151,22 @@ int LocalizationProbe::drawHeatMaps() {
 
    PVLayerLoc const * targetLoc = targetLayer->getLayerLoc();
    PVHalo const * targetHalo = &targetLoc->halo;
-   int winningFeature[maxDetections];
-   int winningIndex[maxDetections];
-   double maxConfidence[maxDetections];
-   for (int d=0; d<maxDetections; d++) {
-      maxConfidence[d] = getValuesBuffer()[6*d+2];
-      winningFeature[d] = (int) getValuesBuffer()[6*d+1];
-      winningIndex[d] = -1;
-      for (int idx=0; idx<numDisplayedCategories; idx++) {
-         if (displayedCategories[idx]==winningFeature[d]+1) {
-            winningIndex[d] = idx;
-         }
-      }
+   size_t numDetections = detections.size();
+   int winningFeature[numDetections];
+   int winningIndex[numDetections];
+   double boxConfidence[numDetections];
+   for (int d=0; d<numDetections; d++) {
+      localization const * box = &detections.at(d);
+      boxConfidence[d] = box->score;
+      winningFeature[d] = box->feature;
+      winningIndex[d] = box->displayedIndex;
    }
 
    double maxConfByCategory[targetLoc->nf];
    for (int f=0; f<targetLoc->nf; f++) { maxConfByCategory[f] = -std::numeric_limits<pvadata_t>::infinity(); }
-   for (int d=0; d<getValuesBuffer()[0]; d++) {
+   for (size_t d=0; d<numDetections; d++) {
       int f = winningFeature[d];
-      double a = maxConfidence[d];
+      double a = boxConfidence[d];
       double m = maxConfByCategory[f];
       maxConfByCategory[f] = a > m ? a : m;
    }

--- a/demos/HeatMapLocalization/src/LocalizationProbe.hpp
+++ b/demos/HeatMapLocalization/src/LocalizationProbe.hpp
@@ -57,10 +57,15 @@ public:
 
    /**
     * Returns the bounding box, feature, and score information for the detection of the given index.
-    * Throws out_of_range exception if index is >= getNumDetections().
+    * Throws an out_of_range exception if index is >= getNumDetections().
     * The bounding box values (left, right, top, bottom) are in imageLayer coordinates.
     */
-   localization const * getDetection(size_t index) {return &detections.at(index);}
+   inline localization const * getDetection(size_t index) { return &detections.at(index); }
+
+   /**
+    * Returns the vector of all detections that would be returned by getDetection(k)
+    */
+   inline std::vector<localization> const * getDetections() { return &detections; }
 
    /**
     * Sets the base of the output filename.  It takes everything after the


### PR DESCRIPTION
The probeValues buffer of a LocalizationProbe now only contains a single value, the number of detections.  The detections are contained in a data member of type 
To retrieve the detection of a specific index, call LocalizationProbe::getDetection(index).
To retrieve a vector of all detections, call LocalizationProbe::getDetections().
The bounding box information is in the coordinates of the imageLayer, not the targetLayer.

This is more intuitive than the previous organization, where feature indices, bounding box coordinates, and confidences were stored in a single flat array.

This update also corrects confusion between the names detectionThreshold/detectionThresholds and between
heatMapMaximum/heatMapMaxima that was introduced when these parameters were changed to arrays.  In both cases,
all references have been changed to the singular version of the name.  The singular was chosen to be consistent with the params files on the web demo.
