### PR TITLE
Overhaul of BaseInput so that all subclasses use autoResizeFlag.  Add…

### DIFF
--- a/demos/HeatMapLocalization/src/MaskFromMemoryBuffer.hpp
+++ b/demos/HeatMapLocalization/src/MaskFromMemoryBuffer.hpp
@@ -33,11 +33,11 @@ private:
 
 // Member variables
    char* imageLayerName;
-   PV::ImageFromMemoryBuffer * imageLayer;
-   int imageLeft;
-   int imageRight;
-   int imageTop;
-   int imageBottom;
+   PV::BaseInput * imageLayer;
+   int dataLeft;
+   int dataRight;
+   int dataTop;
+   int dataBottom;
 
 }; // class MaskFromMemoryBuffer
 

--- a/src/columns/BaseObject.cpp
+++ b/src/columns/BaseObject.cpp
@@ -13,7 +13,6 @@
 #include "BaseObject.hpp"
 #include "include/pv_common.h"
 #include "columns/HyPerCol.hpp"
-#include "utils/PVAssert.hpp"
 
 namespace PV {
 

--- a/src/columns/BaseObject.hpp
+++ b/src/columns/BaseObject.hpp
@@ -23,6 +23,10 @@
 #ifndef BASEOBJECT_HPP_
 #define BASEOBJECT_HPP_
 
+#include "utils/PVLog.hpp"
+#include "utils/PVAssert.hpp"
+#include "utils/PVAlloc.hpp"
+
 namespace PV {
 
 class HyPerCol;

--- a/src/connections/HyPerConn.cpp
+++ b/src/connections/HyPerConn.cpp
@@ -28,10 +28,6 @@
 #include "io/CoreParamGroupHandler.hpp"
 #include "columns/Factory.hpp"
 
-#include "utils/PVLog.hpp"
-#include "utils/PVAlloc.hpp"
-#include "utils/PVAssert.hpp"
-
 namespace PV {
 
 HyPerConn::HyPerConn()

--- a/src/connections/IdentConn.cpp
+++ b/src/connections/IdentConn.cpp
@@ -7,7 +7,6 @@
 
 #include "IdentConn.hpp"
 #include "weightinit/InitIdentWeights.hpp"
-#include "utils/PVLog.hpp"
 
 namespace PV {
 

--- a/src/connections/MomentumConn.cpp
+++ b/src/connections/MomentumConn.cpp
@@ -7,7 +7,6 @@
 
 #include "MomentumConn.hpp"
 #include <cstring>
-#include "utils/PVAlloc.hpp"
 
 namespace PV {
 

--- a/src/connections/PoolingConn.cpp
+++ b/src/connections/PoolingConn.cpp
@@ -8,9 +8,6 @@
 #include "PoolingConn.hpp"
 #include <cstring>
 #include <cmath>
-#include "utils/PVLog.hpp"
-#include "utils/PVAlloc.hpp"
-#include "utils/PVAssert.hpp"
 
 namespace PV {
 

--- a/src/connections/TransposePoolingConn.cpp
+++ b/src/connections/TransposePoolingConn.cpp
@@ -5,9 +5,6 @@
  */
 
 #include "TransposePoolingConn.hpp"
-#include "utils/PVLog.hpp"
-#include "utils/PVAlloc.hpp"
-#include "utils/PVAssert.hpp"
 
 namespace PV {
 

--- a/src/io/imageio.hpp
+++ b/src/io/imageio.hpp
@@ -32,7 +32,12 @@ int gatherImageFile(    const char * filename,
 int gatherImageFilePVP( const char * filename,
                         PV::Communicator * comm, const PVLayerLoc * loc, unsigned char * buf, bool verifyWrites);
 #ifdef PV_USE_GDAL
-int getImageInfoGDAL(const char * filename, PV::Communicator * comm, PVLayerLoc * loc, GDALColorInterp ** colorbandtypes);
+/**
+ * Stores the dimensions of the image specified in the filename argument in the PVLayerLoc,
+ * and allocates the *colorbandtypes array (using malloc) to store information on the color type of each band.
+ * Should only be called by processes that do I/O.
+ */
+int getImageInfoGDAL(const char * filename, PVLayerLoc * loc, GDALColorInterp ** colorbandtypes);
 int gatherImageFileGDAL(const char * filename,
                        PV::Communicator * comm, const PVLayerLoc * loc, unsigned char * buf, bool verifyWrites);
 GDALDataset * PV_GDALOpen(const char * filename);

--- a/src/layers/Image.hpp
+++ b/src/layers/Image.hpp
@@ -25,21 +25,9 @@ protected:
     * @{
     */
 
-   //TODO this functionality should be in both pvp and image. Set here for now, as pvp does not support imageBC
    /**
-    * @brief autoResizeFlag: If set to true, the image will be resized to the layer
-    * @details 
-    *  For the auto resize flag, PV checks which side (x or y) is the shortest, relative to the
-    *  hypercolumn size specified.  Then it determines the largest chunk it can possibly take
-    *  from the image with the correct aspect ratio determined by hypercolumn.  It then
-    *  determines the offset needed in the long dimension to center the cropped image,
-    *  and reads in that portion of the image.  The offset can optionally be translated by
-    *  offset{X,Y} specified in the params file (values can be positive or negative).
-    *  If the specified offset takes the cropped image outside the image file, it uses the
-    *  largest-magnitude offset that stays within the image file's borders.
+    * @brief writeStep: The Image class changes the default of writeStep to -1 (i.e. never write to the output pvp file).
     */
-   virtual void ioParam_autoResizeFlag(enum ParamsIOFlag ioFlag);
-
    virtual void ioParam_writeStep(enum ParamsIOFlag ioFlag);
 
    /** @} */
@@ -63,17 +51,17 @@ private:
    int initialize_base();
 
 protected:
+   virtual int readImageFileGDAL(char const * filename, PVLayerLoc const * loc);
+#ifdef INACTIVE // Commented out April 19, 2016.  Might prove useful to restore the option to resize using GDAL.
    virtual int scatterImageFileGDAL(const char * filename, int xOffset, int yOffset, PV::Communicator * comm, const PVLayerLoc * loc, float * buf, bool autoResizeFlag);
-   virtual int retrieveData(double timef, double dt);
+#endif // INACTIVE // Commented out April 19, 2016.  Might prove useful to restore the option to resize using GDAL.
 
-   virtual int readImage(const char * filename, int batchIdx, int offsetX, int offsetY, const char* anchor);
+   virtual int retrieveData(double timef, double dt, int batchIndex);
 
-   static float * convertToGrayScale(float * buf, int nx, int ny, int numBands, GDALColorInterp * colorbandtypes);
-   static float* copyGrayScaletoMultiBands(float * buf, int nx, int ny, int numBands, GDALColorInterp * colorbandtypes);
-   static inline int calcBandWeights(int numBands, float * bandweights, GDALColorInterp * colorbandtypes);
-   static inline void equalBandWeights(int numBands, float * bandweights);
+   //Virtual function to define how readImage specifies batches
+   virtual int readImage(const char * filename);
+   int calcColorType(int numBands, GDALColorInterp * colorbandtypes);
 
-   bool autoResizeFlag; // if true, PetaVision will automatically resize your images to the size specified by hypercolumn
 #else // PV_USE_GDAL
 public:
    Image(char const * name, HyPerCol * hc);

--- a/src/layers/ImageFromMemoryBuffer.cpp
+++ b/src/layers/ImageFromMemoryBuffer.cpp
@@ -21,16 +21,10 @@ ImageFromMemoryBuffer::ImageFromMemoryBuffer() {
 }
 
 int ImageFromMemoryBuffer::initialize_base() {
-   buffer = NULL;
-   bufferSize = -1;
    hasNewImageFlag = false;
    autoResizeFlag = false;
    aspectRatioAdjustment = NULL;
    resizeFactor = 1.0f;
-   imageLeft = 0;
-   imageRight = 0;
-   imageTop = 0;
-   imageBottom = 0;
    return PV_SUCCESS;
 }
 
@@ -52,29 +46,6 @@ int ImageFromMemoryBuffer::ioParamsFillGroup(enum ParamsIOFlag ioFlag) {
    return status;
 }
 
-void ImageFromMemoryBuffer::ioParam_autoResizeFlag(enum ParamsIOFlag ioFlag) {
-   parent->ioParamValue(ioFlag, name, "autoResizeFlag", &autoResizeFlag, autoResizeFlag);
-}
-
-void ImageFromMemoryBuffer::ioParam_aspectRatioAdjustment(enum ParamsIOFlag ioFlag) {
-   assert(!parent->parameters()->presentAndNotBeenRead(name, "autoResizeFlag"));
-   if (autoResizeFlag) {
-      parent->ioParamString(ioFlag, name, "aspectRatioAdjustment", &aspectRatioAdjustment, "crop"/*default*/);
-      if (ioFlag == PARAMS_IO_READ) {
-         assert(aspectRatioAdjustment);
-         for (char * c = aspectRatioAdjustment; *c; c++) { *c = tolower(*c); }
-      }
-      if (strcmp(aspectRatioAdjustment, "crop") && strcmp(aspectRatioAdjustment, "pad")) {
-         if (parent->columnId()==0) {
-            fprintf(stderr, "%s \"%s\" error: aspectRatioAdjustment must be either \"crop\" or \"pad\".\n",
-                  getKeyword(), name);
-         }
-         MPI_Barrier(parent->icCommunicator()->communicator());
-         exit(EXIT_FAILURE);
-      }
-   }
-}
-
 template <typename pixeltype>
 int ImageFromMemoryBuffer::setMemoryBuffer(pixeltype const * externalBuffer, int height, int width, int numbands, int xstride, int ystride, int bandstride, pixeltype zeroval, pixeltype oneval) {
    if (height<=0 || width<=0 || numbands<=0) {
@@ -84,170 +55,41 @@ int ImageFromMemoryBuffer::setMemoryBuffer(pixeltype const * externalBuffer, int
       return PV_FAILURE;
    }
 
-   int resizedWidth, resizedHeight;
-   if (autoResizeFlag) {
-      float xRatio = (float) getLayerLoc()->nxGlobal/(float) width;
-      float yRatio = (float) getLayerLoc()->nyGlobal/(float) height;
-      if (!strcmp(aspectRatioAdjustment, "crop")) {
-         resizeFactor = xRatio < yRatio ? yRatio : xRatio;
-         // resizeFactor * width should be >= getLayerLoc()->nx; resizeFactor * height should be >= getLayerLoc()->ny,
-         // and one of these relations should be == (up to floating-point roundoff).
-         resizedWidth = (int) nearbyintf(resizeFactor * width);
-         resizedHeight = (int) nearbyintf(resizeFactor * height);
-         assert(resizedWidth >= getLayerLoc()->nxGlobal);
-         assert(resizedHeight >= getLayerLoc()->nyGlobal);
-         assert(resizedWidth == getLayerLoc()->nxGlobal || resizedHeight == getLayerLoc()->nyGlobal);
-      }
-      else if (!strcmp(aspectRatioAdjustment, "pad")) {
-         resizeFactor = xRatio < yRatio ? xRatio : yRatio;
-         // resizeFactor * width should be <= getLayerLoc()->nx; resizeFactor * height should be <= getLayerLoc()->ny,
-         // and one of these relations should be == (up to floating-point roundoff).
-         resizedWidth = (int) nearbyintf(resizeFactor * width);
-         resizedHeight = (int) nearbyintf(resizeFactor * height);
-         assert(resizedWidth <= getLayerLoc()->nxGlobal);
-         assert(resizedHeight <= getLayerLoc()->nyGlobal);
-         assert(resizedWidth == getLayerLoc()->nxGlobal || resizedHeight == getLayerLoc()->nxGlobal);
-      }
-      else {
-         assert(0);
-      }
-   }
-   else {
-      resizedWidth = width;
-      resizedHeight = height;
+   int oldSize = imageLoc.nxGlobal * imageLoc.nyGlobal * imageLoc.nf;
+   int newSize = height * width * numbands;
+
+   if (oldSize != newSize) {
+      delete[] imageData;
+      imageData = new pvadata_t[newSize];
+      imageLoc.nxGlobal = width;
+      imageLoc.nyGlobal = height;
+      imageLoc.nf = numbands;
    }
 
-   imageLoc.nbatch = 1;
-   imageLoc.nx = resizedWidth;
-   imageLoc.ny = resizedHeight;
-   imageLoc.nf = numbands;
-   imageLoc.nbatchGlobal = 1;
-   imageLoc.nxGlobal = resizedWidth;
-   imageLoc.nyGlobal = resizedHeight;
-   imageLoc.kb0 = 0;
-   imageLoc.kx0 = 0;
-   imageLoc.ky0 = 0;
-   memset(&imageLoc.halo, 0, sizeof(PVHalo));
-
-   int dataLeft, dataTop, bufferLeft, bufferTop, localWidth, localHeight;
-   calcLocalBox(parent->columnId(), &dataLeft, &dataTop, &bufferLeft, &bufferTop, &localWidth, &localHeight);
-   imageLeft = dataLeft;
-   imageRight = dataLeft + localWidth;
-   imageTop = dataTop;
-   imageBottom = dataTop + localHeight;
-
-   if (parent->columnId()==0) {
-      int newBufferSize = resizedWidth * resizedHeight * numbands;
-      if (newBufferSize != bufferSize) {
-         free(buffer);
-         bufferSize = newBufferSize;
-         buffer = (pvadata_t *) malloc((size_t) bufferSize * sizeof(pvadata_t));
-         if (buffer==NULL) {
-            fprintf(stderr, "%s \"%s\": unable to allocate buffer for %d values of %zu chars each: %s\n",
-                  getKeyword(), name, bufferSize, sizeof(pvadata_t), strerror(errno));
-            exit(EXIT_FAILURE);
-         }
-      }
-      if (autoResizeFlag) {
-         int const nxExtern = imageLoc.nxGlobal;
-         int const nyExtern = imageLoc.nyGlobal;
-         bicubicinterp(externalBuffer, height, width, numbands, xstride, ystride, bandstride, resizedHeight, resizedWidth, zeroval, oneval);
-      }
-      else {
-         #ifdef PV_USE_OPENMP_THREADS
-         #pragma omp parallel for
-         #endif // PV_USE_OPENMP_THREADS
-         for (int k=0; k<bufferSize; k++) {
-            int x=kxPos(k,width,height,numbands);
-            int y=kyPos(k,width,height,numbands);
-            int f=featureIndex(k,width,height,numbands);
-            int externalIndex = f*bandstride + x*xstride + y*ystride;
-            pixeltype q = externalBuffer[externalIndex];
-            buffer[k] = pixelTypeConvert(q, zeroval, oneval);
-         }
-      }
-
-      // Code duplication from Image::readImage
-      // if normalizeLuminanceFlag == true and normalizeStdDev == true, then force average luminance to be 0, std. dev.=1
-      // if normalizeLuminanceFlag == true and normalizeStdDev == false, then force min=0, max=1.
-      // if normalizeLuminanceFlag == true and the image in buffer is completely flat, force all values to zero
-      bool normalize_standard_dev = normalizeStdDev;
-      if(normalizeLuminanceFlag){
-         if (normalize_standard_dev){
-            double image_sum = 0.0f;
-            double image_sum2 = 0.0f;
-            for (int k=0; k<bufferSize; k++) {
-               image_sum += buffer[k];
-               image_sum2 += buffer[k]*buffer[k];
-            }
-            double image_ave = image_sum / bufferSize;
-            double image_ave2 = image_sum2 / bufferSize;
-            // set mean to zero
-            #ifdef PV_USE_OPENMP_THREADS
-            #pragma omp parallel for
-            #endif // PV_USE_OPENMP_THREADS
-            for (int k=0; k<bufferSize; k++) {
-               buffer[k] -= image_ave;
-            }
-            // set std dev to 1
-            double image_std = sqrt(image_ave2 - image_ave*image_ave);
-            if(image_std == 0){
-               #ifdef PV_USE_OPENMP_THREADS
-               #pragma omp parallel for
-               #endif // PV_USE_OPENMP_THREADS
-               for (int k=0; k<bufferSize; k++) {
-                  buffer[k] = 0.0f;
-               }
-            }
-            else{
-               #ifdef PV_USE_OPENMP_THREADS
-               #pragma omp parallel for
-               #endif // PV_USE_OPENMP_THREADS
-               for (int k=0; k<bufferSize; k++) {
-                  buffer[k] /= image_std;
-               }
-            }
-         }
-         else{
-            float image_max = -FLT_MAX;
-            float image_min = FLT_MAX;
-            for (int k=0; k<bufferSize; k++) {
-               image_max = buffer[k] > image_max ? buffer[k] : image_max;
-               image_min = buffer[k] < image_min ? buffer[k] : image_min;
-            }
-            if (image_max > image_min){
-               float image_stretch = 1.0f / (image_max - image_min);
-               #ifdef PV_USE_OPENMP_THREADS
-               #pragma omp parallel for
-               #endif // PV_USE_OPENMP_THREADS
-               for (int k=0; k<bufferSize; k++) {
-                  buffer[k] -= image_min;
-                  buffer[k] *= image_stretch;
-               }
-            }
-            else{
-               #ifdef PV_USE_OPENMP_THREADS
-               #pragma omp parallel for
-               #endif // PV_USE_OPENMP_THREADS
-               for (int k=0; k<bufferSize; k++) {
-                  buffer[k] = 0.0f;
-               }
-            }
-         }
-      } // normalizeLuminanceFlag
-
-      if( inverseFlag ) {
-         #ifdef PV_USE_OPENMP_THREADS
-         #pragma omp parallel for
-         #endif // PV_USE_OPENMP_THREADS
-         for (int k=0; k<bufferSize; k++) {
-            buffer[k] = 1 - buffer[k];
-         }
-      }
-      // Code duplication from Image::readImage
-
+#ifdef PV_USE_OPENMP_THREADS
+#pragma omp parallel for
+#endif // PV_USE_OPENMP_THREADS
+   for (int k=0; k<newSize; k++) {
+      int x=kxPos(k, imageLoc.nxGlobal, imageLoc.nyGlobal, imageLoc.nf);
+      int y=kyPos(k, imageLoc.nxGlobal, imageLoc.nyGlobal, imageLoc.nf);
+      int f=featureIndex(k, imageLoc.nxGlobal, imageLoc.nyGlobal, imageLoc.nf);
+      int externalIndex = x*xstride + y*ystride + f*bandstride;
+      imageData[k] = pixelTypeConvert(externalBuffer[externalIndex], zeroval, oneval);
    }
-   
+
+   switch (numbands) {
+   case 1:
+   case 2: // fall-through is deliberate
+      imageColorType = COLORTYPE_GRAYSCALE;
+      break;
+   case 3:
+   case 4: // fall-through is deliberate
+      imageColorType = COLORTYPE_RGB; // Only supporting RGB for now.  TODO: add YUV etc.
+      break;
+   default:
+      imageColorType = COLORTYPE_UNRECOGNIZED;
+      break;
+   }
    hasNewImageFlag = true;
 
    return PV_SUCCESS;
@@ -276,267 +118,22 @@ template <typename pixeltype>
 pvadata_t ImageFromMemoryBuffer::pixelTypeConvert(pixeltype q, pixeltype zeroval, pixeltype oneval) {
    return ((pvadata_t) (q-zeroval))/((pvadata_t) (oneval-zeroval));
 }
-
-template <typename pixeltype> int ImageFromMemoryBuffer::bicubicinterp(pixeltype const * bufferIn, int heightIn, int widthIn, int numBands, int xStrideIn, int yStrideIn, int bandStrideIn, int heightOut, int widthOut, pixeltype zeroval, pixeltype oneval) {
-   /* Interpolation using bicubic convolution with a=-1 (following Octave image toolbox's imremap function -- change this?). */
-   float xinterp[widthOut];
-   int xinteger[widthOut];
-   float xfrac[widthOut];
-   float dx = (float) (widthIn-1)/(float) (widthOut-1);
-   for (int kx=0; kx<widthOut; kx++) {
-      float x = dx * (float) kx;
-      xinterp[kx] = x;
-      float xfloor = floorf(x);
-      xinteger[kx] = (int) xfloor;
-      xfrac[kx] = x-xfloor;
-   }
-
-   float yinterp[heightOut];
-   int yinteger[heightOut];
-   float yfrac[heightOut];
-   float dy = (float) (heightIn-1)/(float) (heightOut-1);
-   for (int ky=0; ky<heightOut; ky++) {
-      float y = dy * (float) ky;
-      yinterp[ky] = y;
-      float yfloor = floorf(y);
-      yinteger[ky] = (int) yfloor;
-      yfrac[ky] = y-yfloor;
-   }
-
-   memset(buffer, 0, sizeof(*buffer)*bufferSize);
-   for (int xOff = 2; xOff > -2; xOff--) {
-      for (int yOff = 2; yOff > -2; yOff--) {
-         for (int ky=0; ky<heightOut; ky++) {
-            float ycoeff = bicubic(yfrac[ky]-(float) yOff);
-            int yfetch = yinteger[ky]+yOff;
-            if (yfetch < 0) yfetch = -yfetch;
-            if (yfetch >= heightIn) yfetch = heightIn - (yfetch - heightIn) - 1;
-            for (int kx=0; kx<widthOut; kx++) {
-               float xcoeff = bicubic(xfrac[kx]-(float) xOff);
-               int xfetch = xinteger[kx]+xOff;
-               if (xfetch < 0) xfetch = -xfetch;
-               if (xfetch >= widthIn) xfetch = widthIn - (xfetch - widthIn) - 1;
-               assert(xfetch >= 0 && xfetch < widthIn && yfetch >= 0 && yfetch < heightIn);
-               for (int f=0; f<numBands; f++) {
-                  int fetchIdx = yfetch * yStrideIn + xfetch * xStrideIn + f * bandStrideIn;
-                  pvadata_t p = pixelTypeConvert(bufferIn[fetchIdx], zeroval, oneval);
-                  int outputIdx = kIndex(kx, ky, f, widthOut, heightOut, numBands);
-                  buffer[outputIdx] += xcoeff * ycoeff * p;
-               }
-            }
-         }
-      }
-   }
-   return PV_SUCCESS;
-}
+template pvadata_t ImageFromMemoryBuffer::pixelTypeConvert<unsigned char>(unsigned char q, unsigned char zeroval, unsigned char oneval);
 
 int ImageFromMemoryBuffer::initializeActivity(double time, double dt) {
    return getFrame(time, dt);
 }
 
 int ImageFromMemoryBuffer::updateState(double time, double dt) {
+   assert(hasNewImageFlag); // updateState shouldn't have been called otherwise.
+   hasNewImageFlag = false;
    return getFrame(time, dt);
 }
 
-//Image readImage reads the same thing to every batch
-//This call is here since this is the entry point called from allocate
-//Movie overwrites this function to define how it wants to load into batches
-int ImageFromMemoryBuffer::retrieveData(double timef, double dt)
+int ImageFromMemoryBuffer::retrieveData(double timef, double dt, int batchIndex)
 {
-   int status = PV_SUCCESS;
-   status = copyBuffer();
-   return status;
-}
-
-int ImageFromMemoryBuffer::copyBuffer() {
-   int status = PV_SUCCESS;
-   if (!hasNewImageFlag) { return status; }
-   Communicator * icComm = parent->icCommunicator();
-   if (parent->columnId()==0) {
-      if (buffer == NULL) {
-         fprintf(stderr, "%s \"%s\" error: copyBuffer called without having called setMemoryBuffer.\n",
-               getKeyword(), name);
-         exit(PV_FAILURE); // return PV_FAILURE;
-      }
-      for (int rank=1; rank<icComm->commSize(); rank++) {
-         status = moveBufferToData(rank);
-         assert(status == PV_SUCCESS);
-         MPI_Send(data, getNumExtended(), MPI_FLOAT, rank, 31, icComm->communicator());
-      }
-      status = moveBufferToData(0);
-      assert(status == PV_SUCCESS);
-   }
-   else {
-      MPI_Recv(data, getNumExtended(), MPI_FLOAT, 0, 31, icComm->communicator(), MPI_STATUS_IGNORE);
-   }
-   hasNewImageFlag = false;
-   return status;
-}
-
-int ImageFromMemoryBuffer::moveBufferToData(int rank) {
-   assert(parent->columnId()==0);
-   assert(buffer != NULL);
-
-   int startxdata, startydata, startxbuffer, startybuffer, xsize, ysize;
-   calcLocalBox(rank, &startxdata, &startydata, &startxbuffer, &startybuffer, &xsize, &ysize);
-   PVLayerLoc const * layerLoc = getLayerLoc();
-   PVHalo const * halo = &layerLoc->halo;
-   int fsize = layerLoc->nf;
-   
-   if (fsize != 1 && imageLoc.nf != 1 && fsize != imageLoc.nf) {
-      fprintf(stderr, "%s \"%s\": If nf and the number of bands in the image are both greater than 1, they must be equal.\n", getKeyword(), name);
-      exit(EXIT_FAILURE);
-   }
-
-   // begin by setting entire data buffer to padValue, then load the needed section of the image
-   #ifdef PV_USE_OPENMP_THREADS
-   #pragma omp parallel for
-   #endif // PV_USE_OPENMP_THREADS
-   for (int kExt=0; kExt<getNumExtended(); kExt++) {
-      data[kExt] = padValue;
-   }
-
-   if (fsize == 1 && imageLoc.nf > 1) {
-      // layer has one feature; convert memory buffer to grayscale
-      for (int y=0; y<ysize; y++) {
-         for (int x=0; x<xsize; x++) {
-            int indexdata = kIndex(startxdata+x,startydata+y,0,getLayerLoc()->nx+halo->lt+halo->rt,getLayerLoc()->ny+halo->dn+halo->up,1);
-            int indexbuffer = kIndex(startxdata+x,startydata+y,0,imageLoc.nx,imageLoc.ny,imageLoc.nf);
-            pvdata_t val = (pvadata_t) 0;
-            for (int f=0; f<imageLoc.nf; f++) {
-               val += buffer[indexbuffer+f];
-            }
-            data[indexdata] = val/(pvadata_t) imageLoc.nf;
-         }
-      }
-   }
-   else if (fsize > 1 && imageLoc.nf == 1) {
-      // image is grayscale; replicate over all color bands of layer
-      for (int y=0; y<ysize; y++) {
-         for (int x=0; x<xsize; x++) {
-            for (int f=0; f<fsize; f++) {
-               int indexdata = kIndex(startxdata+x,startydata+y,f,getLayerLoc()->nx+halo->lt+halo->rt,getLayerLoc()->ny+halo->dn+halo->up,getLayerLoc()->nf);
-               int indexbuffer = kIndex(startxdata+x,startydata+y,0,imageLoc.nx,imageLoc.ny,imageLoc.nf);
-               data[indexdata] = buffer[indexbuffer];
-            }
-         }
-      }
-   }
-   else {
-      assert(fsize == imageLoc.nf); // layer and memory buffer have the same number of features
-      for (int y=0; y<ysize; y++) {
-         int linestartdata = kIndex(startxdata,startydata+y,0,getLayerLoc()->nx+halo->lt+halo->rt,getLayerLoc()->ny+halo->dn+halo->up,fsize);
-         int linestartbuffer = kIndex(startxbuffer,startybuffer+y,0,imageLoc.nx,imageLoc.ny,fsize);
-         memcpy(&data[linestartdata], &buffer[linestartbuffer], sizeof(pvadata_t) * xsize * fsize);
-      }
-   }
-   return PV_SUCCESS;
-}
-
-int ImageFromMemoryBuffer::calcLocalBox(int rank, int * dataLeft, int * dataTop, int * imageLeft, int * imageTop, int * width, int * height) {
-   Communicator * icComm = parent->icCommunicator();
-   int column = columnFromRank(rank, icComm->numCommRows(), icComm->numCommColumns());
-   int startxbuffer = getOffsetX(this->offsetAnchor, this->offsets[0]) + column * getLayerLoc()->nx;
-   int startxdata = getLayerLoc()->halo.lt;
-   int row = rowFromRank(rank, icComm->numCommRows(), icComm->numCommColumns());
-   int startybuffer = getOffsetY(this->offsetAnchor, this->offsets[1]) + row * getLayerLoc()->ny;
-   int startydata = getLayerLoc()->halo.up;
-   int xsize = getLayerLoc()->nx;
-   int ysize = getLayerLoc()->ny;
-   int fsize = getLayerLoc()->nf;
-   PVHalo const * halo = &getLayerLoc()->halo;
-   if (useImageBCflag) {
-
-      int moveleft = startxbuffer;
-      if (halo->lt < moveleft) {
-         moveleft = halo->lt;
-      }
-      if (moveleft > 0) {
-         startxbuffer -= moveleft;
-         startxdata -= moveleft;
-         xsize += moveleft;
-      }
-
-      int moveright = imageLoc.nx - (startxbuffer + xsize);
-      if (halo->rt < moveright) {
-         moveright = halo->rt;
-      }
-      if (moveright > 0) {
-         xsize += moveright;
-      }
-
-      int moveup = startybuffer;
-      if (halo->up < moveup) {
-         moveup = halo->up;
-      }
-      if (moveup > 0) {
-         startybuffer -= moveup;
-         startydata -= moveup;
-         ysize += moveup;
-      }
-
-      int movedown = imageLoc.ny - (startybuffer + ysize);
-      if (halo->dn < movedown) {
-         movedown = halo->dn;
-      }
-      if (movedown > 0) {
-         ysize += movedown;
-      }   
-   }
-
-   if (startxbuffer < 0) {
-      int discrepancy = -startxbuffer;
-      startxdata += discrepancy;
-      startxbuffer = 0;
-      xsize -= discrepancy;
-   }
-   if (startxdata < 0) {
-      int discrepancy = -startxdata;
-      startxdata = 0;
-      startxbuffer += discrepancy;
-      xsize -= discrepancy;
-   }
-
-   if (startxbuffer+xsize > imageLoc.nxGlobal) {
-      xsize = imageLoc.nxGlobal - startxbuffer;
-   }
-   if (startxdata+xsize > getLayerLoc()->nx) {
-      xsize = getLayerLoc()->nx - startxdata;
-   }
-
-   if (startybuffer < 0) {
-      int discrepancy = -startybuffer;
-      startydata += discrepancy;
-      startybuffer = 0;
-      ysize -= discrepancy;
-   }
-   if (startydata < 0) {
-      int discrepancy = -startydata;
-      startydata = 0;
-      startybuffer += discrepancy;
-      ysize -= discrepancy;
-   }
-
-   if (startybuffer+ysize > imageLoc.nyGlobal) {
-      ysize = imageLoc.nyGlobal - startybuffer;
-   }
-   if (startydata+ysize > getLayerLoc()->ny) {
-      ysize = getLayerLoc()->ny - startydata;
-   }
-
-   assert(startxbuffer >= 0 && startxbuffer + xsize <= imageLoc.nxGlobal);
-   assert(startxdata >= 0 && startxdata + xsize <= getLayerLoc()->nxGlobal);
-   assert(startybuffer >= 0 && startybuffer + ysize <= imageLoc.nyGlobal);
-   assert(startydata >= 0 && startydata + ysize <= getLayerLoc()->nyGlobal);
-
-   *dataLeft = startxdata;
-   *dataTop = startydata;
-   *imageLeft = startxbuffer;
-   *imageTop = startybuffer;
-   *width = xsize;
-   *height = ysize;
-
-   return PV_SUCCESS;
+   pvAssert(batchIndex==0); // ImageFromMemoryBuffer is not batched.
+   return PV_SUCCESS; // imageData, imageLoc, imageColorType were already set in setMemoryBuffer
 }
 
 double ImageFromMemoryBuffer::getDeltaUpdateTime(){
@@ -549,8 +146,6 @@ int ImageFromMemoryBuffer::outputState(double time, bool last) {
 
 
 ImageFromMemoryBuffer::~ImageFromMemoryBuffer() {
-   free(buffer);
-   free(aspectRatioAdjustment);
 }
 
 BaseObject * createImageFromMemoryBuffer(char const * name, HyPerCol * hc) {

--- a/src/layers/ImageFromMemoryBuffer.hpp
+++ b/src/layers/ImageFromMemoryBuffer.hpp
@@ -70,17 +70,6 @@ public:
     */
    virtual int outputState(double time, bool last=false);
 
-   /**
-    * Returns the factor by which the image was resized when setMemoryBuffer is called:
-    * If autoResizeFlag is true, this factor is the larger of (layer's nx/memory buffer's nx) and (layer's ny/memory buffer's ny).
-    * If autoResizeFlag is false, this factor is always 1.
-    */
-   inline float getResizeFactor() const { return resizeFactor; }
-   inline int getImageLeft() const { return imageLeft; }
-   inline int getImageRight() const { return imageRight; }
-   inline int getImageTop() const { return imageTop; }
-   inline int getImageBottom() const { return imageBottom; }
-
 protected:
    ImageFromMemoryBuffer();
    
@@ -99,98 +88,22 @@ protected:
     * @details ImageFromMemoryBuffer does not read the input from a path.  Instead, call setMemoryBuffer()
     */
    virtual void ioParam_inputPath(enum ParamsIOFlag ioFlag) { return; }
-   
-   /**
-    * @brief autoResizeFlag: resize image before cropping to the layer
-    * @details If set to true, image will be resized to the
-    * smallest size with the same aspect ratio that completely covers the
-    * layer size, and then cropped according to the offsets and offsetAnchor
-    * parameters inherited from BaseInput.
-    */
-   virtual void ioParam_autoResizeFlag(enum ParamsIOFlag ioFlag);
-
-   /**
-    * @brief aspectRatioAdjustment: either "crop" or "pad"
-    * @details If autoResizeFlag is true * and the input buffer's aspect ratio
-    * is different from the layer's, this parameter controls whether to
-    * resize the image so that it completely covers the layer and then crop;
-    * or to resize the image to completely fit inside the layer and then pad.
-    */
-   virtual void ioParam_aspectRatioAdjustment(enum ParamsIOFlag ioFlag);
 
    /**
     * Called by HyPerLayer::setActivity() during setInitialValues stage; calls copyBuffer()
     */
    virtual int initializeActivity(double time, double dt);
-   
-   /**
-    * Copies the contents of the image buffer to the activity buffer.
-    * Under MPI, the image buffer is scattered to the several processes.
-    */
-   int copyBuffer();
-   
-   /**
-    * Under MPI, this function may only be called by the rank-zero process.
-    * Finds the portion of the buffer that corresponds to the process whose rank is the input argument,
-    * and copies it into the data buffer.  It does not call any MPI sends; the calling routine
-    * needs to do so.   (This is the common code for sending to nonroot and root processes)
-    * 
-    */
-   int moveBufferToData(int rank);
 
-   /**
-    * Calculates the dimensions in local extended (n.b. check this) coordinates for the given rank.
-    * of the region occupied by the layer.
-    * Each process calls this method with its own rank to calculate imageLeft, imageRight, etc.
-    * The root process calls it for all ranks to determine what part of the image to scatter to the other processes.
-    */
-   int calcLocalBox(int rank, int * dataLeft, int * dataTop, int * imageLeft, int * imageTop, int * width, int * height);
-
-   int retrieveData(double timef, double dt);
+   int retrieveData(double timef, double dt, int batchIndex);
       
 private:
    int initialize_base();
-   
+
    template <typename pixeltype> pvadata_t pixelTypeConvert(pixeltype q, pixeltype zeroval, pixeltype oneval);
-
-   /**
-    * Used by setMemoryBuffer when autoResizeFlag is set.
-    * Performs band-by-band bicubic interpolation of the input buffer,
-    * placing the result in the buffer member variable.
-    * Inputs:
-    *    bufferIn    A pointer to the beffer containing the image.
-    *                Under MPI, only the root process uses buffer and the root process scatters the image to the other processes.
-    *    heightIn    The height in pixels of the entire image
-    *    widthIn     The width in pixels of the entire image
-    *    numbands    The number of bands in the image: i.e., grayscale=1, RGB=3, etc.
-    *    xStrideIn   The difference between the memory locations, as pointers of type pixeltype, between two pixels adjacent in the x-direction, with the same y-coordinate and band number.
-    *    yStrideIn   The difference between the memory locations, as pointers of type pixeltype, between two pixels adjacent in the y-direction, with the same x-coordinate and band number.
-    *    bandStrideIn The difference between the memory locations, as pointers of type pixeltype, between two pixels from adjacent bands, with the same x- and y-coordinates.
-    *    zeroval     The value that should be converted to 0.0f internally.
-    *    oneval      The value that should be converted to 1.0f internally.  Values other than zeroval and oneval are converted to floats using a linear transformation.
-    */
-   template <typename pixeltype> int bicubicinterp(pixeltype const * bufferIn, int heightIn, int widthIn, int numBands, int xStrideIn, int yStrideIn, int bandStdrideIn, int heightOut, int widthOut, pixeltype zeroval, pixeltype oneval);
-
-   // Bicubic convolution kernel with a=-1
-   inline static pvadata_t bicubic(pvadata_t x) {
-      pvadata_t const absx = fabsf(x); // assumes pvadata_t is float ; ideally should generalize
-      return absx < 1 ? 1 + absx*absx*(-2 + absx) : absx < 2 ? 4 + absx*(-8 + absx*(5-absx)) : 0;
-
-   }
-
 
 // Member variables
 protected:
-   pvadata_t * buffer;
-   int bufferSize;
    bool hasNewImageFlag; // set to true by setMemoryBuffer; cleared to false by initializeActivity();
-   bool autoResizeFlag;
-   char * aspectRatioAdjustment;
-   float resizeFactor;
-   int imageLeft; // image{Left,Right,Top,Bottom} are in local layer coordinates.
-   int imageRight;// They show what part of the local layer is occupied by the image.
-   int imageTop;
-   int imageBottom;
 }; // class ImageFromMemoryBuffer
 
 BaseObject * createImageFromMemoryBuffer(char const * name, HyPerCol * hc);

--- a/src/layers/ImagePvp.hpp
+++ b/src/layers/ImagePvp.hpp
@@ -27,23 +27,21 @@ protected:
     * @}
     */
 
-
-   virtual int retrieveData(double timef, double dt);
+   virtual int getFrame(double timef, double dt);
+   virtual int retrieveData(double timef, double dt, int batchIndex);
+   virtual int readPvp(const char * filename, int frameNumber);
+   int readSparseBinaryActivityFrame(int numParams, int * params, PV_Stream * pvstream, int frameNumber);
+   int readSparseValuesActivityFrame(int numParams, int * params, PV_Stream * pvstream, int frameNumber);
+   int readNonspikingActivityFrame(int numParams, int * params, PV_Stream * pvstream, int frameNumber);
    virtual int scatterImageFilePVP(const char * filename, int xOffset, int yOffset, PV::Communicator * comm, const PVLayerLoc * loc, float * buf, int frameNumber);
    ImagePvp();
    virtual int ioParamsFillGroup(enum ParamsIOFlag ioFlag);
-   //frameIndex is a linear index into both batches and frames
-   int readPvp(const char * filename, int frameIdx, int destBatchIdx, int offsetX, int offsetY, const char* anchor);
 
-   //char * pvpFilename;       // path to file if a file exists
    long * frameStartBuf;
    int * countBuf;
-   //Current pvp file time
-   float pvpFileTime;
+   float pvpFileTime; //Current pvp file time
    long pvpFrameIdx;
-   //long pvpBatchIdx;
    int fileNumFrames; //Number of frames
-   //int fileNumBatches;
 public:
    ImagePvp(const char * name, HyPerCol * hc);
    virtual ~ImagePvp();
@@ -52,7 +50,6 @@ public:
 
    float getPvpFileTime(){ return pvpFileTime;};
    virtual long getPvpFrameIdx() { return pvpFrameIdx; }
-   //virtual long getPvpBatchIdx() { return pvpBatchIdx; }
    virtual double getDeltaUpdateTime();
 private:
    int initialize_base();

--- a/src/layers/Movie.hpp
+++ b/src/layers/Movie.hpp
@@ -24,7 +24,6 @@ public:
 
    virtual int allocateDataStructures();
 
-   virtual pvdata_t * getImageBuffer();
    virtual PVLayerLoc getImageLoc();
 
    virtual int checkpointRead(const char * cpDir, double * timef);
@@ -34,7 +33,6 @@ public:
    virtual double calcTimeScale(int batchIdx);
    virtual int updateState(double time, double dt);
    virtual bool updateImage(double time, double dt);
-   int  randomFrame();
    const char* getFilename(int batchIdx){return framePath[batchIdx];}
    const char* getBatchMethod(){return batchMethod;}
 
@@ -111,8 +109,7 @@ protected:
    virtual int readStateFromCheckpoint(const char * cpDir, double * timeptr);
    virtual int readFrameNumStateFromCheckpoint(const char * cpDir);
 
-   virtual int retrieveData(double timef, double dt);
-   //bool readPvpFile;
+   virtual int retrieveData(double timef, double dt, int batchIdx);
    const char * getNextFileName(int n_skip, int batchIdx);
    int updateFrameNum(int n_skip);
    PV_Stream * timestampFile;
@@ -127,11 +124,6 @@ private:
    bool resetToStartOnLoop;
 
    double displayPeriod;   // length of time a frame is displayed
-
-#ifdef OBSOLETE // randomMovie was commented out of Movie.cpp on Jul 22, 2015.
-   int randomMovie;       // these are used for performing a reverse correlation analysis
-   float randomMovieProb;
-#endif // OBSOLETE // randomMovie was commented out of Movie.cpp on Jul 22, 2015.
 
    bool echoFramePathnameFlag; // if true, echo the frame pathname to stdout
 
@@ -157,7 +149,6 @@ private:
 
    bool flipOnTimescaleError;
    long * batchPos;
-   bool initFlag;
 #else // PV_USE_GDAL
 public:
    Movie(char const * name, HyPerCol * hc);

--- a/src/layers/MoviePvp.cpp
+++ b/src/layers/MoviePvp.cpp
@@ -13,7 +13,6 @@
 #include <string.h>
 #include <time.h>
 #include <errno.h>
-//#include <iostream>
 
 namespace PV {
 
@@ -35,21 +34,13 @@ int MoviePvp::initialize_base() {
    numStartFrame = 0;
    numSkipFrame = 0;
    echoFramePathnameFlag = false;
-   //filenamestream = NULL;
    displayPeriod = DISPLAY_PERIOD;
-   //readPvpFile = false;
-   //fileOfFileNames = NULL;
    frameNumbers = NULL;
-   //fileNumFrames = 0;
-   //fileNumBatches = 0;
    writeFrameToTimestamp = true;
    timestampFile = NULL;
    flipOnTimescaleError = true;
    resetToStartOnLoop = false;
-   initFlag = false;
    batchMethod = NULL;
-   //updateThisTimestep = false;
-   // newImageFlag = false;
    return PV_SUCCESS;
 }
 
@@ -61,23 +52,7 @@ int MoviePvp::readStateFromCheckpoint(const char * cpDir, double * timeptr) {
 
 int MoviePvp::readFrameNumStateFromCheckpoint(const char * cpDir) {
    int status = PV_SUCCESS;
-   
    parent->readArrayFromFile(cpDir, getName(), "FrameNumState", frameNumbers, parent->getNBatch());
-
-   //if (!readPvpFile) {
-   //   int startFrame = frameNumber;
-   //   if (parent->columnId()==0) {
-   //      PV_fseek(filenamestream, 0L, SEEK_SET);
-   //      frameNumber = 0;
-   //   }
-   //   if (filename != NULL) free(filename);
-   //   filename = strdup(getNextFileName(startFrame)); // getNextFileName() will increment frameNumber by startFrame;
-   //   if (parent->columnId()==0) assert(frameNumber==startFrame);
-   //   if (parent->columnId()==0) {
-   //      printf("%s \"%s\" checkpointRead set frameNumber to %d and filename to \"%s\"\n",
-   //            getKeyword(), name, frameNumber, filename);
-   //   }
-   //}
    return status;
 }
 
@@ -129,42 +104,6 @@ int MoviePvp::initialize(const char * name, HyPerCol * hc) {
    //Update on first timestep
    setNextUpdateTime(parent->simulationTime() + hc->getDeltaTime());
 
-   //PVParams * params = hc->parameters();
-
-   //assert(!params->presentAndNotBeenRead(name, "randomMovie")); // randomMovie should have been set in ioParams
-   //if (randomMovie) return status; // Nothing else to be done until data buffer is allocated, in allocateDataStructures
-
-
-   ////If not pvp file, open fileOfFileNames 
-   //assert(!params->presentAndNotBeenRead(name, "readPvpFile")); // readPvpFile should have been set in ioParams
-   //if( getParent()->icCommunicator()->commRank()==0 && !readPvpFile) {
-   //   filenamestream = PV_fopen(fileOfFileNames, "r", false/*verifyWrites*/);
-   //   if( filenamestream == NULL ) {
-   //      fprintf(stderr, "Movie::initialize error opening \"%s\": %s\n", fileOfFileNames, strerror(errno));
-   //      abort();
-   //   }
-   //}
-
-   //if (startFrameIndex <= 1){
-   //   frameNumber = 0;
-   //}
-   //else{
-   //   frameNumber = startFrameIndex - 1;
-   //}
-   ////Set filename as param
-   //Grab number of frames from header
-   
-   //PV_Stream * pvstream = NULL;
-   //if (getParent()->icCommunicator()->commRank()==0) {
-   //   pvstream = PV::PV_fopen(inputPath, "rb", false/*verifyWrites*/);
-   //}
-   //int numParams = NUM_PAR_BYTE_PARAMS;
-   //int params[numParams];
-   //pvp_read_header(pvstream, getParent()->icCommunicator(), params, &numParams);
-   //PV::PV_fclose(pvstream); pvstream = NULL;
-   //fileNumFrames = params[INDEX_NBANDS]; 
-   //fileNumBatches = params[INDEX_NBATCH];
-
    // set output path for movie frames
    if(writeImages){
       status = parent->ensureDirExists(movieOutputPath);
@@ -201,10 +140,6 @@ int MoviePvp::initialize(const char * name, HyPerCol * hc) {
 int MoviePvp::ioParamsFillGroup(enum ParamsIOFlag ioFlag) {
    int status = ImagePvp::ioParamsFillGroup(ioFlag);
    ioParam_displayPeriod(ioFlag);
-   //ioParam_randomMovie(ioFlag);
-   //ioParam_randomMovieProb(ioFlag);
-   //ioParam_readPvpFile(ioFlag);
-   //ioParam_echoFramePathnameFlag(ioFlag);
    ioParam_batchMethod(ioFlag);
    ioParam_start_frame_index(ioFlag);
    ioParam_skip_frame_index(ioFlag);
@@ -242,27 +177,6 @@ void MoviePvp::ioParam_batchMethod(enum ParamsIOFlag ioFlag){
    }
 }
 
-//void MoviePvp::ioParam_randomMovie(enum ParamsIOFlag ioFlag) {
-//   parent->ioParamValue(ioFlag, name, "randomMovie", &randomMovie, 0/*default value*/);
-//}
-//
-//void MoviePvp::ioParam_randomMovieProb(enum ParamsIOFlag ioFlag) {
-//   assert(!parent->parameters()->presentAndNotBeenRead(name, "randomMovie"));
-//   if (randomMovie) {
-//      parent->ioParamValue(ioFlag, name, "randomMovieProb", &randomMovieProb, 0.05f);
-//   }
-//}
-
-//void MoviePvp::ioParam_echoFramePathnameFlag(enum ParamsIOFlag ioFlag) {
-//   assert(!parent->parameters()->presentAndNotBeenRead(name, "randomMovie"));
-//   if (!randomMovie) {
-//      assert(!parent->parameters()->presentAndNotBeenRead(name, "readPvpFile"));
-//      if (!readPvpFile) {
-//         parent->ioParamValue(ioFlag, name, "echoFramePathnameFlag", &echoFramePathnameFlag, false/*default value*/);
-//      }
-//   }
-//}
-
 void MoviePvp::ioParam_start_frame_index(enum ParamsIOFlag ioFlag) {
    this->getParent()->ioParamArray(ioFlag, this->getName(), "start_frame_index", &paramsStartFrameIndex, &numStartFrame);
 }
@@ -288,14 +202,6 @@ void MoviePvp::ioParam_resetToStartOnLoop(enum ParamsIOFlag ioFlag) {
 
 MoviePvp::~MoviePvp()
 {
-   //if (imageData != NULL) {
-   //   delete imageData;
-   //   imageData = NULL;
-   //}
-   //if (getParent()->icCommunicator()->commRank()==0 && filenamestream != NULL && filenamestream->isfile) {
-   //   PV_fclose(filenamestream);
-   //}
-   //free(fileOfFileNames); fileOfFileNames = NULL;
    if (getParent()->icCommunicator()->commRank()==0 && timestampFile != NULL && timestampFile->isfile) {
        PV_fclose(timestampFile);
    }
@@ -426,16 +332,9 @@ int MoviePvp::allocateDataStructures() {
    return status;
 }
 
-pvdata_t * MoviePvp::getImageBuffer()
-{
-   //   return imageData;
-   return data;
-}
-
 PVLayerLoc MoviePvp::getImageLoc()
 {
    return imageLoc;
-   //   return clayer->loc;
    // imageLoc contains size information of the image file being loaded;
    // clayer->loc contains size information of the layer, which may
    // be smaller than the whole image.  To get information on the layer, use
@@ -443,13 +342,10 @@ PVLayerLoc MoviePvp::getImageLoc()
 }
 
 double MoviePvp::getDeltaUpdateTime(){
-   //If jitter or randomMovie, update every timestep
+   //If jittering, update every timestep
    if( jitterFlag ){
       return parent->getDeltaTime();
    }
-   //if(randomMovie){
-   //   return parent->getDeltaTime();
-   //}
    return displayPeriod;
 }
 
@@ -474,26 +370,17 @@ int MoviePvp::updateState(double time, double dt)
 //Image readImage reads the same thing to every batch
 //This call is here since this is the entry point called from allocate
 //Movie overwrites this function to define how it wants to load into batches
-int MoviePvp::retrieveData(double timef, double dt)
+int MoviePvp::retrieveData(double timef, double dt, int batchIndex)
 {
-   bool init = false;
    //TODO this function needs to decide how to read into batches
    int status = PV_SUCCESS;
-   for(int b = 0; b < parent->getNBatch(); b++){
-      if(!initFlag){
-         init = true;
-      }
-      else{
-         updateFrameNum(skipFrameIndex[b], b);
-      }
+   if(timef>parent->getStartTime()){
+      updateFrameNum(skipFrameIndex[batchIndex], batchIndex);
+   }
 
-      //Using member varibles here
-      status = readPvp(inputPath, frameNumbers[b], b, offsets[0], offsets[1], offsetAnchor);
-      assert(status == PV_SUCCESS);
-   }
-   if(init){
-      initFlag = true;
-   }
+   //Using member varibles here
+   status = readPvp(inputPath, frameNumbers[batchIndex]);
+   assert(status == PV_SUCCESS);
    return status;
 }
 
@@ -512,39 +399,8 @@ int MoviePvp::retrieveData(double timef, double dt)
  */
 bool MoviePvp::updateImage(double time, double dt)
 {
-   //if( jitterFlag ) {
-   //   jitter();
-   //} // jitterFlag
-
    InterColComm * icComm = getParent()->icCommunicator();
 
-   //if(randomMovie){
-   //   randomFrame();
-   //   //Moved to updateStateWrapper
-   //   //lastUpdateTime = time;
-   //} else {
-      //TODO: Fix movie layer to take with batches. This is commented out for compile
-      //if(!flipOnTimescaleError && (parent->getTimeScale() > 0 && parent->getTimeScale() < parent->getTimeScaleMin())){
-      //   if (parent->icCommunicator()->commRank()==0) {
-      //      std::cout << "timeScale of " << parent->getTimeScale() << " is less than timeScaleMin of " << parent->getTimeScaleMin() << ", Movie is keeping the same frame\n";
-      //   }
-      //}
-      //else{
-         //if(!readPvpFile){
-         //   //Only do this if it's not the first update timestep
-         //   //The timestep number is (time - startTime)/(width of timestep), with allowance for roundoff.
-         //   //But if we're using adaptive timesteps, the dt passed as a function argument is not the correct (width of timestep).  
-         //   if(fabs(time - (parent->getStartTime() + parent->getDeltaTime())) > (parent->getDeltaTime()/2)){
-         //      //If the error is too high, keep the same frame
-         //      if (filename != NULL) free(filename);
-         //      filename = strdup(getNextFileName(skipFrameIndex));
-         //   }
-         //   assert(filename != NULL);
-         //}
-         //else{
-            //Only do this if it's not the first update timestep
-            //The timestep number is (time - startTime)/(width of timestep), with allowance for roundoff.
-            //But if we're using adaptive timesteps, the dt passed as a function argument is not the correct (width of timestep).  
             if(fabs(time - (parent->getStartTime() + parent->getDeltaTime())) > (parent->getDeltaTime()/2)){
                int status = getFrame(time, dt);
                if( status != PV_SUCCESS ) {
@@ -552,18 +408,9 @@ bool MoviePvp::updateImage(double time, double dt)
                   abort();
                }
             }
-         //}
-      //}
-      
-      
-
       if(writePosition && icComm->commRank()==0){
          fprintf(fp_pos->fp,"%f %s: \n",time,inputPath);
       }
-      //nextDisplayTime removed, now using nextUpdateTime in HyPerLayer
-      //while (time >= nextDisplayTime) {
-      //   nextDisplayTime += displayPeriod;
-      //}
       //Set frame number (member variable in Image)
       //Write to timestamp file here when updated
       if( icComm->commRank()==0 ) {
@@ -604,47 +451,6 @@ int MoviePvp::outputState(double timed, bool last)
 
    return status;
 }
-
-//int MoviePvp::copyReducedImagePortion()
-//{
-//   const PVLayerLoc * loc = getLayerLoc();
-//
-//   const int nx = loc->nx;
-//   const int ny = loc->ny;
-//
-//   const int nx0 = imageLoc.nx;
-//   const int ny0 = imageLoc.ny;
-//
-//   assert(nx0 <= nx);
-//   assert(ny0 <= ny);
-//
-//   const int i0 = nx/2 - nx0/2;
-//   const int j0 = ny/2 - ny0/2;
-//
-//   int ii = 0;
-//   for (int j = j0; j < j0+ny0; j++) {
-//      for (int i = i0; i < i0+nx0; i++) {
-//         imageData[ii++] = data[i+nx*j];
-//      }
-//   }
-//
-//   return 0;
-//}
-
-///**
-// * This creates a random image patch (frame) that is used to perform a reverse correlation analysis
-// * as the input signal propagates up the visual system's hierarchy.
-// * NOTE: Check Image::toGrayScale() method which was the inspiration for this routine
-// */
-//int MoviePvp::randomFrame()
-//{
-//   assert(randomMovie); // randomMovieProb was set only if randomMovie is true
-//   for (int kex = 0; kex < clayer->numExtended; kex++) {
-//      double p = randState->uniformRandom();
-//      data[kex] = (p < randomMovieProb) ? 1: 0;
-//   }
-//   return 0;
-//}
 
 /**
  * A function only called if readPvpFile is set

--- a/src/layers/MoviePvp.hpp
+++ b/src/layers/MoviePvp.hpp
@@ -20,33 +20,23 @@ public:
 
    virtual int allocateDataStructures();
 
-   virtual pvdata_t * getImageBuffer();
    virtual PVLayerLoc getImageLoc();
 
    virtual int checkpointRead(const char * cpDir, double * timef);
    virtual int checkpointWrite(const char * cpDir);
    virtual int outputState(double time, bool last=false);
-   //virtual bool needUpdate(double time, double dt);
    virtual double getDeltaUpdateTime();
    virtual double calcTimeScale(int batchIdx);
-   //virtual int updateStateWrapper(double time, double dt);
    virtual int updateState(double time, double dt);
    virtual bool updateImage(double time, double dt);
-   // bool        getNewImageFlag();
    const char * getCurrentImage();
    const char* getBatchMethod(){return batchMethod;}
  
-   //Overwriting ImagePvp's getPvpFrameIdx
-   //virtual long getPvpFrameIdx() { return frameNumber; }
-
-
-   //int  randomFrame();
-
 protected:
    MoviePvp();
    int initialize(const char * name, HyPerCol * hc);
    virtual int ioParamsFillGroup(enum ParamsIOFlag ioFlag);
-   virtual int retrieveData(double timef, double dt);
+   virtual int retrieveData(double timef, double dt, int batchIndex);
 
    /**
     * List of parameters needed from the MoviePvp class
@@ -114,8 +104,6 @@ protected:
    virtual int readStateFromCheckpoint(const char * cpDir, double * timeptr);
    virtual int readFrameNumStateFromCheckpoint(const char * cpDir);
 
-   //bool readPvpFile;
-   //const char * getNextFileName(int n_skip);
    int updateFrameNum(int n_skip, int batchIdx);
    PV_Stream * timestampFile;
 
@@ -124,18 +112,12 @@ private:
    int initialize_base();
    int copyReducedImagePortion();
    int updateFrameNum(int batchIdx);
-   //const char * advanceFileName();
 
    bool resetToStartOnLoop;
 
    double displayPeriod;   // length of time a frame is displayed
-   //double nextDisplayTime; // time of next frame; now handled by HyPerLayer nextUpdateTime
-
-   //int randomMovie;       // these are used for performing a reverse correlation analysis
-   //float randomMovieProb;
 
    bool echoFramePathnameFlag; // if true, echo the frame pathname to stdout
-   // bool newImageFlag; // true when a new image was presented this timestep;
 
    int* startFrameIndex;
    int* skipFrameIndex;
@@ -152,7 +134,6 @@ private:
    bool writeFrameToTimestamp;
 
    bool flipOnTimescaleError;
-   bool initFlag;
    char* batchMethod;
 }; // class MoviePvp
 

--- a/src/layers/Patterns.cpp
+++ b/src/layers/Patterns.cpp
@@ -930,8 +930,9 @@ int Patterns::updateState(double timef, double dt) {
 //Image readImage reads the same thing to every batch
 //This call is here since this is the entry point called from allocate
 //Movie overwrites this function to define how it wants to load into batches
-int Patterns::retrieveData(double timef, double dt)
+int Patterns::retrieveData(double timef, double dt, int batchIndex)
 {
+   assert(batchIndex==0); // TODO incorporate batches
    int status = PV_SUCCESS;
    status = updatePattern(timef);
    return status;

--- a/src/layers/Patterns.hpp
+++ b/src/layers/Patterns.hpp
@@ -121,7 +121,7 @@ protected:
    virtual int readStateFromCheckpoint(const char * cpDir, double * timeptr);
    virtual int readPatternStateFromCheckpoint(const char * cpDir);
 
-   virtual int retrieveData(double timef, double dt);
+   virtual int retrieveData(double timef, double dt, int batchIndex);
 
    PatternType type;
    char * typeString;

--- a/src/utils/PVLog.hpp
+++ b/src/utils/PVLog.hpp
@@ -200,15 +200,17 @@ typedef _Log<wchar_t, LogStackTraceType> WStackTrace;
  *
  * Provides a standardized method for logging error, debug and information messages.
  *
- * logDebug(), logError() and logInfo()q work the same as printf().
+ * pvLogDebug(), pvLogError() and pvLogInfo() take printf-style format control string and arguments.
  *
- * logDebug() and logError() will prepend DEBUG: and ERROR: plus the file name and line number
- * of the call.
+ * pvLogDebug() and pvLogError() will prepend DEBUG: and ERROR: plus the file name and line number
+ * of the call, and append a newline.
  *
- * logInfo() works just like printf. Nothing is prepended.
+ * pvLogInfo() appends a newline. Nothing is prepended.
  *
- * logDebug() calls are compiled out in a Release build. logError() and logInfo() calls are not
+ * pvLogDebug() calls are compiled out in a Release build. pvLogError() and pvLogInfo() calls are not
  * compiled out.
+ *
+ * pvLogDebug() and pvLogInfo() send output to stdout.  pvLogError sends output to stderr.
  *
  * These macros provide an opportunity to handle sending debug, error and info messages to other MPI ranks
  */

--- a/tests/ImageSystemTest/input/ImageFileIO.params
+++ b/tests/ImageSystemTest/input/ImageFileIO.params
@@ -36,7 +36,7 @@ HyPerCol "column" = {
 ImageTestLayer "input" = {
     restart = 0;  // make only a certain layer restart
     nxScale = 1;  // this must be 2^n, n = ...,-2,-1,0,1,2,... 
-    nyScale = 1;  // the scale is to decide how much area will be used as input. For exampel, nx * nxScale = 32. The size of input
+    nyScale = 1;  // the scale is to decide how much area will be used as input. For example, nx * nxScale = 32. The size of input
     	      	  // cannot be larger than the input image size.
     inputPath = "input/data/ImageFileIO_input.png";
     nf = 3; //number of features. For a grey image, it's 1. For a color image, it could be either 1 or 3.

--- a/tests/ImageSystemTest/input/ImagePvpFileIO.params
+++ b/tests/ImageSystemTest/input/ImagePvpFileIO.params
@@ -37,7 +37,7 @@ HyPerCol "column" = {
 ImagePvpTestLayer "input0" = {
     restart = 0;  // make only a certain layer restart
     nxScale = 1;  // this must be 2^n, n = ...,-2,-1,0,1,2,... 
-    nyScale = 1;  // the scale is to decide how much area will be used as input. For exampel, nx * nxScale = 32. The size of input
+    nyScale = 1;  // the scale is to decide how much area will be used as input. For example, nx * nxScale = 32. The size of input
     	      	  // cannot be larger than the input image size.
     inputPath = "input/data/PvpFileIO_input.pvp";
     nf = 3; //number of features. For a grey image, it's 1. For a color image, it could be either 1 or 3.

--- a/tests/ImageSystemTest/input/ImagePvpFileIOSparse.params
+++ b/tests/ImageSystemTest/input/ImagePvpFileIOSparse.params
@@ -37,7 +37,7 @@ HyPerCol "column" = {
 ImagePvpTestLayer "input0" = {
     restart = 0;  // make only a certain layer restart
     nxScale = 1;  // this must be 2^n, n = ...,-2,-1,0,1,2,... 
-    nyScale = 1;  // the scale is to decide how much area will be used as input. For exampel, nx * nxScale = 32. The size of input
+    nyScale = 1;  // the scale is to decide how much area will be used as input. For example, nx * nxScale = 32. The size of input
     	      	  // cannot be larger than the input image size.
     inputPath = "input/data/PvpFileIOSparse_input.pvp";
     nf = 3; //number of features. For a grey image, it's 1. For a color image, it could be either 1 or 3.

--- a/tests/ImageSystemTest/input/MovieFileIO.params
+++ b/tests/ImageSystemTest/input/MovieFileIO.params
@@ -37,7 +37,7 @@ HyPerCol "column" = {
 // this is a input layer
 MovieTestLayer "inputByImage" = {
     nxScale = 1;  // this must be 2^n, n = ...,-2,-1,0,1,2,... 
-    nyScale = 1;  // the scale is to decide how much area will be used as input. For exampel, nx * nxScale = 32. The size of input
+    nyScale = 1;  // the scale is to decide how much area will be used as input. For example, nx * nxScale = 32. The size of input
     	      	  // cannot be larger than the input image size.
     inputPath = "input/data/MovieFileIO_input.txt";
     nf = 3; //number of features. For a grey image, it's 1. For a color image, it could be either 1 or 3.
@@ -61,7 +61,7 @@ MovieTestLayer "inputByImage" = {
 
 MovieTestLayer "inputByMovie" = {
     nxScale = 1;  // this must be 2^n, n = ...,-2,-1,0,1,2,... 
-    nyScale = 1;  // the scale is to decide how much area will be used as input. For exampel, nx * nxScale = 32. The size of input
+    nyScale = 1;  // the scale is to decide how much area will be used as input. For example, nx * nxScale = 32. The size of input
     	      	  // cannot be larger than the input image size.
     inputPath = "input/data/MovieFileIO_input.txt";
     nf = 3; //number of features. For a grey image, it's 1. For a color image, it could be either 1 or 3.

--- a/tests/ImageSystemTest/input/MoviePvpFileIO.params
+++ b/tests/ImageSystemTest/input/MoviePvpFileIO.params
@@ -39,7 +39,7 @@ HyPerCol "column" = {
 MoviePvpTestLayer "inputByImage" = {
     restart = 0;  // make only a certain layer restart
     nxScale = 1;  // this must be 2^n, n = ...,-2,-1,0,1,2,... 
-    nyScale = 1;  // the scale is to decide how much area will be used as input. For exampel, nx * nxScale = 32. The size of input
+    nyScale = 1;  // the scale is to decide how much area will be used as input. For example, nx * nxScale = 32. The size of input
     	      	  // cannot be larger than the input image size.
     inputPath = "input/data/PvpFileIO_input.pvp";
     nf = 3; //number of features. For a grey image, it's 1. For a color image, it could be either 1 or 3.
@@ -65,7 +65,7 @@ MoviePvpTestLayer "inputByImage" = {
 MoviePvpTestLayer "inputByMovie" = {
     restart = 0;  // make only a certain layer restart
     nxScale = 1;  // this must be 2^n, n = ...,-2,-1,0,1,2,... 
-    nyScale = 1;  // the scale is to decide how much area will be used as input. For exampel, nx * nxScale = 32. The size of input
+    nyScale = 1;  // the scale is to decide how much area will be used as input. For example, nx * nxScale = 32. The size of input
     	      	  // cannot be larger than the input image size.
     inputPath = "input/data/PvpFileIO_input.pvp";
     nf = 3; //number of features. For a grey image, it's 1. For a color image, it could be either 1 or 3.


### PR DESCRIPTION
This pull request overhauls the BaseInput hierarchy so that the resizing capabilities of ImageFromMemoryBuffer are available in all movie and image classes.  Note that if an Image or Movie layer uses resizing, the resizing is now done using BaseInput methods after loading from the file, and not GDAL functions while loading from the file.  It might be a good idea to have a flag to allow Image to resize from within GDAL, if desired, but this has not been added yet.

If autoResizeFlag is set to true, the BaseInput reads a new parameter, "interpolationMethod", that can be set to either "bicubic" or "nearestNeighbor" (the string matching in this case is case-insensitive), with a default of bicubic.

The pull request passes all the system tests; however, jittering and Patterns are not tested in any system test.
