### PR TITLE
Does tilde expansion in more places in the code.

### DIFF
--- a/src/columns/HyPerCol.hpp
+++ b/src/columns/HyPerCol.hpp
@@ -385,7 +385,7 @@ private:
    virtual void ioParam_defaultInitializeFromCheckpointFlag(enum ParamsIOFlag ioFlag);
 
    /**
-    * @brief checkpointRead: Depreciated. Use <-c foo/Checkpoint100>
+    * @brief checkpointRead is obsolete.  Instead use -c foo/Checkpoint100 on the command line.
     */
    virtual void ioParam_checkpointRead(enum ParamsIOFlag ioFlag);
 

--- a/src/columns/PV_Init.cpp
+++ b/src/columns/PV_Init.cpp
@@ -20,12 +20,12 @@ PV_Init::PV_Init(int* argc, char ** argv[], bool allowUnrecognizedArguments){
    initSignalHandler();
    commInit(argc, argv);
    initMaxThreads();
-   params = NULL;
-   icComm = NULL;
+   params = nullptr;
+   icComm = nullptr;
    arguments = new PV_Arguments(*argc, *argv, allowUnrecognizedArguments);
    factory = new Factory();
    buildandrunDeprecationWarning = true;
-   initialize();
+   initialize(); // must follow initialization of arguments data member.
 }
 
 PV_Init::~PV_Init(){
@@ -163,6 +163,10 @@ int PV_Init::setMPIConfiguration(int rows, int columns, int batchWidth) {
    if (batchWidth >= 0) { arguments->setBatchWidth(batchWidth); }
    initialize();
    return PV_SUCCESS;
+}
+
+int PV_Init::resetState() {
+   return arguments->resetState();
 }
 
 int PV_Init::registerKeyword(char const * keyword, ObjectCreateFn creator) {

--- a/src/columns/PV_Init.hpp
+++ b/src/columns/PV_Init.hpp
@@ -274,7 +274,7 @@ public:
     * for getArgs or getArgsCopy are no longer valid.
     * Always returns PV_SUCCESS.  If the routine fails, it exits with an error.
     */
-   int resetState() { arguments->resetState(); return PV_SUCCESS; }
+   int resetState();
 
    InterColComm * getComm(){return icComm;}
 

--- a/src/io/PVParams.cpp
+++ b/src/io/PVParams.cpp
@@ -941,7 +941,7 @@ int PVParams::parseFile(const char * filename) {
          pvError().printf("PVParams::parseFile: filename was null.\n");
       }
       struct stat filestatus;
-      if( stat(filename, &filestatus) ) {
+      if( PV_stat(filename, &filestatus) ) {
          pvError().printf("PVParams::parseFile ERROR getting status of file \"%s\": %s\n", filename, strerror(errno));
       }
       if( filestatus.st_mode & S_IFDIR ) {
@@ -2080,7 +2080,6 @@ void PVParams::action_parameter_filename_def(const char * id, const char * strin
    ParameterString * pstr = NULL;
    char * filename = NULL;
    if (param_value && param_value[0]=='~') {
-      filename = expandLeadingTilde(param_value);
       pstr = new ParameterString(id, filename);
       free(filename);
    }
@@ -2116,7 +2115,6 @@ void PVParams::action_parameter_filename_def_overwrite(const char * id, const ch
    assert(param_value);
    char * filename = NULL;
    if (param_value && param_value[0]=='~') {
-      filename = expandLeadingTilde(param_value);
       currParam->setValue(filename);
    }
    else {
@@ -2271,11 +2269,6 @@ void PVParams::action_parameter_sweep_values_filename(const char * stringval)
    }
    char * filename = stripQuotationMarks(stringval);
    assert(filename);
-   if (filename && filename[0]=='~') {
-      char * newfilename = expandLeadingTilde(filename);
-      free(filename);
-      filename = newfilename;
-   }
    activeParamSweep->pushStringValue(filename);
    free(filename);
 }
@@ -2290,11 +2283,6 @@ void PVParams::action_batch_sweep_values_filename(const char * stringval)
    }
    char * filename = stripQuotationMarks(stringval);
    assert(filename);
-   if (filename && filename[0]=='~') {
-      char * newfilename = expandLeadingTilde(filename);
-      free(filename);
-      filename = newfilename;
-   }
    activeBatchSweep->pushStringValue(filename);
    free(filename);
 }

--- a/src/io/imageio.cpp
+++ b/src/io/imageio.cpp
@@ -228,10 +228,11 @@ int gatherImageFilePVP(const char * filename,
 #ifdef PV_USE_GDAL
 GDALDataset * PV_GDALOpen(const char * filename)
 {
+   char * path = PV::expandLeadingTilde(filename);
    int gdalopencounts = 0;
    GDALDataset * dataset = NULL;
    while (dataset == NULL) {
-      dataset = (GDALDataset *) GDALOpen(filename, GA_ReadOnly);
+      dataset = (GDALDataset *) GDALOpen(path, GA_ReadOnly);
       if (dataset != NULL) break;
       gdalopencounts++;
       if (gdalopencounts < MAX_FILESYSTEMCALL_TRIES) {
@@ -245,6 +246,7 @@ GDALDataset * PV_GDALOpen(const char * filename)
       pvErrorNoExit().printf("getImageInfoGDAL unable to open \"%s\": %s\n", filename,
             strerror(errno));
    }
+   free(path);
    return dataset;
 }
 

--- a/src/layers/Movie.cpp
+++ b/src/layers/Movie.cpp
@@ -639,12 +639,6 @@ const char * Movie::advanceFileName(int batchIdx) {
       // assert(inputfile && strlen(inputfile)>(size_t) 0);
       // current version of clang generates a warning since inputfile is a member variable declared as an array and therefore always non-null.
       // Keeping the line in case inputfile is changed to be malloc'd instead of declared as an array.
-      char * expandedpath = expandLeadingTilde(inputfile);
-      if (strlen(expandedpath)>=PV_PATH_MAX) {
-         pvError().printf("Movie \"%s\": input line \"%s\" from imageListPath is too long.\n", name, expandedpath);
-      }
-      strncpy(inputfile, expandedpath, PV_PATH_MAX);
-      free(expandedpath);
    }
    //Save batch position
    batchPos[batchIdx] = getPV_StreamFilepos(filenamestream);

--- a/src/utils/PVLog.cpp
+++ b/src/utils/PVLog.cpp
@@ -4,6 +4,7 @@
 #include <libgen.h>
 #include <fstream>
 #include "utils/PVLog.hpp"
+#include "io/io.hpp" // expandLeadingTilde
 
 namespace PV {
 
@@ -19,8 +20,15 @@ public:
          delete mStream;
       }
       if (path) {
-         mStream = new std::basic_ofstream<T>(path, mode);
+         char * realPath = expandLeadingTilde(path);
+         if (realPath==nullptr) {
+            // Error message has to go to cerr and not pvError() because pvError uses LogFileStream.
+            std::cerr << "LogFileStream::setStream failed for \"" << realPath << "\"\n";
+            exit(EXIT_FAILURE);
+         }
+         mStream = new std::basic_ofstream<T>(realPath, mode);
          if (mStream->fail() || mStream->fail()) {
+            // Error message has to go to cerr and not pvError() because pvError uses setLogStream.
             std::cerr << "Unable to open logFile \"" << path << "\"." << std::endl;
             exit(EXIT_FAILURE);
          }


### PR DESCRIPTION
This pull request adds calls to expandLeadingTilde at several places, so that filenames can be specified as "~/..." more consistently.  For example, when specifying batch checkpoint directories with a colon-separated list, each entry in the list can be prefixed with "~/" to indicate the user's home directory.

In addition, the long-deprecated checkpointRead parameter in HyPerCol has been made obsolete, in favor of specifying the checkpointRead directory on the command line with the -c option.
