### PR TITLE
getDescription method in BaseObject

### DIFF
--- a/demos/HeatMapLocalization/src/BBFindConfRemapLayer.cpp
+++ b/demos/HeatMapLocalization/src/BBFindConfRemapLayer.cpp
@@ -136,7 +136,7 @@ int BBFindConfRemapLayer::communicateInitInfo() {
       imageLayer = parent->getLayerFromName(imageLayerName);
       if (imageLayer==nullptr) {
          if (parent->columnId()==0) {
-            pvError() << getKeyword() << " \"" << name << "\" error: imageLayer \"" << imageLayerName << "\" does not refer to a layer in the column." << std::endl;
+            pvError() << getDescription_c() << ": imageLayer \"" << imageLayerName << "\" does not refer to a layer in the column." << std::endl;
          }
          MPI_Barrier(parent->icCommunicator()->communicator());
          pvExitFailure("");
@@ -152,8 +152,8 @@ int BBFindConfRemapLayer::communicateInitInfo() {
    if (numDisplayedCategories==0) {
       assert(displayedCategories==nullptr);
       numDisplayedCategories = getLayerLoc()->nf;
-      displayedCategories = (int *) pvMallocError(sizeof(*displayedCategories)*(size_t) numDisplayedCategories, "%s \"%s\" error: unable to allocate %d values for displayedCategories array",
-            getKeyword(), name, numDisplayedCategories);
+      displayedCategories = (int *) pvMallocError(sizeof(*displayedCategories)*(size_t) numDisplayedCategories, "%s: unable to allocate %d values for displayedCategories array",
+            getDescription_c(), numDisplayedCategories);
       for (int k=0; k<numDisplayedCategories; k++) { displayedCategories[k] = k+1; }
    }
    else {
@@ -161,7 +161,7 @@ int BBFindConfRemapLayer::communicateInitInfo() {
          int cat = displayedCategories[k];
          if (cat <=0 || cat > getLayerLoc()->nf) {
             if (parent->columnId()==0) {
-               pvError() << getKeyword() << " \"" << name << "\" error: displayedCategories element " << k+1 << " is " << cat << ", outside the range [1," << getLayerLoc()->nf << "]." << std::endl;
+               pvError() << getDescription_c() << ": displayedCategories element " << k+1 << " is " << cat << ", outside the range [1," << getLayerLoc()->nf << "]." << std::endl;
             }
             MPI_Barrier(parent->icCommunicator()->communicator());
             pvExitFailure("");

--- a/demos/HeatMapLocalization/src/BBFindConfRemapProbe.cpp
+++ b/demos/HeatMapLocalization/src/BBFindConfRemapProbe.cpp
@@ -75,8 +75,8 @@ void BBFindConfRemapProbe::ioParam_drawMontage(enum PV::ParamsIOFlag ioFlag) {
 #else // PV_USE_GDAL
    if (ioFlag==PARAMS_IO_READ) {
       if (parent->columnId()==0) {
-         fprintf(stderr, "%s \"%s\" error: PetaVision must be compiled with GDAL to use BBFindConfRemapProbe with drawMontage set.\n",
-               getKeyword(), name);
+         fprintf(stderr, "%s error: PetaVision must be compiled with GDAL to use BBFindConfRemapProbe with drawMontage set.\n",
+               getDescription_c());
       }
       MPI_Barrier(parent->icCommunicator()->communicator());
       return PV_FAILURE;
@@ -162,8 +162,8 @@ int BBFindConfRemapProbe::communicateInitInfo() {
    targetBBFindConfRemapLayer = dynamic_cast<BBFindConfRemapLayer*>(targetLayer);
    if (targetBBFindConfRemapLayer==NULL) {
       if (parent->columnId()==0) {
-         fprintf(stderr, "%s \"%s\" error: targetLayer \"%s\" must be a BBFindLayer.\n",
-               getKeyword(), name, this->targetName);
+         fprintf(stderr, "%s error: targetLayer \"%s\" must be a BBFindLayer.\n",
+               getDescription_c(), this->targetName);
       }
       MPI_Barrier(parent->icCommunicator()->communicator());
       exit(EXIT_FAILURE);
@@ -182,13 +182,13 @@ int BBFindConfRemapProbe::communicateInitInfo() {
       int const nf = targetLayer->getLayerLoc()->nf;
       classNames = (char **) malloc(nf * sizeof(char *));
       if (classNames == NULL) {
-         fprintf(stderr, "%s \"%s\" unable to allocate classNames: %s\n", getKeyword(), name, strerror(errno));
+         fprintf(stderr, "%s unable to allocate classNames: %s\n", getDescription_c(), strerror(errno));
          exit(EXIT_FAILURE);
       }
       if (strcmp(classNamesFile,"")) {
          std::ifstream * classNamesStream = new std::ifstream(classNamesFile);
          if (classNamesStream->fail()) {
-            fprintf(stderr, "%s \"%s\": unable to open classNamesFile \"%s\".\n", getKeyword(), name, classNamesFile);
+            fprintf(stderr, "%s: unable to open classNamesFile \"%s\".\n", getDescription_c(), classNamesFile);
             exit(EXIT_FAILURE);
          }
          for (int k=0; k<nf; k++) {
@@ -197,8 +197,8 @@ int BBFindConfRemapProbe::communicateInitInfo() {
             classNamesStream->getline(oneclass, 1024);
             classNames[k] = strdup(oneclass);
             if (classNames[k] == NULL) {
-               fprintf(stderr, "%s \"%s\" unable to allocate class name %d from \"%s\": %s\n",
-                     getKeyword(), name, k, classNamesFile, strerror(errno));
+               fprintf(stderr, "%s unable to allocate class name %d from \"%s\": %s\n",
+                     getDescription_c(), k, classNamesFile, strerror(errno));
                exit(EXIT_FAILURE);
             }
          }
@@ -210,7 +210,7 @@ int BBFindConfRemapProbe::communicateInitInfo() {
             classNameString << "Feature " << k+1;
             classNames[k] = strdup(classNameString.str().c_str());
             if (classNames[k]==NULL) {
-               fprintf(stderr, "%s \"%s\": unable to allocate className %d: %s\n", getKeyword(), name, k, strerror(errno));
+               fprintf(stderr, "%s: unable to allocate className %d: %s\n", getDescription_c(), k, strerror(errno));
                exit(EXIT_FAILURE);
             }
          }
@@ -226,8 +226,8 @@ void BBFindConfRemapProbe::setLayerFromParam(PV::HyPerLayer ** layer, char const
    PV::HyPerLayer * l = parent->getLayerFromName(layerName);
    if (l==NULL) {
       if (parent->columnId()==0) {
-         fprintf(stderr, "%s \"%s\" error: %s \"%s\" does not refer to a layer in the column.\n",
-               getKeyword(), name, layerType, layerName);
+         fprintf(stderr, "%s error: %s \"%s\" does not refer to a layer in the column.\n",
+               getDescription_c(), layerType, layerName);
       }
       throw std::invalid_argument("setLayerFromParam:bad layer name");
    }
@@ -235,8 +235,8 @@ void BBFindConfRemapProbe::setLayerFromParam(PV::HyPerLayer ** layer, char const
    int const nf = l->getLayerLoc()->nf;
    if (drawMontage && nf != 3) {
       if (parent->columnId()==0) {
-         fprintf(stderr, "%s \"%s\" error: If the drawMontage flag is set, the %s must have exactly three features (\"%s\" has %d).\n",
-               getKeyword(), name, layerType, layerName, nf);
+         fprintf(stderr, "%s error: If the drawMontage flag is set, the %s must have exactly three features (\"%s\" has %d).\n",
+               getDescription_c(), layerType, layerName, nf);
       }
       throw std::invalid_argument("setLayerFromParam:not three features");
    }
@@ -291,14 +291,14 @@ int BBFindConfRemapProbe::allocateDataStructures() {
    int const imageMontageSize = montageDimX * montageDimY * 3;
    if (parent->columnId()==0 && drawMontage) {
       montageImage = (unsigned char *) pvCallocError(imageMontageSize, sizeof(*montageImage),
-            "%s \"%s\" allocation for heat map montage image\n", getKeyword(), name);
+            "%s allocation for heat map montage image\n", getDescription_c());
       montageImageComm = (unsigned char *) pvCallocError(imageLocalSize, sizeof(*montageImageComm),
-            "%s \"%s\" allocation for MPI communication of heat map montage image\n", getKeyword(), name);
+            "%s allocation for MPI communication of heat map montage image\n", getDescription_c());
    }
    montageImageLocal = (unsigned char *) pvCallocError(imageLocalSize, sizeof(*montageImageLocal),
-         "%s \"%s\" allocation for heat map image in rank %d\n", getKeyword(), name, parent->columnId());
+         "%s allocation for heat map image in rank %d\n", getDescription_c(), parent->columnId());
    grayScaleImage = (pvadata_t *) pvCallocError(imageLoc->nx*imageLoc->ny, sizeof(pvadata_t),
-         "%s \"%s\" allocation for background image in rank %d\n", getKeyword(), name, parent->columnId());
+         "%s allocation for background image in rank %d\n", getDescription_c(), parent->columnId());
    return PV_SUCCESS;
 }
 
@@ -627,24 +627,24 @@ void BBFindConfRemapProbe::drawTextOnMontage(char const * backgroundColor, char 
    assert(parent->columnId()==0);
    char * tempfile = strdup("/tmp/Localization_XXXXXX.tif");
    if (tempfile == NULL) {
-      fprintf(stderr, "%s \"%s\": drawTextOnMontage failed to create temporary file for text\n", getKeyword(), name);
+      fprintf(stderr, "%s: drawTextOnMontage failed to create temporary file for text\n", getDescription_c());
       exit(EXIT_FAILURE);
    }
    int tempfd = mkstemps(tempfile, 4/*suffixlen*/);
    if (tempfd < 0) {
-      fprintf(stderr, "%s \"%s\": drawTextOnMontage failed to create temporary file for writing\n", getKeyword(), name);
+      fprintf(stderr, "%s: drawTextOnMontage failed to create temporary file for writing\n", getDescription_c());
       exit(EXIT_FAILURE);
    }
    int status = close(tempfd); //mkstemps opens the file to avoid race between finding unused filename and opening it, but we don't need the file descriptor.
    if (status != 0) {
-      fprintf(stderr, "%s \"%s\": drawTextOnMontage failed to close temporory file %s: %s\n", getKeyword(), name, tempfile, strerror(errno));
+      fprintf(stderr, "%s: drawTextOnMontage failed to close temporory file %s: %s\n", getDescription_c(), tempfile, strerror(errno));
       exit(EXIT_FAILURE);
    }
    drawTextIntoFile(tempfile, backgroundColor, textColor, labelText, width, height);
    insertFileIntoMontage(tempfile, xOffset, yOffset, width, height);
    status = unlink(tempfile);
    if (status != 0) {
-      fprintf(stderr, "%s \"%s\": drawTextOnMontage failed to delete temporary file %s: %s\n", getKeyword(), name, tempfile, strerror(errno));
+      fprintf(stderr, "%s: drawTextOnMontage failed to delete temporary file %s: %s\n", getDescription_c(), tempfile, strerror(errno));
       exit(EXIT_FAILURE);
    }
    free(tempfile);
@@ -657,7 +657,7 @@ void BBFindConfRemapProbe::drawTextIntoFile(char const * labelFilename, char con
    int status = system(convertCmd.str().c_str());
    if (status != 0) {
       fflush(stdout);
-      fprintf(stderr, "%s \"%s\" error creating label file \"%s\": ImageMagick convert returned %d.\n", getKeyword(), name, labelFilename, WEXITSTATUS(status));
+      fprintf(stderr, "%s error creating label file \"%s\": ImageMagick convert returned %d.\n", getDescription_c(), labelFilename, WEXITSTATUS(status));
       exit(EXIT_FAILURE);
    }
 }
@@ -671,7 +671,7 @@ void BBFindConfRemapProbe::insertFileIntoMontage(char const * labelFilename, int
    GDALDataset * dataset = (GDALDataset *) GDALOpen(labelFilename, GA_ReadOnly);
    if (dataset==NULL) {
       fflush(stdout);
-      fprintf(stderr, "%s \"%s\" error opening label file \"%s\" for reading.\n", getKeyword(), name, labelFilename);
+      fprintf(stderr, "%s error opening label file \"%s\" for reading.\n", getDescription_c(), labelFilename);
       exit(EXIT_FAILURE);
    }
    int xLabelSize = dataset->GetRasterXSize();
@@ -679,8 +679,8 @@ void BBFindConfRemapProbe::insertFileIntoMontage(char const * labelFilename, int
    int labelBands = dataset->GetRasterCount();
    if (xLabelSize != xExpectedSize || yLabelSize != yExpectedSize) {
       fflush(stdout);
-      fprintf(stderr, "%s \"%s\" error: label files \"%s\" has dimensions %dx%d (expected %dx%d)\n",
-            getKeyword(), name, labelFilename, xLabelSize, yLabelSize, xExpectedSize, yExpectedSize);
+      fprintf(stderr, "%s error: label files \"%s\" has dimensions %dx%d (expected %dx%d)\n",
+            getDescription_c(), labelFilename, xLabelSize, yLabelSize, xExpectedSize, yExpectedSize);
       exit(EXIT_FAILURE);
    }
    // same xStart.
@@ -767,7 +767,7 @@ void BBFindConfRemapProbe::writeMontage() {
    char * montagePath = strdup(montagePathSStream.str().c_str()); // not sure why I have to strdup this
    if (montagePath==NULL) {
       fflush(stdout);
-      fprintf(stderr, "%s \"%s\" error: unable to create montagePath\n", getKeyword(), name);
+      fprintf(stderr, "%s error: unable to create montagePath\n", getDescription_c());
       exit(EXIT_FAILURE);
    }
    GDALDriver * driver = GetGDALDriverManager()->GetDriverByName("GTiff");

--- a/demos/HeatMapLocalization/src/ConvertFromTable.cpp
+++ b/demos/HeatMapLocalization/src/ConvertFromTable.cpp
@@ -52,26 +52,26 @@ int ConvertFromTable::loadConversionTable() {
    if (parent->globalRank()==0) {
       FILE * conversionTableFP = fopen(dataFile, "r");
       if (conversionTableFP==NULL) {
-         pvError().printf("%s \"%s\": error opening dataFile \"%s\": %s\n",
-               getKeyword(), getName(), dataFile, strerror(errno));
+         pvError().printf("%s: unable to open dataFile \"%s\": %s\n",
+               getDescription_c(), dataFile, strerror(errno));
       }
       status = fseek(conversionTableFP, 0L, SEEK_END);
       if (status != 0) {
-         pvError().printf("%s \"%s\": error seeking to end off dataFile \"%s\": %s\n",
-               getKeyword(), getName(), dataFile, strerror(errno));
+         pvError().printf("%s: unable to seek to end off dataFile \"%s\": %s\n",
+               getDescription_c(), dataFile, strerror(errno));
       }
       long fileLength = ftell(conversionTableFP);
       if (fileLength<0) {
-         pvError().printf("%s \"%s\": error getting length of dataFile \"%s\": %s\n",
-               getKeyword(), getName(), dataFile, strerror(errno));
+         pvError().printf("%s: unable to get length of dataFile \"%s\": %s\n",
+               getDescription_c(), dataFile, strerror(errno));
       }
       if (fileLength==0) {
-         pvError().printf("%s \"%s\": dataFile \"%s\" is empty.\n",
-               getName(), getKeyword(), dataFile);
+         pvError().printf("%s: dataFile \"%s\" is empty.\n",
+               getDescription_c(), dataFile);
       }
       if (fileLength<CONVTABLEHEADERSIZE) {
          pvError().printf("%s \"%s\": dataFile \"%s\" is too small (%ld bytes; minimum is %zu bytes)\n",
-               getKeyword(), getName(), dataFile, fileLength, CONVTABLEHEADERSIZE);
+               getDescription_c(), dataFile, fileLength, CONVTABLEHEADERSIZE);
       }
       rewind(conversionTableFP);
       size_t numRead = (size_t) 0;
@@ -83,35 +83,35 @@ int ConvertFromTable::loadConversionTable() {
       numRead += fread(&convTable.maxRecon, 1, sizeof(int), conversionTableFP);
       if(numRead != CONVTABLEHEADERSIZE) {
          pvError().printf("%s \"%s\": reading header of dataFile \"%s\": expected %zu bytes; only read %zu\n",
-               getName(), getKeyword(), dataFile, CONVTABLEHEADERSIZE, numRead);
+               getDescription_c(), dataFile, CONVTABLEHEADERSIZE, numRead);
       }
       if (memcmp(hdr, "convTabl", 8)) {
          pvError().printf("%s \"%s\": dataFile \"%s\" does not have the expected header.\n",
-               getKeyword(), getName(), dataFile);
+               getDescription_c(), dataFile);
       }
       int correctFileSize = (int) (sizeof(float)*convTable.numPoints*convTable.numFeatures+CONVTABLEHEADERSIZE);
       if (correctFileSize != fileLength) {
-         pvError().printf("%s \"%s\": dataFile \"%s\" has unexpected length (%d-by-%d %zu-byte data values with %zu-byte header, but file size is %ld\n",
-               getKeyword(), getName(), dataFile, convTable.numPoints, convTable.numFeatures, sizeof(float), CONVTABLEHEADERSIZE, fileLength);
+         pvError().printf("%s: dataFile \"%s\" has unexpected length (%d-by-%d %zu-byte data values with %zu-byte header, but file size is %ld\n",
+               getDescription_c(), dataFile, convTable.numPoints, convTable.numFeatures, sizeof(float), CONVTABLEHEADERSIZE, fileLength);
       }
       if (convTable.numFeatures != getLayerLoc()->nf) {
-         pvError().printf("%s \"%s\" error: layer has %d features but dataFile \"%s\" has numFeatures=%d\n",
-               getKeyword(), getName(), getLayerLoc()->nf, dataFile, convTable.numFeatures);
+         pvError().printf("%s: layer has %d features but dataFile \"%s\" has numFeatures=%d\n",
+               getDescription_c(), getLayerLoc()->nf, dataFile, convTable.numFeatures);
       }
       if (convTable.numFeatures < 2) {
-         pvError().printf("%s \"%s\" error: dataFile \"%s\" has numPoints=%d but must be >= 2.\n",
-               getKeyword(), getName(), dataFile, convTable.numPoints);
+         pvError().printf("%s: dataFile \"%s\" has numPoints=%d but must be >= 2.\n",
+               getDescription_c(), dataFile, convTable.numPoints);
       }
       size_t numValues = (size_t) (convTable.numPoints * convTable.numFeatures);
       convData = (float *) malloc(sizeof(float)*numValues);
       if (convData==NULL) {
-         pvError().printf("%s \"%s\": unable to allocate memory for loading dataFile \"%s\": %s.\n",
-               getKeyword(), getName(), dataFile, strerror(errno));
+         pvError().printf("%s: unable to allocate memory for loading dataFile \"%s\": %s.\n",
+               getDescription_c(), dataFile, strerror(errno));
       }
       numRead = fread(convData, sizeof(float), numValues, conversionTableFP);
       if(numRead != numValues) {
-         pvError().printf("%s \"%s\" error reading dataFile \"%s\": expecting %zu data values but only read %zu.\n",
-               getKeyword(), getName(), dataFile, numValues, numRead);
+         pvError().printf("%s: unable to read dataFile \"%s\": expecting %zu data values but only read %zu.\n",
+               getDescription_c(), dataFile, numValues, numRead);
       }
       fclose(conversionTableFP);
    }
@@ -121,8 +121,8 @@ int ConvertFromTable::loadConversionTable() {
    if (parent->globalRank()!=0) {
       convData = (float *) malloc(sizeof(float)*numValues);
       if (convData==NULL) {
-         pvError().printf("%s \"%s\": unable to allocate memory for loading dataFile \"%s\": %s.\n",
-               getKeyword(), getName(), dataFile, strerror(errno));
+         pvError().printf("%s: unable to allocate memory for loading dataFile \"%s\": %s.\n",
+               getDescription_c(), dataFile, strerror(errno));
       }
    }
    MPI_Bcast(convData, numValues, MPI_FLOAT, 0, parent->icCommunicator()->communicator());

--- a/demos/HeatMapLocalization/src/LocalizationProbe.cpp
+++ b/demos/HeatMapLocalization/src/LocalizationProbe.cpp
@@ -152,8 +152,8 @@ void LocalizationProbe::ioParam_drawMontage(enum PV::ParamsIOFlag ioFlag) {
 #else // PV_USE_GDAL
    if (ioFlag==PARAMS_IO_READ) {
       if (parent->columnId()==0) {
-         pvErrorNoExit().printf("%s \"%s\" error: PetaVision must be compiled with GDAL to use drawMontage=true.\n",
-               getKeyword(), name);
+         pvErrorNoExit().printf("%s: PetaVision must be compiled with GDAL to use drawMontage=true.\n",
+               getDescription_c());
       }
       MPI_Barrier(parent->icCommunicator()->communicator());
       pvExitFailure("");
@@ -214,15 +214,15 @@ int LocalizationProbe::communicateInitInfo() {
    imageLayer = parent->getLayerFromName(imageLayerName);
    if (imageLayer==NULL) {
       if (parent->columnId()==0) {
-         pvErrorNoExit().printf("%s \"%s\" error: imageLayer \"%s\" does not refer to a layer in the column.\n",
-               getKeyword(), name, imageLayerName);
+         pvErrorNoExit().printf("%s: imageLayer \"%s\" does not refer to a layer in the column.\n",
+               getDescription_c(), imageLayerName);
       }
       MPI_Barrier(parent->icCommunicator()->communicator());
       exit(EXIT_FAILURE);
    }
    if (drawMontage && imageLayer->getLayerLoc()->nf != 3) {
       if (parent->columnId()==0) {
-         pvErrorNoExit().printf("%s \"%s\" error: drawMontage requires the image layer have exactly three features.\n", getKeyword(), name);
+         pvErrorNoExit().printf("%s: drawMontage requires the image layer have exactly three features.\n", getDescription_c());
       }
       MPI_Barrier(parent->icCommunicator()->communicator());
       exit(EXIT_FAILURE);
@@ -232,21 +232,21 @@ int LocalizationProbe::communicateInitInfo() {
       if (displayCategoryIndexStart <= 0) {
          displayCategoryIndexStart = 1;
          if (parent->globalRank()==0) {
-            pvInfo().printf("%s \"%s\": setting displayCategoryIndexStart to 1.\n",
-                  getKeyword(), name);
+            pvInfo().printf("%s: setting displayCategoryIndexStart to 1.\n",
+                  getDescription_c());
          }
       }
       if (displayCategoryIndexEnd <= 0) {
          displayCategoryIndexEnd = nf;
          if (parent->globalRank()==0) {
-            pvInfo().printf("%s \"%s\": setting displayCategoryIndexEnd to nf=%d.\n",
-                  getKeyword(), name, nf);
+            pvInfo().printf("%s: setting displayCategoryIndexEnd to nf=%d.\n",
+                  getDescription_c(), nf);
          }
       }
       if (displayCategoryIndexEnd > nf) {
          if (parent->globalRank()==0) {
-            pvErrorNoExit().printf("%s \"%s\": displayCategoryIndexEnd=%d cannot be greater than nf=%d.\n",
-                  getKeyword(), name, displayCategoryIndexEnd, nf);
+            pvErrorNoExit().printf("%s: displayCategoryIndexEnd=%d cannot be greater than nf=%d.\n",
+                  getDescription_c(), displayCategoryIndexEnd, nf);
          }
          MPI_Barrier(parent->icCommunicator()->globalCommunicator());
          exit(EXIT_FAILURE);
@@ -254,14 +254,14 @@ int LocalizationProbe::communicateInitInfo() {
       numDisplayedCategories = displayCategoryIndexEnd - displayCategoryIndexStart + 1;
       if (parent->globalRank()==0) {
          pvInfo().flush();
-         pvInfo().printf("%s \"%s\": converting values of displayCategoryIndexStart and displayCategoryIndexEnd to a displayedCategories array.\n",
-               getKeyword(), name);
+         pvInfo().printf("%s: converting values of displayCategoryIndexStart and displayCategoryIndexEnd to a displayedCategories array.\n",
+               getDescription_c());
       }
 
       if (numDisplayedCategories <= 0) {
          if (parent->globalRank()==0) {
-            pvErrorNoExit().printf("%s \"%s\": displayCategoryIndexStart (%d) cannot be greater than displayCategoryIndexEnd (%d).\n",
-                  getKeyword(), name, displayCategoryIndexStart, displayCategoryIndexEnd);
+            pvErrorNoExit().printf("%s: displayCategoryIndexStart (%d) cannot be greater than displayCategoryIndexEnd (%d).\n",
+                  getDescription_c(), displayCategoryIndexStart, displayCategoryIndexEnd);
          }
          MPI_Barrier(getParent()->icCommunicator()->globalCommunicator());
          exit(EXIT_FAILURE);
@@ -276,8 +276,8 @@ int LocalizationProbe::communicateInitInfo() {
    if (numDetectionThresholds==0) {
       detectionThreshold = (float *) malloc(sizeof(*detectionThreshold)*(size_t) numDisplayedCategories);
       if (detectionThreshold==NULL) {
-         pvError().printf("%s \"%s\": Unable to allocate memory for detectionThreshold array: %s\n",
-               getKeyword(), name, strerror(errno));
+         pvError().printf("%s: Unable to allocate memory for detectionThreshold array: %s\n",
+               getDescription_c(), strerror(errno));
       }
       for (int k=0; k<numDisplayedCategories; k++) { detectionThreshold[0] = 0.0f; }
       numDetectionThresholds = numDisplayedCategories;
@@ -285,8 +285,8 @@ int LocalizationProbe::communicateInitInfo() {
    else if (numDetectionThresholds==1 && numDisplayedCategories>1) {
       detectionThreshold = (float *) realloc(detectionThreshold, sizeof(*detectionThreshold)*(size_t) numDisplayedCategories);
       if (detectionThreshold==NULL) {
-         pvError().printf("%s \"%s\": Unable to allocate memory for detectionThreshold array: %s\n",
-               getKeyword(), name, strerror(errno));
+         pvError().printf("%s: Unable to allocate memory for detectionThreshold array: %s\n",
+               getDescription_c(), strerror(errno));
       }
       float detThresh = detectionThreshold[0];
       for (int k=1; k<numDisplayedCategories; k++) { detectionThreshold[k] = detThresh; }
@@ -294,8 +294,8 @@ int LocalizationProbe::communicateInitInfo() {
    }
    else if (numDetectionThresholds != numDisplayedCategories) {
       if (parent->columnId()==0) {
-         pvError().printf("%s \"%s\" error: detectionThreshold array given %d entries, but number of displayed categories is %d.\n",
-               getKeyword(), name, numDetectionThresholds, numDisplayedCategories);
+         pvError().printf("%s: detectionThreshold array given %d entries, but number of displayed categories is %d.\n",
+               getDescription_c(), numDetectionThresholds, numDisplayedCategories);
       }
    }
 
@@ -303,8 +303,8 @@ int LocalizationProbe::communicateInitInfo() {
       int displayedCategory = displayedCategories[k];
       if (displayedCategory<=0 || displayedCategory>nf) {
          if (parent->columnId()==0) {
-            fprintf(stderr, "%s \"%s\" error: displayedCategories must be between 1 and nf=%d inclusive. (index %d is %d)\n",
-                  getKeyword(), name, nf, k+1, displayedCategory);
+            fprintf(stderr, "%s: displayedCategories must be between 1 and nf=%d inclusive. (index %d is %d)\n",
+                  getDescription_c(), nf, k+1, displayedCategory);
          }
          MPI_Barrier(parent->icCommunicator()->communicator());
          exit(EXIT_FAILURE);
@@ -316,8 +316,8 @@ int LocalizationProbe::communicateInitInfo() {
       if (numHeatMapMaxima==0) {
          heatMapMaximum = (float *) malloc(sizeof(*detectionThreshold)*(size_t) numDisplayedCategories);
          if (heatMapMaximum==NULL) {
-            pvError().printf("%s \"%s\": Unable to allocate memory for heatMapMaximum array: %s\n",
-                  getKeyword(), name, strerror(errno));
+            pvError().printf("%s: Unable to allocate memory for heatMapMaximum array: %s\n",
+                  getDescription_c(), strerror(errno));
          }
          for (int k=0; k<numDisplayedCategories; k++) { heatMapMaximum[k] = 1.0f; }
          numHeatMapMaxima = numDisplayedCategories;
@@ -325,8 +325,8 @@ int LocalizationProbe::communicateInitInfo() {
       else if (numHeatMapMaxima==1 && numDisplayedCategories>1) {
          heatMapMaximum = (float *) realloc(heatMapMaximum, sizeof(*heatMapMaximum)*(size_t) numDisplayedCategories);
          if (heatMapMaximum==NULL) {
-            pvError().printf("%s \"%s\": Unable to allocate memory for heatMapMaximum array: %s\n",
-                  getKeyword(), name, strerror(errno));
+            pvError().printf("%s: Unable to allocate memory for heatMapMaximum array: %s\n",
+                  getDescription_c(), strerror(errno));
          }
          float heatMapMax = heatMapMaximum[0];
          for (int k=1; k<numDisplayedCategories; k++) { heatMapMaximum[k] = heatMapMax; }
@@ -334,8 +334,8 @@ int LocalizationProbe::communicateInitInfo() {
       }
       else if (numHeatMapMaxima != numDisplayedCategories) {
          if (parent->columnId()==0) {
-            pvError().printf("%s \"%s\" error: detectionThreshold array given %d entries, but number of displayed categories is %d.\n",
-                  getKeyword(), name, numDetectionThresholds, numDisplayedCategories);
+            pvError().printf("%s: detectionThreshold array given %d entries, but number of displayed categories is %d.\n",
+                  getDescription_c(), numDetectionThresholds, numDisplayedCategories);
          }
       }
       assert(status==PV_SUCCESS);
@@ -343,8 +343,8 @@ int LocalizationProbe::communicateInitInfo() {
          if (heatMapMaximum[k] < detectionThreshold[k]) {
             status = PV_FAILURE;
             if (parent->columnId()==0) {
-               pvErrorNoExit().printf("%s \"%s\": heatMapMaximum entry %d (%f) cannot be less than corresponding detectionThreshold entry (%f).\n",
-                     getKeyword(), name, k, heatMapMaximum[k], detectionThreshold[k]);
+               pvErrorNoExit().printf("%s: heatMapMaximum entry %d (%f) cannot be less than corresponding detectionThreshold entry (%f).\n",
+                     getDescription_c(), k, heatMapMaximum[k], detectionThreshold[k]);
             }
          }
       }
@@ -364,15 +364,15 @@ int LocalizationProbe::communicateInitInfo() {
    reconLayer = parent->getLayerFromName(reconLayerName);
    if (reconLayer==NULL) {
       if (parent->columnId()==0) {
-         pvErrorNoExit().printf("%s \"%s\" error: reconLayer \"%s\" does not refer to a layer in the column.\n",
-               name, getKeyword(), reconLayerName);
+         pvErrorNoExit().printf("%s: reconLayer \"%s\" does not refer to a layer in the column.\n",
+               getDescription_c(), reconLayerName);
       }
       MPI_Barrier(parent->icCommunicator()->communicator());
       exit(EXIT_FAILURE);
    }
    if (drawMontage && reconLayer->getLayerLoc()->nf != 3) {
       if (parent->columnId()!=0) {
-         pvErrorNoExit().printf("%s \"%s\" error: drawMontage requires the recon layer have exactly three features.\n", getKeyword(), name);
+         pvErrorNoExit().printf("%s: drawMontage requires the recon layer have exactly three features.\n", getDescription_c());
       }
       MPI_Barrier(parent->icCommunicator()->communicator());
       exit(EXIT_FAILURE);
@@ -382,12 +382,12 @@ int LocalizationProbe::communicateInitInfo() {
    if (parent->columnId()==0) {
       classNames = (char **) malloc(nf * sizeof(char *));
       if (classNames == NULL) {
-         pvError().printf("%s \"%s\" unable to allocate classNames: %s\n", getKeyword(), name, strerror(errno));
+         pvError().printf("%s unable to allocate classNames: %s\n", getDescription_c(), strerror(errno));
       }
       if (strcmp(classNamesFile,"")) {
          std::ifstream * classNamesStream = new std::ifstream(classNamesFile);
          if (classNamesStream->fail()) {
-            pvError().printf("%s \"%s\": unable to open classNamesFile \"%s\".\n", getKeyword(), name, classNamesFile);
+            pvError().printf("%s: unable to open classNamesFile \"%s\".\n", getDescription_c(), classNamesFile);
          }
          for (int k=0; k<nf; k++) {
             // Need to clean this section up: handle too-long lines, premature eof, other issues
@@ -395,8 +395,8 @@ int LocalizationProbe::communicateInitInfo() {
             classNamesStream->getline(oneclass, 1024);
             classNames[k] = strdup(oneclass);
             if (classNames[k] == NULL) {
-               pvErrorNoExit().printf("%s \"%s\" unable to allocate class name %d from \"%s\": %s\n",
-                     getKeyword(), name, k, classNamesFile, strerror(errno));
+               pvErrorNoExit().printf("%s unable to allocate class name %d from \"%s\": %s\n",
+                     getDescription_c(), k, classNamesFile, strerror(errno));
                exit(EXIT_FAILURE);
             }
          }
@@ -408,7 +408,7 @@ int LocalizationProbe::communicateInitInfo() {
             classNameString << "Feature " << k;
             classNames[k] = strdup(classNameString.str().c_str());
             if (classNames[k]==NULL) {
-               pvError().printf("%s \"%s\": unable to allocate className %d: %s\n", getKeyword(), name, k, strerror(errno));
+               pvError().printf("%s: unable to allocate className %d: %s\n", getDescription_c(), k, strerror(errno));
             }
          }
       }
@@ -445,7 +445,7 @@ int LocalizationProbe::communicateInitInfo() {
          originalLabelString += "/labels/original.tif";
          status = drawTextIntoFile(originalLabelString.c_str(), "black", "white", "Original Image", nxGlobal);
          if (status != 0) {
-            pvError().printf("%s \"%s\" error creating label file \"%s\".\n", getKeyword(), name, originalLabelString.c_str());
+            pvError().printf("%s unable to create label file \"%s\".\n", getDescription_c(), originalLabelString.c_str());
          }
 
          std::string reconLabelString("");
@@ -453,7 +453,7 @@ int LocalizationProbe::communicateInitInfo() {
          reconLabelString += "/labels/reconstruction.tif";
          status = drawTextIntoFile(reconLabelString.c_str(), "black", "white", "Reconstruction", nxGlobal);
          if (status != 0) {
-            pvError().printf("%s \"%s\" error creating label file \"%s\".\n", getKeyword(), name, reconLabelString.c_str());
+            pvError().printf("%s unable to create label file \"%s\".\n", getDescription_c(), reconLabelString.c_str());
          }
 
          for (int idx=0; idx<numDisplayedCategories; idx++) {
@@ -463,11 +463,11 @@ int LocalizationProbe::communicateInitInfo() {
             int slen;
             slen = snprintf(labelFilename, PV_PATH_MAX, "%s/labels/gray%0*d.tif", heatMapMontageDir, featurefieldwidth, category);
             if (slen>=PV_PATH_MAX) {
-               pvError().printf("%s \"%s\" error: file name for label %d is too long (%d characters versus %d).\n", getKeyword(), name, category, slen, PV_PATH_MAX);
+               pvError().printf("%s: file name for label %d is too long (%d characters versus %d).\n", getDescription_c(), category, slen, PV_PATH_MAX);
             }
             status = drawTextIntoFile(labelFilename, "white", "gray", classNames[f], nxGlobal);
             if (status != 0) {
-               pvError().printf("%s \"%s\" error creating label file \"%s\".\n", getKeyword(), name, labelFilename);
+               pvError().printf("%s: unable to create label file \"%s\".\n", getDescription_c(), labelFilename);
             }
          }
       } 
@@ -519,7 +519,7 @@ char const * LocalizationProbe::getClassName(int k) {
 int LocalizationProbe::allocateDataStructures() {
    int status = PV::LayerProbe::allocateDataStructures();
    if (status != PV_SUCCESS) {
-      pvError().printf("%s \"%s\": allocateDataStructures failed.\n", getKeyword(), name);
+      pvError().printf("%s: allocateDataStructures failed.\n", getDescription_c());
    }
    detections.reserve(maxDetections);
    if (drawMontage) {
@@ -529,18 +529,18 @@ int LocalizationProbe::allocateDataStructures() {
       int const ny = imageLoc->ny;
       grayScaleImage = (pvadata_t *) calloc(nx*ny, sizeof(pvadata_t));
       if (grayScaleImage==NULL) {
-         pvError().printf("%s \"%s\" error allocating for montage background image: %s\n", getKeyword(), name, strerror(errno));
+         pvError().printf("%s: unable to allocate memory for montage background image: %s\n", getDescription_c(), strerror(errno));
       }
 
       montageImageLocal = (unsigned char *) calloc(nx*ny*3, sizeof(unsigned char));
       if (montageImageLocal==NULL) {
-         pvError().printf("%s \"%s\" error allocating for montage background image: %s\n", getKeyword(), name, strerror(errno));
+         pvError().printf("%s: unable to allocate memory for montage background image: %s\n", getDescription_c(), strerror(errno));
       }
 
       if (parent->columnId()==0) {
          montageImageComm = (unsigned char *) calloc(nx * ny * 3, sizeof(unsigned char));
          if (montageImageComm==NULL) {
-            pvError().printf("%s \"%s\" error allocating for MPI communication of heat map montage image: %s\n", getKeyword(), name, strerror(errno));
+            pvError().printf("%s: unable to allocate memory for MPI communication of heat map montage image: %s\n", getDescription_c(), strerror(errno));
          }
 
          int const nxGlobal = imageLoc->nxGlobal;
@@ -549,7 +549,7 @@ int LocalizationProbe::allocateDataStructures() {
          montageDimY = (nyGlobal + 64 + 10) * numMontageRows + 32;
          montageImage = (unsigned char *) calloc(montageDimX * montageDimY * 3, sizeof(unsigned char));
          if (montageImage==NULL) {
-            pvError().printf("%s \"%s\" error allocating for heat map montage image: %s\n", getKeyword(), name, strerror(errno));
+            pvError().printf("%s: unable to allocate memory for heat map montage image: %s\n", getDescription_c(), strerror(errno));
          }
    
          int xStart = (2*numMontageColumns+1)*(nxGlobal+10)/2; // Integer division
@@ -559,7 +559,7 @@ int LocalizationProbe::allocateDataStructures() {
          originalFileName += "/labels/original.tif";
          status = insertFileIntoMontage(originalFileName.c_str(), xStart, yStart, nxGlobal, 32/*yExpectedSize*/);
          if (status != PV_SUCCESS) {
-            pvError().printf("%s \"%s\" error placing the \"original image\" label.\n", getKeyword(), name);
+            pvError().printf("%s: unable to place the \"original image\" label.\n", getDescription_c());
          }
    
          // same xStart.
@@ -569,7 +569,7 @@ int LocalizationProbe::allocateDataStructures() {
          reconFileName += "/labels/reconstruction.tif";
          status = insertFileIntoMontage(reconFileName.c_str(), xStart, yStart, nxGlobal, 32/*yExpectedSize*/);
          if (status != PV_SUCCESS) {
-            pvError().printf("%s \"%s\" error placing the \"reconstruction\" label.\n", getKeyword(), name);
+            pvError().printf("%s: unable to place the \"reconstruction\" label.\n", getDescription_c());
          }
    
          for (int idx=0; idx<numDisplayedCategories; idx++) {
@@ -582,12 +582,12 @@ int LocalizationProbe::allocateDataStructures() {
             char filename[PV_PATH_MAX];
             int slen = snprintf(filename, PV_PATH_MAX, "%s/labels/gray%0*d.tif", heatMapMontageDir, featurefieldwidth, category);
             if (slen >= PV_PATH_MAX) {
-               pvError().printf("%s \"%s\" allocateDataStructures error: path to label file for label %d is too large.\n",
-                     getKeyword(), name, category);
+               pvError().printf("%s: path to label file for label %d is too large.\n",
+                     getDescription_c(), category);
             }
             status = insertFileIntoMontage(filename, xStart, yStart, nxGlobal, 32/*yExpectedSize*/);
             if (status != PV_SUCCESS) {
-               pvError().printf("%s \"%s\" error placing the label for feature %d.\n", getKeyword(), name, f);
+               pvError().printf("%s: unable to place the label for feature %d.\n", getDescription_c(), f);
             }
          }
       }
@@ -595,8 +595,8 @@ int LocalizationProbe::allocateDataStructures() {
    if (getTextOutputFlag()) {
       if (outputStream) {
          PVLayerLoc const * targetLoc = targetLayer->getLayerLoc();
-         outputStream->printf("Layer \"%s\", %dx%d with %d categories.\n",
-               targetLayer->getName(), targetLoc->nxGlobal, targetLoc->nyGlobal, targetLoc->nf);
+         outputStream->printf("%s, %dx%d with %d categories.\n",
+               targetLayer->getDescription_c(), targetLoc->nxGlobal, targetLoc->nyGlobal, targetLoc->nf);
          PVLayerLoc const * imageLoc = imageLayer->getLayerLoc();
          outputStream->printf("Image \"%s\", %dx%d with %d features.\n",
                imageLayer->getName(), imageLoc->nxGlobal, imageLoc->nyGlobal, imageLoc->nf);
@@ -609,15 +609,15 @@ int LocalizationProbe::drawTextOnMontage(char const * backgroundColor, char cons
    assert(parent->columnId()==0);
    char * tempfile = strdup("/tmp/Localization_XXXXXX.tif");
    if (tempfile == NULL) {
-      pvError().printf("%s \"%s\": drawTextOnMontage failed to create temporary file for text\n", getKeyword(), name);
+      pvError().printf("%s: drawTextOnMontage failed to create temporary file for text\n", getDescription_c());
    }
    int tempfd = mkstemps(tempfile, 4/*suffixlen*/);
    if (tempfd < 0) {
-      pvError().printf("%s \"%s\": drawTextOnMontage failed to create temporary file for writing\n", getKeyword(), name);
+      pvError().printf("%s: drawTextOnMontage failed to create temporary file for writing\n", getDescription_c());
    }
    int status = close(tempfd); //mkstemps opens the file to avoid race between finding unused filename and opening it, but we don't need the file descriptor.
    if (status != 0) {
-      pvError().printf("%s \"%s\": drawTextOnMontage failed to close temporory file %s: %s\n", getKeyword(), name, tempfile, strerror(errno));
+      pvError().printf("%s: drawTextOnMontage failed to close temporory file %s: %s\n", getDescription_c(), tempfile, strerror(errno));
    }
    status = drawTextIntoFile(tempfile, backgroundColor, textColor, labelText, width, height);
    if (status == 0) {
@@ -625,7 +625,7 @@ int LocalizationProbe::drawTextOnMontage(char const * backgroundColor, char cons
    }
    status = unlink(tempfile);
    if (status != 0) {
-      pvError().printf("%s \"%s\": drawTextOnMontage failed to delete temporary file %s: %s\n", getKeyword(), name, tempfile, strerror(errno));
+      pvError().printf("%s: drawTextOnMontage failed to delete temporary file %s: %s\n", getDescription_c(), tempfile, strerror(errno));
    }
    free(tempfile);
    return status;
@@ -637,7 +637,7 @@ int LocalizationProbe::drawTextIntoFile(char const * labelFilename, char const *
    convertCmd << "convert -depth 8 -background \"" << backgroundColor << "\" -fill \"" << textColor << "\" -size " << width << "x" << height << " -pointsize 18 -gravity center label:\"" << labelText << "\" \"" << labelFilename << "\"";
    int status = system(convertCmd.str().c_str());
    if (status != 0) {
-      pvError().printf("%s \"%s\" error creating label file \"%s\": ImageMagick convert returned %d.\n", getKeyword(), name, labelFilename, WEXITSTATUS(status));
+      pvError().printf("%s: unable to create label file \"%s\": ImageMagick convert returned %d.\n", getDescription_c(), labelFilename, WEXITSTATUS(status));
    }
    return status;
 }
@@ -650,15 +650,15 @@ int LocalizationProbe::insertFileIntoMontage(char const * labelFilename, int xOf
    int const nf = imageLoc->nf;
    GDALDataset * dataset = (GDALDataset *) GDALOpen(labelFilename, GA_ReadOnly);
    if (dataset==NULL) {
-      pvErrorNoExit().printf("%s \"%s\" error opening label file \"%s\" for reading.\n", getKeyword(), name, labelFilename);
+      pvErrorNoExit().printf("%s: unable to open label file \"%s\" for reading.\n", getDescription_c(), labelFilename);
       return PV_FAILURE;
    }
    int xLabelSize = dataset->GetRasterXSize();
    int yLabelSize = dataset->GetRasterYSize();
    int labelBands = dataset->GetRasterCount();
    if (xLabelSize != xExpectedSize || yLabelSize != yExpectedSize) {
-      pvError().printf("%s \"%s\" error: label files \"%s\" has dimensions %dx%d (expected %dx%d)\n",
-            getKeyword(), name, labelFilename, xLabelSize, yLabelSize, xExpectedSize, yExpectedSize);
+      pvError().printf("%s: label files \"%s\" has dimensions %dx%d (expected %dx%d)\n",
+            getDescription_c(), labelFilename, xLabelSize, yLabelSize, xExpectedSize, yExpectedSize);
    }
    // same xStart.
    int offsetIdx = kIndex(xOffset, yOffset, 0, montageDimX, montageDimY, 3);
@@ -752,7 +752,7 @@ int LocalizationProbe::setOutputFilenameBase(char const * fn) {
    }
    if (fnString.empty()) {
       if (parent->columnId()==0) {
-         pvErrorNoExit().printf("%s \"%s\" setOutputFilenameBase error: string \"%s\" is empty after removing directory and extension.\n", getKeyword(), name, fn);
+         pvErrorNoExit().printf("%s setOutputFilenameBase: string \"%s\" is empty after removing directory and extension.\n", getDescription_c(), fn);
       }
       status = PV_FAILURE;
       outputFilenameBase = NULL;
@@ -760,7 +760,7 @@ int LocalizationProbe::setOutputFilenameBase(char const * fn) {
    else {
       outputFilenameBase = strdup(fnString.c_str());
       if (outputFilenameBase==NULL) {
-         pvError().printf("%s \"%s\" setOutputFilenameBase failed for filename \"%s\": %s\n", getKeyword(), name, fn, strerror(errno));
+         pvError().printf("%s setOutputFilenameBase failed for filename \"%s\": %s\n", getDescription_c(), fn, strerror(errno));
       }
    }
    return status;
@@ -789,7 +789,7 @@ int LocalizationProbe::calcValues(double timevalue) {
    PVHalo const * halo = &loc->halo;
    float * targetRes = (float *) malloc(sizeof(float)*N);
    if (targetRes==NULL) {
-      pvError().printf("%s \"%s\" unable to allocate buffer for calcValues\n", getKeyword(), name);
+      pvError().printf("%s unable to allocate buffer for calcValues\n", getDescription_c());
    }
    for (int n=0; n<N; n++) {
       int nExt = kIndexExtended(n, loc->nx, loc->ny, loc->nf, halo->lt, halo->rt, halo->dn, halo->up);
@@ -1259,7 +1259,7 @@ int LocalizationProbe::writeMontage() {
    montagePathSStream << ".tif";
    char * montagePath = strdup(montagePathSStream.str().c_str()); // not sure why I have to strdup this
    if (montagePath==NULL) {
-      pvError().printf("%s \"%s\" error: unable to create montagePath\n", getKeyword(), name);
+      pvError().printf("%s: unable to create montagePath\n", getDescription_c());
    }
    GDALDriver * driver = GetGDALDriverManager()->GetDriverByName("GTiff");
    if (driver == NULL) {

--- a/demos/HeatMapLocalization/src/MaskFromMemoryBuffer.cpp
+++ b/demos/HeatMapLocalization/src/MaskFromMemoryBuffer.cpp
@@ -48,8 +48,8 @@ int MaskFromMemoryBuffer::communicateInitInfo() {
    HyPerLayer * hyperLayer = parent->getLayerFromName(imageLayerName);
    if (hyperLayer==NULL) {
       if (parent->columnId()==0) {
-         pvErrorNoExit().printf("%s \"%s\": imageLayerName \"%s\" is not a layer in the HyPerCol.\n",
-                 getKeyword(), name, imageLayerName);
+         pvErrorNoExit().printf("%s: imageLayerName \"%s\" is not a layer in the HyPerCol.\n",
+                 getDescription_c(), imageLayerName);
       }
       status = PV_FAILURE;
    }
@@ -57,8 +57,8 @@ int MaskFromMemoryBuffer::communicateInitInfo() {
       imageLayer = dynamic_cast<PV::BaseInput *>(hyperLayer);
       if (imageLayer==NULL) {
          if (parent->columnId()==0) {
-         pvErrorNoExit().printf("%s \"%s\": imageLayerName \"%s\" is not an BaseInput-derived layer.\n",
-               getKeyword(), name, imageLayerName);
+         pvErrorNoExit().printf("%s: imageLayerName \"%s\" is not an BaseInput-derived layer.\n",
+               getDescription_c(), imageLayerName);
          }
          status = PV_FAILURE;
       }
@@ -66,7 +66,7 @@ int MaskFromMemoryBuffer::communicateInitInfo() {
    MPI_Barrier(parent->icCommunicator()->communicator());
    if (!imageLayer->getInitInfoCommunicatedFlag()) {
       if (parent->columnId()==0) {
-         pvInfo().printf("%s \"%s\" must wait until imageLayer \"%s\" has finished its communicateInitInfo stage.\n", getKeyword(), name, imageLayerName);
+         pvInfo().printf("%s must wait until imageLayer \"%s\" has finished its communicateInitInfo stage.\n", getDescription_c(), imageLayerName);
       }
       return PV_POSTPONE;
    }
@@ -74,7 +74,7 @@ int MaskFromMemoryBuffer::communicateInitInfo() {
    PVLayerLoc const * loc = getLayerLoc();
    if (imageLayerLoc->nx != loc->nx || imageLayerLoc->ny != loc->ny) {
       if (parent->columnId()==0) {
-         pvErrorNoExit().printf("%s \"%s\": dimensions (%d-by-%d) do not agree with dimensions of image layer \"%s\" (%d-by-%d)n", getKeyword(), name, loc->nx, loc->ny, imageLayerName, imageLayerLoc->nx, imageLayerLoc->ny);
+         pvErrorNoExit().printf("%s: dimensions (%d-by-%d) do not agree with dimensions of image layer \"%s\" (%d-by-%d)n", getDescription_c(), loc->nx, loc->ny, imageLayerName, imageLayerLoc->nx, imageLayerLoc->ny);
       }
       status = PV_FAILURE;
    }

--- a/src/columns/BaseObject.cpp
+++ b/src/columns/BaseObject.cpp
@@ -63,10 +63,7 @@ int BaseObject::setParent(HyPerCol * hc) {
 
 int BaseObject::setDescription() {
    description.clear();
-   description.append(getKeyword());
-   description.append(" \"");
-   description.append(getName());
-   description.append("\"");
+   description.append(getKeyword()).append(" \"").append(getName()).append("\"");
    return PV_SUCCESS;
 }
 

--- a/src/columns/BaseObject.cpp
+++ b/src/columns/BaseObject.cpp
@@ -31,7 +31,8 @@ int BaseObject::initialize_base() {
 
 int BaseObject::initialize(const char * name, HyPerCol * hc) {
    int status = setName(name);
-   if (status==PV_SUCCESS) { setParent(hc); }
+   if (status==PV_SUCCESS) { status = setParent(hc); }
+   if (status==PV_SUCCESS) { status = setDescription(); }
    return status;
 }
 
@@ -58,6 +59,15 @@ int BaseObject::setParent(HyPerCol * hc) {
       parent = parentCol;
    }
    return status;
+}
+
+int BaseObject::setDescription() {
+   description.clear();
+   description.append(getKeyword());
+   description.append(" \"");
+   description.append(getName());
+   description.append("\"");
+   return PV_SUCCESS;
 }
 
 BaseObject::~BaseObject() {

--- a/src/columns/BaseObject.hpp
+++ b/src/columns/BaseObject.hpp
@@ -46,7 +46,7 @@ protected:
    int initialize(char const * name, HyPerCol * hc);
    int setName(char const * name);
    int setParent(HyPerCol * hc);
-   int setDescription();
+   virtual int setDescription();
 
 // Member variable
 protected:

--- a/src/columns/BaseObject.hpp
+++ b/src/columns/BaseObject.hpp
@@ -35,19 +35,24 @@ class BaseObject {
 public:
    inline char const * getName() const { return name; }
    inline HyPerCol * getParent() const { return parent; }
+   inline char const * getDescription_c() const { return description.c_str(); }
+   inline std::string const& getDescription() const { return description; }
    char const * getKeyword() const;
    virtual ~BaseObject();
+
 
 protected:
    BaseObject();
    int initialize(char const * name, HyPerCol * hc);
    int setName(char const * name);
    int setParent(HyPerCol * hc);
+   int setDescription();
 
 // Member variable
 protected:
-   char * name;
-   HyPerCol * parent;
+   char * name = nullptr;
+   HyPerCol * parent = nullptr;
+   std::string description;
 
 private:
    int initialize_base();

--- a/src/columns/HyPerCol.cpp
+++ b/src/columns/HyPerCol.cpp
@@ -1654,7 +1654,7 @@ int HyPerCol::run(double start_time, double stop_time, double dt)
          BaseProbe * p = baseProbes[i];
          int pstatus = p->allocateDataStructures();
          if (pstatus==PV_SUCCESS) {
-            if (globalRank()==0) { pvInfo().printf("Probe \"%s\" allocateDataStructures completed.\n", p->getName()); }
+            if (globalRank()==0) { pvInfo().printf("%s allocateDataStructures completed.\n", p->getDescription_c()); }
          }
          else {
             assert(pstatus == PV_FAILURE); // PV_POSTPONE etc. hasn't been implemented for probes yet.
@@ -1932,12 +1932,12 @@ int HyPerCol::processParams(char const * path) {
          BaseProbe * p = baseProbes[i];
          int pstatus = p->communicateInitInfo();
          if (pstatus==PV_SUCCESS) {
-            if (globalRank()==0) pvInfo().printf("Probe \"%s\" communicateInitInfo completed.\n", p->getName());
+            if (globalRank()==0) pvInfo().printf("%s communicateInitInfo completed.\n", p->getDescription_c());
          }
          else {
             assert(pstatus == PV_FAILURE); // PV_POSTPONE etc. hasn't been implemented for probes yet.
             // A more detailed error message should be printed by probe's communicateInitInfo function.
-            pvErrorNoExit().printf("Probe \"%s\" communicateInitInfo failed.\n", p->getName());
+            pvErrorNoExit().printf("%s communicateInitInfo failed.\n", p->getDescription_c());
             return PV_FAILURE;
          }
       }
@@ -1981,10 +1981,10 @@ int HyPerCol::doInitializationStage(int (HyPerCol::*layerInitializationStage)(in
                layerStatus[l] = PV_SUCCESS;
                numPostponedLayers--;
                assert(numPostponedLayers>=0);
-               if (globalRank()==0) pvInfo().printf("Layer \"%s\" %s completed.\n", layers[l]->getName(), stageName);
+               if (globalRank()==0) pvInfo().printf("%s: %s completed.\n", layers[l]->getDescription_c(), stageName);
                break;
             case PV_POSTPONE:
-               if (globalRank()==0) pvInfo().printf("Layer \"%s\": %s postponed.\n", layers[l]->getName(), stageName);
+               if (globalRank()==0) pvInfo().printf("%s: %s postponed.\n", layers[l]->getDescription_c(), stageName);
                break;
             case PV_FAILURE:
                exit(EXIT_FAILURE); // Any error message should be printed by layerInitializationStage function.
@@ -2002,10 +2002,10 @@ int HyPerCol::doInitializationStage(int (HyPerCol::*layerInitializationStage)(in
                connectionStatus[c] = PV_SUCCESS;
                numPostponedConns--;
                assert(numPostponedConns>=0);
-               if (globalRank()==0) pvInfo().printf("Connection \"%s\" %s completed.\n", connections[c]->getName(), stageName);
+               if (globalRank()==0) pvInfo().printf("%s %s completed.\n", connections[c]->getDescription_c(), stageName);
                break;
             case PV_POSTPONE:
-               if (globalRank()==0) pvInfo().printf("Connection \"%s\" %s postponed.\n", connections[c]->getName(), stageName);
+               if (globalRank()==0) pvInfo().printf("%s %s postponed.\n", connections[c]->getDescription_c(), stageName);
                break;
             case PV_FAILURE:
                exit(EXIT_FAILURE); // Error message should be printed in connection's communicateInitInfo().
@@ -2023,12 +2023,12 @@ int HyPerCol::doInitializationStage(int (HyPerCol::*layerInitializationStage)(in
       errorMessage.printf("%s loop has hung on global rank %d process.\n", stageName, globalRank());
       for (int l=0; l<numLayers; l++) {
          if (layerStatus[l]==PV_POSTPONE) {
-            errorMessage.printf("Layer \"%s\" on global rank %d is still postponed.\n", layers[l]->getName(), globalRank());
+            errorMessage.printf("%s on global rank %d is still postponed.\n", layers[l]->getDescription_c(), globalRank());
          }
       }
       for (int c=0; c<numConnections; c++) {
          if (layerStatus[c]==PV_POSTPONE) {
-            errorMessage.printf("Connection \"%s\" on global rank %d is still postponed.\n", connections[c]->getName(), globalRank());
+            errorMessage.printf("%s on global rank %d is still postponed.\n", connections[c]->getDescription_c(), globalRank());
          }
       }
       exit(EXIT_FAILURE);
@@ -2264,10 +2264,10 @@ int HyPerCol::calcTimeScaleTrue() {
                if (timeScaleTmp < dtMinToleratedTimeScale) {
                   if (globalRank()==0) {
                      if (nbatch==1) {
-                        pvErrorNoExit().printf("Layer \"%s\" returned time scale %g, less than dtMinToleratedTimeScale=%g.\n", layers[l]->getName(), timeScaleTmp, dtMinToleratedTimeScale);
+                        pvErrorNoExit().printf("%s returned time scale %g, less than dtMinToleratedTimeScale=%g.\n", layers[l]->getDescription_c(), timeScaleTmp, dtMinToleratedTimeScale);
                      }
                      else {
-                        pvErrorNoExit().printf("Layer \"%s\", batch element %d, returned time scale %g, less than dtMinToleratedTimeScale=%g.\n", layers[l]->getName(), b, timeScaleTmp, dtMinToleratedTimeScale);
+                        pvErrorNoExit().printf("%s, batch element %d, returned time scale %g, less than dtMinToleratedTimeScale=%g.\n", layers[l]->getDescription_c(), b, timeScaleTmp, dtMinToleratedTimeScale);
                      }
                   }
                   MPI_Barrier(icComm->globalCommunicator());
@@ -2306,10 +2306,10 @@ int HyPerCol::calcTimeScaleTrue() {
          if (timeScaleProbe > 0 && timeScaleProbe < dtMinToleratedTimeScale) {
             if (globalRank()==0) {
                if (nbatch==1) {
-                  pvErrorNoExit().printf("Probe \"%s\" has time scale %g, less than dtMinToleratedTimeScale=%g.\n", dtAdaptControlProbe->getName(), timeScaleProbe, dtMinToleratedTimeScale);
+                  pvErrorNoExit().printf("%s has time scale %g, less than dtMinToleratedTimeScale=%g.\n", dtAdaptControlProbe->getDescription_c(), timeScaleProbe, dtMinToleratedTimeScale);
                }
                else {
-                  pvErrorNoExit().printf("Layer \"%s\", batch element %d, has time scale %g, less than dtMinToleratedTimeScale=%g.\n", dtAdaptControlProbe->getName(), b, timeScaleProbe, dtMinToleratedTimeScale);
+                  pvErrorNoExit().printf("%s, batch element %d, has time scale %g, less than dtMinToleratedTimeScale=%g.\n", dtAdaptControlProbe->getDescription_c(), b, timeScaleProbe, dtMinToleratedTimeScale);
                }
             }
             MPI_Barrier(icComm->globalCommunicator());
@@ -2626,7 +2626,7 @@ int HyPerCol::advanceTime(double sim_time)
       if (status==PV_FAILURE) {
          for (int l=0; l<numLayers;l++) {
             if (brokenlayers[l]) {
-               pvErrorNoExit().printf("Layer \"%s\" has not-a-number values in the activity buffer.  Exiting.\n", layers[l]->getName());
+               pvErrorNoExit().printf("%s has not-a-number values in the activity buffer.  Exiting.\n", layers[l]->getDescription_c());
             }
          }
          exit(EXIT_FAILURE);

--- a/src/connections/CloneConn.cpp
+++ b/src/connections/CloneConn.cpp
@@ -186,8 +186,8 @@ int CloneConn::communicateInitInfo() {
    BaseConnection * originalConnBase = parent->getConnFromName(originalConnName);
    if (originalConnBase == NULL) {
       if (parent->columnId()==0) {
-         pvErrorNoExit().printf("CloneConn \"%s\": originalConnName \"%s\" is not a connection in the column.\n",
-               name, originalConnName);
+         pvErrorNoExit().printf("%s: originalConnName \"%s\" is not a connection in the column.\n",
+               getDescription_c(), originalConnName);
       }
       MPI_Barrier(parent->icCommunicator()->communicator());
       exit(EXIT_FAILURE);
@@ -195,14 +195,13 @@ int CloneConn::communicateInitInfo() {
    originalConn = dynamic_cast<HyPerConn *>(originalConnBase);
    if (originalConn == NULL) {
       if (parent->columnId()==0) {
-         pvErrorNoExit().printf("CloneConn \"%s\": originalConnName \"%s\" is not a HyPerConn or HyPerConn-derived class.\n",
-               name, originalConnName);
+         pvErrorNoExit().printf("%s: originalConnName \"%s\" is not a HyPerConn or HyPerConn-derived class.\n",
+               getDescription_c(), originalConnName);
       }
    }
    if (!originalConn->getInitInfoCommunicatedFlag()) {
       if (parent->columnId()==0) {
-         const char * connectiontype = this->getKeyword();
-         pvInfo().printf("%s \"%s\" must wait until original connection \"%s\" has finished its communicateInitInfo stage.\n", connectiontype, name, originalConn->getName());
+         pvInfo().printf("%s must wait until original connection \"%s\" has finished its communicateInitInfo stage.\n", getDescription_c(), originalConn->getName());
       }
       return PV_POSTPONE;
    }
@@ -236,13 +235,13 @@ int CloneConn::communicateInitInfo() {
 
    if (preLoc->nx != origPreLoc->nx || preLoc->ny != origPreLoc->ny || preLoc->nf != origPreLoc->nf ) {
       if (parent->icCommunicator()->commRank()==0) {
-         const char * classname = this->getKeyword();
          pvErrorNoExit(errorMessage);
-         errorMessage.printf("%s \"%s\" error in rank %d process: CloneConn and originalConn \"%s\" must have presynaptic layers with the same nx,ny,nf.\n",
-               classname, name, parent->columnId(), originalConn->getName());
+         errorMessage.printf("%s: CloneConn and originalConn \"%s\" must have presynaptic layers with the same nx,ny,nf.\n",
+               getDescription_c(), parent->columnId(), originalConn->getName());
          errorMessage.printf("{nx=%d, ny=%d, nf=%d} versus {nx=%d, ny=%d, nf=%d}\n",
                  preLoc->nx, preLoc->ny, preLoc->nf, origPreLoc->nx, origPreLoc->ny, origPreLoc->nf);
       }
+      MPI_Barrier(parent->icCommunicator()->communicator());
       abort();
    }
 
@@ -278,8 +277,7 @@ int CloneConn::allocatePostConn(){
 int CloneConn::allocateDataStructures() {
    if (!originalConn->getDataStructuresAllocatedFlag()) {
       if (parent->columnId()==0) {
-         const char * connectiontype = this->getKeyword();
-         pvInfo().printf("%s \"%s\" must wait until original connection \"%s\" has finished its communicateInitInfo stage.\n", connectiontype, name, originalConn->getName());
+         pvInfo().printf("%s must wait until original connection \"%s\" has finished its communicateInitInfo stage.\n", getDescription_c(), originalConn->getName());
       }
       return PV_POSTPONE;
    }

--- a/src/connections/CloneKernelConn.cpp
+++ b/src/connections/CloneKernelConn.cpp
@@ -18,7 +18,7 @@ CloneKernelConn::CloneKernelConn(const char * name, HyPerCol * hc) {
 int CloneKernelConn::initialize(const char * name, HyPerCol * hc) {
    int status = CloneConn::initialize(name, hc);
    if (hc->columnId()==0) {
-      pvError().printf("%s \"%s\": CloneKernelConn is obsolete.  Use CloneConn with sharedWeights=true.\n", this->getKeyword(), name);
+      pvError().printf("%s: CloneKernelConn is obsolete.  Use CloneConn with sharedWeights=true.\n", getDescription_c());
    }
    MPI_Barrier(parent->icCommunicator()->communicator());
    exit(EXIT_FAILURE);

--- a/src/connections/CopyConn.cpp
+++ b/src/connections/CopyConn.cpp
@@ -138,7 +138,7 @@ int CopyConn::communicateInitInfo() {
    BaseConnection * originalConnBase = parent->getConnFromName(this->originalConnName);
    if (originalConnBase==NULL) {
       if (parent->columnId()==0) {
-         pvErrorNoExit().printf("%s \"%s\": originalConnName \"%s\" does not refer to any connection in the column.\n", this->getKeyword(), name, this->originalConnName);
+         pvErrorNoExit().printf("%s: originalConnName \"%s\" does not refer to any connection in the column.\n", getDescription_c(), this->originalConnName);
       }
       MPI_Barrier(parent->icCommunicator()->communicator());
       exit(EXIT_FAILURE);
@@ -146,7 +146,7 @@ int CopyConn::communicateInitInfo() {
    this->originalConn = dynamic_cast<HyPerConn *>(originalConnBase);
    if (originalConn == NULL) {
       if (parent->columnId()==0) {
-         pvErrorNoExit().printf("CopyConn \"%s\": originalConnName \"%s\" is not an existing connection.\n", name, originalConnName);
+         pvErrorNoExit().printf("%s: originalConnName \"%s\" is not an existing connection.\n", getDescription_c(), originalConnName);
          status = PV_FAILURE;
       }
    }
@@ -154,8 +154,7 @@ int CopyConn::communicateInitInfo() {
 
    if (!originalConn->getInitInfoCommunicatedFlag()) {
       if (parent->columnId()==0) {
-         const char * connectiontype = this->getKeyword();
-         pvInfo().printf("%s \"%s\" must wait until original connection \"%s\" has finished its communicateInitInfo stage.\n", connectiontype, name, originalConn->getName());
+         pvInfo().printf("%s must wait until original connection \"%s\" has finished its communicateInitInfo stage.\n", getDescription_c(), originalConn->getName());
       }
       return PV_POSTPONE;
    }

--- a/src/connections/FeedbackConn.cpp
+++ b/src/connections/FeedbackConn.cpp
@@ -37,7 +37,7 @@ int FeedbackConn::setPreAndPostLayerNames() {
    PVParams * params = parent->parameters();
    if (params->stringPresent(name, "preLayerName") || params->stringPresent(name, "postLayerName")) {
       if (parent->columnId()==0) {
-         pvErrorNoExit().printf("%s \"%s\": FeedbackConn does not use preLayerName or postLayerName.\n", this->getKeyword(), name);
+         pvErrorNoExit().printf("%s: FeedbackConn does not use preLayerName or postLayerName.\n", getDescription_c());
       }
       status = PV_FAILURE;
    }
@@ -52,7 +52,7 @@ int FeedbackConn::handleMissingPreAndPostLayerNames() {
    preLayerName = strdup(originalConn->getPostLayerName());
    postLayerName = strdup(originalConn->getPreLayerName());
    if (preLayerName==NULL || postLayerName==NULL) {
-      pvError().printf("Error in rank %d process: FeedbackConn \"%s\" unable to allocate memory for pre and post layer names: %s", parent->columnId(), name, strerror(errno));
+      pvError().printf("%s: Rank %d process unable to allocate memory for pre and post layer names: %s", getDescription_c(), parent->columnId(), strerror(errno));
    }
    return PV_SUCCESS;
 }

--- a/src/connections/GapConn.cpp
+++ b/src/connections/GapConn.cpp
@@ -54,7 +54,7 @@ void GapConn::ioParam_sharedWeights(enum ParamsIOFlag ioFlag) {
    if (ioFlag==PARAMS_IO_READ && !parent->parameters()->present(name, "sharedWeights")) {
       sharedWeights = true;
       if (parent->columnId()==0) {
-         pvWarn().printf("%s \"%s\": sharedWeights defaults to true for GapConns, but the default may be changed to false in a future release, to be consistent with other HyPerConns.\n", this->getKeyword(), name);
+         pvWarn().printf("%s: sharedWeights defaults to true for GapConns, but the default may be changed to false in a future release, to be consistent with other HyPerConns.\n", getDescription_c());
       }
       return;
    }
@@ -70,7 +70,7 @@ void GapConn::ioParam_normalizeMethod(enum ParamsIOFlag ioFlag) {
       GapConn * conn = this;
       normalizer = new NormalizeGap(name, parent);
       if (parent->columnId()==0) {
-         pvWarn().printf("%s \"%s\": normalizeMethod defaults to normalizeSum for GapConns, but this parameter may be required in a future release, to be consistent with other HyPerConns.\n", this->getKeyword(), name);
+         pvWarn().printf("%s: normalizeMethod defaults to normalizeSum for GapConns, but this parameter may be required in a future release, to be consistent with other HyPerConns.\n", getDescription_c());
       }
       return;
    }
@@ -82,8 +82,8 @@ int GapConn::allocateDataStructures() {
    LIFGap * postLIFGap = dynamic_cast <LIFGap*> (postHyPerLayer);
    if (postLIFGap == NULL) {
       if (parent->columnId()==0) {
-         pvErrorNoExit().printf("%s \"%s\": postsynaptic layer must be a LIFGap or LIFGap-derived layer.\n",
-               this->getKeyword(), name);
+         pvErrorNoExit().printf("%s: postsynaptic layer must be a LIFGap or LIFGap-derived layer.\n",
+               getDescription_c());
       }
       MPI_Barrier(parent->icCommunicator()->communicator());
       exit(EXIT_FAILURE);

--- a/src/connections/HyPerConn.cpp
+++ b/src/connections/HyPerConn.cpp
@@ -270,7 +270,7 @@ int HyPerConn::createArbors() {
 }
 
 void HyPerConn::createArborsOutOfMemory() {
-   pvError().printf("Out of memory error in HyPerConn::createArbors() for connection \"%s\"\n", name);
+   pvError().printf("Out of memory error in HyPerConn::createArbors() for %s\n", getDescription_c());
 }
 
 
@@ -472,7 +472,7 @@ int HyPerConn::setPreLayerName(const char * pre_name) {
 
    if (pre_name != NULL) {
       preLayerName = strdup(pre_name);
-      pvAssertMessage(preLayerName != NULL, "Connection \"%s\" error in rank %d process: unable to allocate memory for name of presynaptic layer \"%s\": %s", name, parent->columnId(), pre_name);
+      pvAssertMessage(preLayerName != NULL, "%s: rank %d process unable to allocate memory for name of presynaptic layer \"%s\": %s", getDescription_c(), parent->columnId(), pre_name);
    }
    return PV_SUCCESS;
 }
@@ -481,7 +481,7 @@ int HyPerConn::setPostLayerName(const char * post_name) {
    pvAssert(postLayerName==NULL);
    if (post_name != NULL) {
       postLayerName = strdup(post_name);
-      pvAssertMessage(postLayerName != NULL, "Connection \"%s\" error in rank %d process: unable to allocate memory for name of postsynaptic layer \"%s\": %s", name, parent->columnId(), post_name, strerror(errno));
+      pvAssertMessage(postLayerName != NULL, "%s: unable to allocate memory for name of postsynaptic layer \"%s\": %s", getDescription_c(), parent->columnId(), post_name, strerror(errno));
    }
    return PV_SUCCESS;
 }
@@ -684,7 +684,7 @@ void HyPerConn::ioParam_channelCode(enum ParamsIOFlag ioFlag) {
       int status = decodeChannel(ch, &channel);
       if (status != PV_SUCCESS) {
          if (parent->columnId()==0) {
-            pvErrorNoExit().printf("%s \"%s\": channelCode %d is not a valid channel.\n", getKeyword(), name,  ch);
+            pvErrorNoExit().printf("%s: channelCode %d is not a valid channel.\n", getDescription_c(),  ch);
          }
          MPI_Barrier(parent->icCommunicator()->communicator());
          pvAssert(0);
@@ -709,7 +709,7 @@ void HyPerConn::ioParam_weightInitType(enum ParamsIOFlag ioFlag) {
    // Once that constructor is removed, the weightInitializer==NULL part of the if-statement below can be removed.
    if (ioFlag==PARAMS_IO_READ && weightInitializer==NULL) {
       int status = setWeightInitializer();
-      pvAssertMessage(status == PV_SUCCESS, "%s \"%s\": Rank %d process unable to construct weightInitializer", getKeyword(), name, parent->columnId());
+      pvAssertMessage(status == PV_SUCCESS, "%s: Rank %d process unable to construct weightInitializer", getDescription_c(), parent->columnId());
    }
 }
 
@@ -737,7 +737,7 @@ void HyPerConn::ioParam_triggerFlag(enum ParamsIOFlag ioFlag) {
          parent->ioParamValue(ioFlag, name, "triggerFlag", &flagFromParams, flagFromParams);
          if (parent->columnId()==0) {
             pvWarn(triggerFlagMessage);
-            triggerFlagMessage.printf("Layer \"%s\": triggerFlag has been deprecated.\n", name);
+            triggerFlagMessage.printf("%s: triggerFlag has been deprecated.\n", getDescription_c());
             triggerFlagMessage.printf("   If triggerLayerName is a nonempty string, triggering will be on;\n");
             triggerFlagMessage.printf("   if triggerLayerName is empty or null, triggering will be off.\n");
             if (parent->columnId()==0) {
@@ -766,7 +766,7 @@ void HyPerConn::ioParam_triggerOffset(enum ParamsIOFlag ioFlag) {
       if (triggerFlag) {
          parent->ioParamValue(ioFlag, name, "triggerOffset", &triggerOffset, triggerOffset);
          if(triggerOffset < 0){
-            pvError().printf("%s \"%s\" error in rank %d process: TriggerOffset (%f) must be positive", getKeyword(), name, parent->columnId(), triggerOffset);
+            pvError().printf("%s error in rank %d process: TriggerOffset (%f) must be positive", getDescription_c(), parent->columnId(), triggerOffset);
          }
       }
    }
@@ -841,12 +841,12 @@ void HyPerConn::ioParam_pvpatchAccumulateType(enum ParamsIOFlag ioFlag) {
 void HyPerConn::unsetAccumulateType() {
    if (parent->columnId()==0) {
       if (pvpatchAccumulateTypeString) {
-         pvErrorNoExit().printf("%s \"%s\" error: pvpatchAccumulateType \"%s\" is unrecognized.",
-               getKeyword(), name, pvpatchAccumulateTypeString);
+         pvErrorNoExit().printf("%s error: pvpatchAccumulateType \"%s\" is unrecognized.",
+               getDescription_c(), pvpatchAccumulateTypeString);
       }
       else {
-         pvErrorNoExit().printf("%s \"%s\" error: pvpatchAccumulateType NULL is unrecognized.",
-               getKeyword(), name);
+         pvErrorNoExit().printf("%s error: pvpatchAccumulateType NULL is unrecognized.",
+               getDescription_c());
       }
       pvErrorNoExit().printf("  Allowed values are \"convolve\" or \"stochastic\".");
    }
@@ -868,16 +868,16 @@ void HyPerConn::ioParam_initialWriteTime(enum ParamsIOFlag ioFlag) {
          if (writeStep>0 && initialWriteTime < start_time) {
             if (parent->columnId()==0) {
                pvWarn(adjustInitialWriteTime);
-               adjustInitialWriteTime.printf("%s \"%s\": initialWriteTime %f earlier than starting time %f.  Adjusting initialWriteTime:\n",
-                     getKeyword(), name, initialWriteTime, start_time);
+               adjustInitialWriteTime.printf("%s: initialWriteTime %f earlier than starting time %f.  Adjusting initialWriteTime:\n",
+                     getDescription_c(), initialWriteTime, start_time);
                adjustInitialWriteTime.flush();
             }
             while (initialWriteTime < start_time) {
                initialWriteTime += writeStep;
             }
             if (parent->columnId()==0) {
-               pvInfo().printf("%s \"%s\": initialWriteTime adjusted to %f\n",
-                     getKeyword(), name, initialWriteTime);
+               pvInfo().printf("%s: initialWriteTime adjusted to %f\n",
+                     getDescription_c(), initialWriteTime);
             }
          }
          writeTime = initialWriteTime;
@@ -931,8 +931,8 @@ void HyPerConn::ioParam_nxpShrunken(enum ParamsIOFlag ioFlag) {
          int nxpShrunken;
          parent->ioParamValue(ioFlag, name, "nxpShrunken", &nxpShrunken, nxp);
          if (parent->columnId()==0) {
-            pvError().printf("%s \"%s\": nxpShrunken is obsolete, as nxp can now take any of the values nxpShrunken could take before.  nxp will be set to %d and nxpShrunken will not be used.",
-                  getKeyword(), name, nxp);
+            pvError().printf("%s: nxpShrunken is obsolete, as nxp can now take any of the values nxpShrunken could take before.  nxp will be set to %d and nxpShrunken will not be used.",
+                  getDescription_c(), nxp);
             MPI_Barrier(parent->icCommunicator()->communicator());
             exit(EXIT_FAILURE);
          }
@@ -947,8 +947,8 @@ void HyPerConn::ioParam_nypShrunken(enum ParamsIOFlag ioFlag) {
          int nypShrunken;
          parent->ioParamValue(ioFlag, name, "nypShrunken", &nypShrunken, nyp);
          if (parent->columnId()==0) {
-            pvWarn().printf("%s \"%s\": nypShrunken is deprecated, as nyp can now take any of the values nypShrunken could take before.  nyp will be set to %d and nypShrunken will not be used.",
-                  getKeyword(), name, nyp);
+            pvWarn().printf("%s: nypShrunken is deprecated, as nyp can now take any of the values nypShrunken could take before.  nyp will be set to %d and nypShrunken will not be used.",
+                  getDescription_c(), nyp);
          }
          MPI_Barrier(parent->icCommunicator()->communicator());
          exit(EXIT_FAILURE);
@@ -959,8 +959,8 @@ void HyPerConn::ioParam_nypShrunken(enum ParamsIOFlag ioFlag) {
 void HyPerConn::ioParam_nfp(enum ParamsIOFlag ioFlag) {
    parent->ioParamValue(ioFlag, name, "nfp", &nfp, -1, false);
    if (ioFlag==PARAMS_IO_READ && nfp==-1 && !parent->parameters()->present(name, "nfp") && parent->columnId()==0) {
-      pvInfo().printf("%s \"%s\": nfp will be set in the communicateInitInfo() stage.\n",
-            getKeyword(), name);
+      pvInfo().printf("%s: nfp will be set in the communicateInitInfo() stage.\n",
+            getDescription_c());
    }
 }
 
@@ -991,7 +991,7 @@ void HyPerConn::ioParam_normalizeMethod(enum ParamsIOFlag ioFlag) {
    if (ioFlag==PARAMS_IO_READ) {
       if (normalizeMethod==NULL) {
          if (parent->columnId()==0) {
-            pvError().printf("%s \"%s\": specifying a normalizeMethod string is required.\n", getKeyword(), name);
+            pvError().printf("%s: specifying a normalizeMethod string is required.\n", getDescription_c());
          }
       }
       if (!strcmp(normalizeMethod, "")) {
@@ -1003,7 +1003,7 @@ void HyPerConn::ioParam_normalizeMethod(enum ParamsIOFlag ioFlag) {
       if (normalizer==nullptr && strcmp(normalizeMethod, "none")) {
          int status = setWeightNormalizer();
          if (status != PV_SUCCESS) {
-            pvError().printf("%s \"%s\": Rank %d process unable to construct weight normalizer\n", getKeyword(), name, parent->columnId());
+            pvError().printf("%s: Rank %d process unable to construct weight normalizer\n", getDescription_c(), parent->columnId());
          }
       }
    }
@@ -1020,7 +1020,7 @@ int HyPerConn::setWeightNormalizer() {
    BaseObject * baseObj = parent->getPV_InitObj()->create(normalizeMethod, name, parent);
    if (baseObj == nullptr) {
       if (parent->columnId()==0) {
-         pvError() << getKeyword() << " \"" << name << "\": normalizeMethod \"" << normalizeMethod << "\" is not recognized." << std::endl;
+         pvError() << getDescription_c() << ": normalizeMethod \"" << normalizeMethod << "\" is not recognized." << std::endl;
       }
       MPI_Barrier(parent->icCommunicator()->communicator());
       exit(EXIT_FAILURE);
@@ -1029,7 +1029,7 @@ int HyPerConn::setWeightNormalizer() {
    if (normalizer == nullptr) {
       pvAssert(baseObj);
       if (parent->columnId()==0) {
-         pvError() << getKeyword() << " \"" << name << "\": normalizeMethod \"" << normalizeMethod << "\" is not a normalization method." << std::endl;
+         pvError() << getDescription_c() << ": normalizeMethod \"" << normalizeMethod << "\" is not a normalization method." << std::endl;
       }
       MPI_Barrier(parent->icCommunicator()->communicator());
       exit(EXIT_FAILURE);
@@ -1145,7 +1145,7 @@ int HyPerConn::communicateInitInfo() {
    int status = BaseConnection::communicateInitInfo();
    if (status != PV_SUCCESS) {
       if (parent->columnId()==0) {
-         pvErrorNoExit().printf("%s \"%s\": communicateInitInfo failed.\n", getKeyword(), name);
+         pvErrorNoExit().printf("%s: communicateInitInfo failed.\n", getDescription_c());
       }
       MPI_Barrier(parent->icCommunicator()->communicator());
       exit(EXIT_FAILURE);
@@ -1157,7 +1157,7 @@ int HyPerConn::communicateInitInfo() {
       mask = getParent()->getLayerFromName(maskLayerName);
       if (mask == NULL) {
          if (getParent()->columnId()==0) {
-            pvErrorNoExit().printf("Connection \"%s\": maskLayerName \"%s\" does not correspond to a layer in the column.\n", getName(), maskLayerName);
+            pvErrorNoExit().printf("%s: maskLayerName \"%s\" does not correspond to a layer in the column.\n", getDescription_c(), maskLayerName);
          }
          status = PV_FAILURE;
          exit(-1);
@@ -1167,14 +1167,14 @@ int HyPerConn::communicateInitInfo() {
       const PVLayerLoc * postLoc = post->getLayerLoc();
       if(postLoc->nx != maskLoc->nx || postLoc->ny != maskLoc->ny){
          if (getParent()->columnId()==0) {
-            pvErrorNoExit().printf("Connection \"%s\": Mask \"%s\" (%d, %d, %d) must have the same x and y size as post layer \"%s\" (%d, %d, %d).\n", getName(), maskLayerName, maskLoc->nx, maskLoc->ny, maskLoc->nf, post->getName(), postLoc->nx, postLoc->ny, postLoc->nf);
+            pvErrorNoExit().printf("%s: Mask \"%s\" (%d, %d, %d) must have the same x and y size as post layer \"%s\" (%d, %d, %d).\n", getDescription_c(), maskLayerName, maskLoc->nx, maskLoc->ny, maskLoc->nf, post->getName(), postLoc->nx, postLoc->ny, postLoc->nf);
          }
          status = PV_FAILURE;
          exit(-1);
       }
       //Make sure maskFeatureIdx is within bounds
       if(maskFeatureIdx >= maskLoc->nf || maskFeatureIdx < -1){
-         pvErrorNoExit().printf("Connection \"%s\": maskFeatureIdx must be between -1 (inclusive) and mask layer \"%s\" (%d, %d, %d) nf dimension (exclusive)\n", getName(), maskLayerName, maskLoc->nx, maskLoc->ny, maskLoc->nf);
+         pvErrorNoExit().printf("%s: maskFeatureIdx must be between -1 (inclusive) and mask layer \"%s\" (%d, %d, %d) nf dimension (exclusive)\n", getDescription_c(), maskLayerName, maskLoc->nx, maskLoc->ny, maskLoc->nf);
          status = PV_FAILURE;
          exit(-1);
       }
@@ -1183,7 +1183,7 @@ int HyPerConn::communicateInitInfo() {
       if(maskFeatureIdx == -1){
          if(postLoc->nf != maskLoc->nf && maskLoc->nf != 1){
             if (getParent()->columnId()==0) {
-               pvErrorNoExit().printf("Connection \"%s\": Mask \"%s\" (%d, %d, %d) nf dimension must be either the same as post layer \"%s\" (%d, %d, %d) or 1\n", getName(), maskLayerName, maskLoc->nx, maskLoc->ny, maskLoc->nf, post->getName(), postLoc->nx, postLoc->ny, postLoc->nf);
+               pvErrorNoExit().printf("%s: Mask \"%s\" (%d, %d, %d) nf dimension must be either the same as post layer \"%s\" (%d, %d, %d) or 1\n", getDescription_c(), maskLayerName, maskLoc->nx, maskLoc->ny, maskLoc->nf, post->getName(), postLoc->nx, postLoc->ny, postLoc->nf);
             }
             status = PV_FAILURE;
             exit(-1);
@@ -1195,7 +1195,7 @@ int HyPerConn::communicateInitInfo() {
    if (getPvpatchAccumulateType()==STOCHASTIC && (getConvertRateToSpikeCount() || pre->activityIsSpiking())) {
       if (parent->columnId()==0) {
          pvErrorNoExit(errorMessage);
-         errorMessage.printf("Connection \"%s\": stochastic accumulation function is not consistent with ", getName());
+         errorMessage.printf("%s: stochastic accumulation function is not consistent with ", getDescription_c());
          if (getConvertRateToSpikeCount()) {
             errorMessage.printf("setting convertRateToSpikeCount to true.\n");
          }
@@ -1215,13 +1215,13 @@ int HyPerConn::communicateInitInfo() {
    if (nfp == -1) {
       nfp = post->getCLayer()->loc.nf;
       if (warnDefaultNfp && parent->columnId()==0) {
-         pvInfo().printf("Connection \"%s\" setting nfp to number of postsynaptic features = %d.\n", name, nfp);
+         pvInfo().printf("%s setting nfp to number of postsynaptic features = %d.\n", getDescription_c(), nfp);
       }
    }
    if (nfp != post->getCLayer()->loc.nf) {
       if (parent->columnId()==0) {
          pvErrorNoExit(errorMessage);
-         errorMessage.printf("Params file specifies %d features for connection \"%s\",\n", nfp, name );
+         errorMessage.printf("Params file specifies %d features for %s,\n", nfp, getDescription_c() );
          errorMessage.printf("but %d features for post-synaptic layer %s\n", post->getCLayer()->loc.nf, post->getName() );
       }
       MPI_Barrier(parent->icCommunicator()->communicator());
@@ -1237,13 +1237,13 @@ int HyPerConn::communicateInitInfo() {
    int receivedxmargin = 0;
    int statusx = pre->requireMarginWidth(xmargin, &receivedxmargin, 'x');
    if (statusx != PV_SUCCESS) {
-      pvErrorNoExit().printf("Margin Failure for layer %s.  Received x-margin is %d, but connection \"%s\" requires margin of at least %d\n", pre->getName(),receivedxmargin, name, xmargin);
+      pvErrorNoExit().printf("Margin Failure for layer %s.  Received x-margin is %d, but %s requires margin of at least %d\n", pre->getDescription_c(), receivedxmargin, name, xmargin);
       status = PV_MARGINWIDTH_FAILURE;
    }
    int receivedymargin = 0;
    int statusy = pre->requireMarginWidth(ymargin, &receivedymargin, 'y');
    if (statusy != PV_SUCCESS) {
-      pvErrorNoExit().printf("Margin Failure for layer %s.  Received y-margin is %d, but connection \"%s\" requires margin of at least %d\n", pre->getName(),receivedymargin, name, ymargin);
+      pvErrorNoExit().printf("Margin Failure for layer %s.  Received y-margin is %d, but %s requires margin of at least %d\n", pre->getDescription_c(), receivedymargin, name, ymargin);
       status = PV_MARGINWIDTH_FAILURE;
    }
 
@@ -1254,8 +1254,8 @@ int HyPerConn::communicateInitInfo() {
       triggerLayer = parent->getLayerFromName(triggerLayerName);
       if (triggerLayer==NULL) {
          if (parent->columnId()==0) {
-            pvErrorNoExit().printf("%s \"%s\" error: triggerLayer \"%s\" is not a layer in the HyPerCol.\n",
-                    getKeyword(), name, triggerLayerName);
+            pvErrorNoExit().printf("%s error: triggerLayer \"%s\" is not a layer in the HyPerCol.\n",
+                    getDescription_c(), triggerLayerName);
          }
          MPI_Barrier(parent->icCommunicator()->communicator());
          exit(EXIT_FAILURE);
@@ -1271,7 +1271,7 @@ int HyPerConn::communicateInitInfo() {
          }
       }
       if(weightUpdatePeriod != -1 && triggerOffset >= weightUpdatePeriod){
-         pvError().printf("%s \"%s\", rank %d process: TriggerOffset (%f) must be lower than the change in update time (%f) of the attached trigger layer\n", getKeyword(), name, parent->columnId(), triggerOffset, weightUpdatePeriod);
+         pvError().printf("%s, rank %d process: TriggerOffset (%f) must be lower than the change in update time (%f) of the attached trigger layer\n", getDescription_c(), parent->columnId(), triggerOffset, weightUpdatePeriod);
       }
       weightUpdateTime = parent->getDeltaTime();
    }
@@ -1319,8 +1319,8 @@ int HyPerConn::communicateInitInfo() {
    //No batches with non-shared weights
    if(parent->getNBatch() > 1 && !sharedWeights){
       if (parent->columnId()==0) {
-         pvErrorNoExit().printf("%s \"%s\" error: Non-shared weights with batches not implemented yet.\n",
-               getKeyword(), name);
+         pvErrorNoExit().printf("%s error: Non-shared weights with batches not implemented yet.\n",
+               getDescription_c());
       }
       MPI_Barrier(parent->icCommunicator()->communicator());
       exit(EXIT_FAILURE);
@@ -1439,8 +1439,7 @@ int HyPerConn::allocateDataStructures() {
 #if defined(PV_USE_CUDA)
    if (!pre->getDataStructuresAllocatedFlag()) {
       if (parent->columnId()==0) {
-         const char * connectiontype = this->getKeyword();
-         pvInfo().printf("%s \"%s\" must wait until pre-synaptic layer \"%s\" has finished its allocateDataStructures stage.\n", connectiontype, name, pre->getName());
+         pvInfo().printf("%s must wait until pre-synaptic layer \"%s\" has finished its allocateDataStructures stage.\n", getDescription_c(), pre->getName());
       }
       return PV_POSTPONE;
    }
@@ -1467,8 +1466,8 @@ int HyPerConn::allocateDataStructures() {
       if (parent->getCheckpointReadFlag()==false && weightUpdateTime < parent->simulationTime()) {
          while(weightUpdateTime <= parent->simulationTime()) {weightUpdateTime += weightUpdatePeriod;}
          if (parent->columnId()==0) {
-            pvWarn().printf("initialWeightUpdateTime of %s \"%s\" less than simulation start time.  Adjusting weightUpdateTime to %f\n",
-                  getKeyword(), name, weightUpdateTime);
+            pvWarn().printf("initialWeightUpdateTime of %s less than simulation start time.  Adjusting weightUpdateTime to %f\n",
+                  getDescription_c(), weightUpdateTime);
          }
       }
       lastUpdateTime = weightUpdateTime - parent->getDeltaTime();
@@ -1492,7 +1491,7 @@ int HyPerConn::allocateDataStructures() {
       status = PV_SUCCESS;
    }
    else{
-      pvError().printf("Connection \"%s\" unable to allocate device memory in rank %d process: %s\n", getName(), getParent()->columnId(), strerror(errno));
+      pvError().printf("%s: unable to allocate device memory in rank %d process: %s\n", getDescription_c(), getParent()->columnId(), strerror(errno));
    }
 #endif
 
@@ -1504,12 +1503,12 @@ int HyPerConn::allocateDataStructures() {
 
       //Assign thread_gSyn to different points of tempMem
       for(int i = 0; i < parent->getNumThreads(); i++){
-         thread_gSyn[i] = (pvdata_t*) pvMallocError(sizeof(pvdata_t) * post->getNumNeurons(), "HyPerLayer \"%s\" error: rank %d unable to allocate %zu memory for thread_gSyn", name, parent->columnId(), sizeof(pvdata_t) * post->getNumNeurons());
+         thread_gSyn[i] = (pvdata_t*) pvMallocError(sizeof(pvdata_t) * post->getNumNeurons(), "%s: rank %d unable to allocate %zu memory for thread_gSyn", getDescription_c(), parent->columnId(), sizeof(pvdata_t) * post->getNumNeurons());
       }
    }
 
    //Allocate batchSkip buffer
-   batchSkip = (bool*) pvMallocError(parent->getNBatch() * sizeof(bool), "HyPerLayer \"%s\" error: rank %d unable to allocate %zu memory for batchSkip", name, parent->columnId(), sizeof(bool) * parent->getNBatch());
+   batchSkip = (bool*) pvMallocError(parent->getNBatch() * sizeof(bool), "%s: rank %d unable to allocate %zu memory for batchSkip", getDescription_c(), parent->columnId(), sizeof(bool) * parent->getNBatch());
 
    for(int i = 0; i < parent->getNBatch(); i++){
       batchSkip[i] = false;
@@ -1544,7 +1543,7 @@ taus_uint4 * HyPerConn::getRandState(int index) {
 
 InitWeights * HyPerConn::getDefaultInitWeightsMethod(const char * keyword) {
    if (parent->columnId()==0) {
-      pvErrorNoExit().printf("Connection \"%s\": weightInitType \"%s\" not recognized.  Exiting\n", name, weightInitTypeString);
+      pvErrorNoExit().printf("%s: weightInitType \"%s\" not recognized.  Exiting\n", getDescription_c(), weightInitTypeString);
    }
    MPI_Barrier(parent->icCommunicator()->communicator());
    exit(EXIT_FAILURE);
@@ -2021,7 +2020,7 @@ int HyPerConn::writeWeights(PVPatch *** patches, pvwdata_t ** dataStart, int num
       chars_needed = snprintf(path, PV_PATH_MAX, "%s", filename);
    }
    if (chars_needed >= PV_PATH_MAX) {
-      pvError().printf("HyPerConn::writeWeights in connection \"%s\": path is too long (it would be cut off as \"%s\")\n", name, path);
+      pvError().printf("HyPerConn::writeWeights in %s: path is too long (it would be cut off as \"%s\")\n", getDescription_c(), path);
    }
 
    Communicator * comm = parent->icCommunicator();
@@ -2032,7 +2031,7 @@ int HyPerConn::writeWeights(PVPatch *** patches, pvwdata_t ** dataStart, int num
          nfp, minVal, maxVal, patches, dataStart, numPatches,
          numberOfAxonalArborLists(), compressWeights, fileType);
    if(status != PV_SUCCESS) {
-      pvError().printf("%s \"%s\" error in writing weights.\n", getKeyword(), name);
+      pvError().printf("%s error in writing weights.\n", getDescription_c());
    }
 
    return status;
@@ -2041,7 +2040,7 @@ int HyPerConn::writeWeights(PVPatch *** patches, pvwdata_t ** dataStart, int num
 int HyPerConn::writeTextWeights(const char * filename, int k)
 {
    if (parent->icCommunicator()->commSize()>1) {
-      pvError().printf("writeTextWeights error for connection \"%s\": writeTextWeights is not compatible with MPI", name);
+      pvError().printf("writeTextWeights error for %s: writeTextWeights is not compatible with MPI", getDescription_c());
       // NOTE : if run under MPI when more than one process sees the same file system, the contending processes will clobber each other.
    }
    OutStream * outStream = nullptr;
@@ -2059,7 +2058,7 @@ int HyPerConn::writeTextWeights(const char * filename, int k)
      return PV_FAILURE;
    }
 
-   outStream->printf("Weights for connection \"%s\", neuron %d\n", name, k);
+   outStream->printf("Weights for %s, neuron %d\n", getDescription_c(), k);
    outStream->printf("   (kxPre,kyPre,kfPre)   = (%i,%i,%i)\n",
            kxPos(k,pre->getLayerLoc()->nx + pre->getLayerLoc()->halo.lt + pre->getLayerLoc()->halo.rt,
                  pre->getLayerLoc()->ny + pre->getLayerLoc()->halo.dn + pre->getLayerLoc()->halo.up, pre->getLayerLoc()->nf),
@@ -2123,8 +2122,8 @@ int HyPerConn::checkpointRead(const char * cpDir, double * timeptr) {
          pvAssert(status == PV_SUCCESS);
          while(weightUpdateTime <= parent->simulationTime()) {weightUpdateTime += weightUpdatePeriod;}
          if (parent->columnId()==0) {
-            pvWarn().printf("initialWeightUpdateTime of %s \"%s\" less than simulation start time.  Adjusting weightUpdateTime to %f\n",
-                  getKeyword(), name, weightUpdateTime);
+            pvWarn().printf("initialWeightUpdateTime of %s less than simulation start time.  Adjusting weightUpdateTime to %f\n",
+                  getDescription_c(), weightUpdateTime);
          }
       }
    }
@@ -2359,19 +2358,19 @@ int HyPerConn::updateState(double time, double dt){
          //This is implemented as an optimization so weights don't change dramatically as ANNNormalizedErrorLayer values get large.
          if (preTimeScale > 0 && preTimeScale < timeScaleMin) { 
             if (parent->icCommunicator()->commRank()==0) {
-               pvInfo().printf("TimeScale = %f for layer %s batch %d, which is less than your specified dtScaleMin, %f. updateState won't be called for connection \"%s\" this timestep.\n", preTimeScale, pre->getName(), b, timeScaleMin, getName());
+               pvInfo().printf("TimeScale = %f for %s batch %d, which is less than your specified dtScaleMin, %f. updateState won't be called for %s this timestep.\n", preTimeScale, pre->getDescription_c(), b, timeScaleMin, getDescription_c());
             }
             skip = true;
          }
          else if (postTimeScale > 0 && postTimeScale < timeScaleMin) { 
             if (parent->icCommunicator()->commRank()==0) {
-               pvInfo().printf("TimeScale = %f for layer %s batch %d, which is less than your specified dtScaleMin, %f. updateState won't be called for connection \"%s\" this timestep.\n", postTimeScale, post->getName(), b, timeScaleMin, getName());
+               pvInfo().printf("TimeScale = %f for %s batch %d, which is less than your specified dtScaleMin, %f. updateState won't be called for %s this timestep.\n", postTimeScale, post->getDescription_c(), b, timeScaleMin, getDescription_c());
             }
             skip = true;
          }
          else if (colTimeScale > 0 && colTimeScale < timeScaleMin) { 
             if (parent->icCommunicator()->commRank()==0) {
-               pvInfo().printf("TimeScale = %f for column %s batch %d, which is less than your specified dtScaleMin, %f. updateState won't be called for connection \"%s\" this timestep.\n", colTimeScale, parent->getName(), b, timeScaleMin, getName());
+               pvInfo().printf("TimeScale = %f for column %s batch %d, which is less than your specified dtScaleMin, %f. updateState won't be called for %s this timestep.\n", colTimeScale, parent->getName(), b, timeScaleMin, getDescription_c());
             }
             skip = true;
          }
@@ -4296,7 +4295,7 @@ int HyPerConn::writePostSynapticWeights(double timef, bool last) {
         writeCompressedWeights, fileType);
 
    if(status != PV_SUCCESS) {
-      pvError().printf("Connection \"%s\": writePostSynapticWeights failed at time %f.  Exiting.\n", name, timef);
+      pvError().printf("%s: writePostSynapticWeights failed at time %f.  Exiting.\n", getDescription_c(), timef);
    }
 
    return PV_SUCCESS;
@@ -4415,11 +4414,11 @@ pvwdata_t * HyPerConn::allocWeights(int nPatches, int nxPatch, int nyPatch, int 
    if (arborSize / dataSize != numberOfAxonalArborLists()) { overflow = true; }
 
    if (overflow) {
-      pvError().printf("Connection \"%s\" is too big (%d patches of size nxPatch=%d by nyPatch=%d by nfPatch=%d; %d arbors, weight size=%zu bytes).  Exiting.\n",
-            getName(), nPatches, nxPatch, nyPatch, nfPatch, numberOfAxonalArborLists(), sizeof(pvwdata_t));
+      pvError().printf("%s is too big (%d patches of size nxPatch=%d by nyPatch=%d by nfPatch=%d; %d arbors, weight size=%zu bytes).  Exiting.\n",
+            getDescription_c(), nPatches, nxPatch, nyPatch, nfPatch, numberOfAxonalArborLists(), sizeof(pvwdata_t));
    }
 
-   return (pvwdata_t *)pvCallocError(arborSize, sizeof(char), "Error allocating weights for connection \"%s\"", getName());
+   return (pvwdata_t *)pvCallocError(arborSize, sizeof(char), "Error allocating weights for %s", getDescription_c());
 }
 
 int HyPerConn::patchToDataLUT(int patchIndex) {

--- a/src/connections/IdentConn.cpp
+++ b/src/connections/IdentConn.cpp
@@ -106,7 +106,7 @@ void IdentConn::ioParam_writeStep(enum ParamsIOFlag ioFlag) {
          parent->ioParamValue(ioFlag, name, "writeStep", &writeStep, -1.0/*default*/, false/*warnIfAbsent*/);
          if (writeStep>=0) {
             if (parent->columnId()==0) {
-               pvErrorNoExit().printf("%s \"%s\" does not use writeStep, but the parameters file sets it to %f.\n", getKeyword(), getName(), writeStep);
+               pvErrorNoExit().printf("%s does not use writeStep, but the parameters file sets it to %f.\n", getDescription_c(), writeStep);
             }
             MPI_Barrier(parent->icCommunicator()->communicator());
             exit(EXIT_FAILURE);

--- a/src/connections/ImprintConn.cpp
+++ b/src/connections/ImprintConn.cpp
@@ -307,7 +307,7 @@ int ImprintConn::checkpointWrite(const char * cpDir) {
          pvError().printf("Unable to write to \"%s\"\n", filename);
       }
       if (status != PV_SUCCESS) {
-         pvError().printf("Patterns::checkpointWrite error: %s \"%s\" failed writing to %s\n", this->getKeyword(), name, filename);
+         pvError().printf("Patterns::checkpointWrite error: %s failed writing to %s\n", getDescription_c(), filename);
       }
       free(filename); filename=NULL;
    }

--- a/src/connections/PoolingConn.cpp
+++ b/src/connections/PoolingConn.cpp
@@ -107,12 +107,12 @@ void PoolingConn::unsetAccumulateType() {
    if (parent->columnId()==0) {
       pvErrorNoExit(errorMessage);
       if (pvpatchAccumulateTypeString) {
-         errorMessage.printf("%s \"%s\": pvpatchAccumulateType \"%s\" is unrecognized.",
-               getKeyword(), name, pvpatchAccumulateTypeString);
+         errorMessage.printf("%s: pvpatchAccumulateType \"%s\" is unrecognized.",
+               getDescription_c(), pvpatchAccumulateTypeString);
       }
       else {
-         errorMessage.printf("%s \"%s\" error: pvpatchAccumulateType NULL is unrecognized.",
-               getKeyword(), name);
+         errorMessage.printf("%s: pvpatchAccumulateType NULL is unrecognized.",
+               getDescription_c());
       }
       errorMessage.printf("  Allowed values are \"maxpooling\", \"sumpooling\", or \"avgpooling\".");
    }
@@ -207,7 +207,7 @@ int PoolingConn::communicateInitInfo() {
       BaseLayer * basePostIndexLayer = parent->getLayerFromName(this->postIndexLayerName);
       if (basePostIndexLayer==NULL) {
          if (parent->columnId()==0) {
-            pvErrorNoExit().printf("%s \"%s\": postIndexLayerName \"%s\" does not refer to any layer in the column.\n", this->getKeyword(), name, this->postIndexLayerName);
+            pvErrorNoExit().printf("%s: postIndexLayerName \"%s\" does not refer to any layer in the column.\n", getDescription_c(), this->postIndexLayerName);
          }
          MPI_Barrier(parent->icCommunicator()->communicator());
          exit(EXIT_FAILURE);
@@ -216,7 +216,7 @@ int PoolingConn::communicateInitInfo() {
       postIndexLayer = dynamic_cast<PoolingIndexLayer*>(basePostIndexLayer);
       if (postIndexLayer==NULL) {
          if (parent->columnId()==0) {
-            pvErrorNoExit().printf("%s \"%s\": postIndexLayerName \"%s\" is not a PoolingIndexLayer.\n", this->getKeyword(), name, this->postIndexLayerName);
+            pvErrorNoExit().printf("%s: postIndexLayerName \"%s\" is not a PoolingIndexLayer.\n", getDescription_c(), this->postIndexLayerName);
          }
          MPI_Barrier(parent->icCommunicator()->communicator());
          exit(EXIT_FAILURE);
@@ -224,7 +224,7 @@ int PoolingConn::communicateInitInfo() {
 
       if(postIndexLayer->getDataType() != PV_INT){
          if (parent->columnId()==0) {
-            pvErrorNoExit().printf("%s \"%s\": postIndexLayer \"%s\" must have data type of int. Specify parameter dataType in this layer to be \"int\".\n", this->getKeyword(), name, this->postIndexLayerName);
+            pvErrorNoExit().printf("%s: postIndexLayer \"%s\" must have data type of int. Specify parameter dataType in this layer to be \"int\".\n", getDescription_c(), this->postIndexLayerName);
          }
          MPI_Barrier(parent->icCommunicator()->communicator());
          exit(EXIT_FAILURE);
@@ -236,7 +236,7 @@ int PoolingConn::communicateInitInfo() {
       //(margins doesnt matter)
       if(idxLoc->nxGlobal != postLoc->nxGlobal || idxLoc->nyGlobal != postLoc->nyGlobal || idxLoc->nf != postLoc->nf){
          if (parent->columnId()==0) {
-            pvErrorNoExit().printf("%s \"%s\": postIndexLayer \"%s\" must have the same dimensions as the post pooling layer \"%s\".", this->getKeyword(), name, this->postIndexLayerName, this->postLayerName);
+            pvErrorNoExit().printf("%s: postIndexLayer \"%s\" must have the same dimensions as the post pooling layer \"%s\".", getDescription_c(), this->postIndexLayerName, this->postLayerName);
          }
          MPI_Barrier(parent->icCommunicator()->communicator());
          exit(EXIT_FAILURE);

--- a/src/connections/TransposeConn.cpp
+++ b/src/connections/TransposeConn.cpp
@@ -182,7 +182,7 @@ int TransposeConn::communicateInitInfo() {
    BaseConnection * originalConnBase = parent->getConnFromName(this->originalConnName);
    if (originalConnBase==NULL) {
       if (parent->columnId()==0) {
-         pvErrorNoExit().printf("%s \"%s\": originalConnName \"%s\" does not refer to any connection in the column.\n", this->getKeyword(), name, this->originalConnName);
+         pvErrorNoExit().printf("%s: originalConnName \"%s\" does not refer to any connection in the column.\n", getDescription_c(), this->originalConnName);
       }
       MPI_Barrier(parent->icCommunicator()->communicator());
       exit(EXIT_FAILURE);
@@ -190,7 +190,7 @@ int TransposeConn::communicateInitInfo() {
    this->originalConn = dynamic_cast<HyPerConn *>(originalConnBase);
    if (originalConn == NULL) {
       if (parent->columnId()==0) {
-         pvErrorNoExit().printf("TransposeConn \"%s\": originalConnName \"%s\" is not an existing connection.\n", name, originalConnName);
+         pvErrorNoExit().printf("%s: originalConnName \"%s\" is not an existing connection.\n", getDescription_c(), originalConnName);
          status = PV_FAILURE;
       }
    }
@@ -198,8 +198,7 @@ int TransposeConn::communicateInitInfo() {
 
    if (!originalConn->getInitInfoCommunicatedFlag()) {
       if (parent->columnId()==0) {
-         const char * connectiontype = this->getKeyword();
-         pvInfo().printf("%s \"%s\" must wait until original connection \"%s\" has finished its communicateInitInfo stage.\n", connectiontype, name, originalConn->getName());
+         pvInfo().printf("%s must wait until original connection \"%s\" has finished its communicateInitInfo stage.\n", getDescription_c(), originalConn->getName());
       }
       return PV_POSTPONE;
    }
@@ -229,7 +228,7 @@ int TransposeConn::communicateInitInfo() {
    if (preLoc->nx != origPostLoc->nx || preLoc->ny != origPostLoc->ny || preLoc->nf != origPostLoc->nf) {
       if (parent->columnId()==0) {
          pvErrorNoExit(errorMessage);
-         errorMessage.printf("%s \"%s\": transpose's pre layer and original connection's post layer must have the same dimensions.\n", this->getKeyword(), name);
+         errorMessage.printf("%s: transpose's pre layer and original connection's post layer must have the same dimensions.\n", getDescription_c());
          errorMessage.printf("    (x=%d, y=%d, f=%d) versus (x=%d, y=%d, f=%d).\n", preLoc->nx, preLoc->ny, preLoc->nf, origPostLoc->nx, origPostLoc->ny, origPostLoc->nf);
       }
       MPI_Barrier(parent->icCommunicator()->communicator());
@@ -240,7 +239,7 @@ int TransposeConn::communicateInitInfo() {
    if (postLoc->nx != origPreLoc->nx || postLoc->ny != origPreLoc->ny || postLoc->nf != origPreLoc->nf) {
       if (parent->columnId()==0) {
          pvErrorNoExit(errorMessage);
-         errorMessage.printf("%s \"%s\": transpose's post layer and original connection's pre layer must have the same dimensions.\n", this->getKeyword(), name);
+         errorMessage.printf("%s: transpose's post layer and original connection's pre layer must have the same dimensions.\n", getDescription_c());
          errorMessage.printf("    (x=%d, y=%d, f=%d) versus (x=%d, y=%d, f=%d).\n", postLoc->nx, postLoc->ny, postLoc->nf, origPreLoc->nx, origPreLoc->ny, origPreLoc->nf);
       }
       MPI_Barrier(parent->icCommunicator()->communicator());
@@ -331,8 +330,7 @@ int TransposeConn::allocatePostConn(){
 int TransposeConn::allocateDataStructures() {
    if (!originalConn->getDataStructuresAllocatedFlag()) {
       if (parent->columnId()==0) {
-         const char * connectiontype = this->getKeyword();
-         pvInfo().printf("%s \"%s\" must wait until original connection \"%s\" has finished its allocateDataStructures stage.\n", connectiontype, name, originalConn->getName());
+         pvInfo().printf("%s must wait until original connection \"%s\" has finished its allocateDataStructures stage.\n", getDescription_c(), originalConn->getName());
       }
       return PV_POSTPONE;
    }
@@ -486,8 +484,8 @@ int TransposeConn::finalizeUpdate(double timed, double dt){
 //            int yGlobalRes = yGlobalExt-preLocOrig->halo.up;
 //            if (xGlobalRes >= preLocOrig->kx0 && xGlobalRes < preLocOrig->kx0+preLocOrig->nx && yGlobalRes >= preLocOrig->ky0 && yGlobalRes < preLocOrig->ky0+preLocOrig->ny) {
 //               pvError(errorMessage);
-//               errorMessage.printf("Rank %d, connection \"%s\", x=%d, y=%d, neighbor=%d: xGlobalRes = %d, preLocOrig->kx0 = %d, preLocOrig->nx = %d\n", parent->columnId(), name, x, y, neighbor, xGlobalRes, preLocOrig->kx0, preLocOrig->nx);
-//               errorMessage.printf("Rank %d, connection \"%s\", x=%d, y=%d, neighbor=%d: yGlobalRes = %d, preLocOrig->ky0 = %d, preLocOrig->ny = %d\n", parent->columnId(), name, x, y, neighbor, yGlobalRes, preLocOrig->ky0, preLocOrig->ny);
+//               errorMessage.printf("Rank %d, %s, x=%d, y=%d, neighbor=%d: xGlobalRes = %d, preLocOrig->kx0 = %d, preLocOrig->nx = %d\n", parent->columnId(), getDescription_c(), x, y, neighbor, xGlobalRes, preLocOrig->kx0, preLocOrig->nx);
+//               errorMessage.printf("Rank %d, %s, x=%d, y=%d, neighbor=%d: yGlobalRes = %d, preLocOrig->ky0 = %d, preLocOrig->ny = %d\n", parent->columnId(), getDescription_c(), x, y, neighbor, yGlobalRes, preLocOrig->ky0, preLocOrig->ny);
 //            }
 //            int idxGlobalRes = kIndex(xGlobalRes, yGlobalRes, 0, preLocOrig->nxGlobal, preLocOrig->nyGlobal, preLocOrig->nf);
 //            memcpy(b, &idxGlobalRes, sizeof(idxGlobalRes));

--- a/src/connections/TransposePoolingConn.cpp
+++ b/src/connections/TransposePoolingConn.cpp
@@ -194,12 +194,12 @@ void TransposePoolingConn::unsetAccumulateType() {
    if (parent->columnId()==0) {
       pvErrorNoExit(errorMessage);
       if (pvpatchAccumulateTypeString) {
-         errorMessage.printf("%s \"%s\" error: pvpatchAccumulateType \"%s\" is unrecognized.",
-               getKeyword(), name, pvpatchAccumulateTypeString);
+         errorMessage.printf("%s: pvpatchAccumulateType \"%s\" is unrecognized.",
+               getDescription_c(), pvpatchAccumulateTypeString);
       }
       else {
-         errorMessage.printf("%s \"%s\" error: pvpatchAccumulateType NULL is unrecognized.",
-               getKeyword(), name);
+         errorMessage.printf("%s: pvpatchAccumulateType NULL is unrecognized.",
+               getDescription_c());
       }
       errorMessage.printf("  Allowed values are \"maxpooling\", \"sumpooling\", or \"avgpooling\".");
    }
@@ -281,7 +281,7 @@ int TransposePoolingConn::communicateInitInfo() {
    BaseConnection * originalConnBase = parent->getConnFromName(this->originalConnName);
    if (originalConnBase==NULL) {
       if (parent->columnId()==0) {
-         pvErrorNoExit().printf("%s \"%s\": originalConnName \"%s\" does not refer to any connection in the column.\n", this->getKeyword(), name, this->originalConnName);
+         pvErrorNoExit().printf("%s: originalConnName \"%s\" does not refer to any connection in the column.\n", getDescription_c(), this->originalConnName);
       }
       MPI_Barrier(parent->icCommunicator()->communicator());
       exit(EXIT_FAILURE);
@@ -289,7 +289,7 @@ int TransposePoolingConn::communicateInitInfo() {
    originalConn = dynamic_cast<PoolingConn *>(originalConnBase);
    if (originalConn == NULL) {
       if (parent->columnId()==0) {
-         pvErrorNoExit().printf("TransposePoolingConn \"%s\": originalConnName \"%s\" is not a PoolingConn.\n", name, originalConnName);
+         pvErrorNoExit().printf("%s: originalConnName \"%s\" is not a PoolingConn.\n", getDescription_c(), originalConnName);
          status = PV_FAILURE;
       }
    }
@@ -297,8 +297,7 @@ int TransposePoolingConn::communicateInitInfo() {
 
    if (!originalConn->getInitInfoCommunicatedFlag()) {
       if (parent->columnId()==0) {
-         const char * connectiontype = this->getKeyword();
-         pvInfo().printf("%s \"%s\" must wait until original connection \"%s\" has finished its communicateInitInfo stage.\n", connectiontype, name, originalConn->getName());
+         pvInfo().printf("%s must wait until original connection \"%s\" has finished its communicateInitInfo stage.\n", getDescription_c(), originalConn->getName());
       }
       return PV_POSTPONE;
    }
@@ -346,7 +345,7 @@ int TransposePoolingConn::communicateInitInfo() {
    if (preLoc->nx != origPostLoc->nx || preLoc->ny != origPostLoc->ny || preLoc->nf != origPostLoc->nf) {
       if (parent->columnId()==0) {
          pvErrorNoExit(errorMessage);
-         errorMessage.printf("%s \"%s\": transpose's pre layer and original connection's post layer must have the same dimensions.\n", this->getKeyword(), name);
+         errorMessage.printf("%s: transpose's pre layer and original connection's post layer must have the same dimensions.\n", getDescription_c());
          errorMessage.printf("    (x=%d, y=%d, f=%d) versus (x=%d, y=%d, f=%d).\n", preLoc->nx, preLoc->ny, preLoc->nf, origPostLoc->nx, origPostLoc->ny, origPostLoc->nf);
       }
       MPI_Barrier(parent->icCommunicator()->communicator());
@@ -357,7 +356,7 @@ int TransposePoolingConn::communicateInitInfo() {
    if (postLoc->nx != origPreLoc->nx || postLoc->ny != origPreLoc->ny || postLoc->nf != origPreLoc->nf) {
       if (parent->columnId()==0) {
          pvErrorNoExit(errorMessage);
-         errorMessage.printf("%s \"%s\": transpose's post layer and original connection's pre layer must have the same dimensions.\n", this->getKeyword(), name);
+         errorMessage.printf("%s: transpose's post layer and original connection's pre layer must have the same dimensions.\n", getDescription_c());
          errorMessage.printf("    (x=%d, y=%d, f=%d) versus (x=%d, y=%d, f=%d).\n", postLoc->nx, postLoc->ny, postLoc->nf, origPreLoc->nx, origPreLoc->ny, origPreLoc->nf);
       }
       MPI_Barrier(parent->icCommunicator()->communicator());
@@ -384,7 +383,7 @@ int TransposePoolingConn::communicateInitInfo() {
       int allowedDelay = originalConn->getPostIndexLayer()->increaseDelayLevels(getDelayArraySize());
       if( allowedDelay < getDelayArraySize()) {
          if( this->getParent()->columnId() == 0 ) {
-            pvErrorNoExit().printf("Connection \"%s\": attempt to set delay to %d, but the maximum allowed delay is %d.  Exiting\n", this->getName(), getDelayArraySize(), allowedDelay);
+            pvErrorNoExit().printf("%s: attempt to set delay to %d, but the maximum allowed delay is %d.  Exiting\n", this->getDescription_c(), getDelayArraySize(), allowedDelay);
          }
          exit(EXIT_FAILURE);
       }
@@ -439,8 +438,7 @@ int TransposePoolingConn::setPatchSize() {
 int TransposePoolingConn::allocateDataStructures() {
    if (!originalConn->getDataStructuresAllocatedFlag()) {
       if (parent->columnId()==0) {
-         const char * connectiontype = this->getKeyword();
-         pvInfo().printf("%s \"%s\" must wait until original connection \"%s\" has finished its allocateDataStructures stage.\n", connectiontype, name, originalConn->getName());
+         pvInfo().printf("%s must wait until original connection \"%s\" has finished its allocateDataStructures stage.\n", getDescription_c(), originalConn->getName());
       }
       return PV_POSTPONE;
    }

--- a/src/connections/privateTransposeConn.hpp
+++ b/src/connections/privateTransposeConn.hpp
@@ -29,6 +29,7 @@ public:
 
 protected:
     int initialize(const char * name, HyPerCol * hc, HyPerConn * parentConn, bool needWeights);
+    virtual int setDescription();
     virtual int ioParamsFillGroup(enum ParamsIOFlag ioFlag);
     virtual int setPatchSize();
     virtual int setNeededRNGSeeds() {return 0;}

--- a/src/io/AbstractNormProbe.cpp
+++ b/src/io/AbstractNormProbe.cpp
@@ -61,8 +61,8 @@ int AbstractNormProbe::communicateInitInfo() {
       maskLayer = parent->getLayerFromName(maskLayerName);
       if (maskLayer==NULL) {
          if (parent->columnId()==0) {
-            pvErrorNoExit().printf("%s \"%s\": maskLayerName \"%s\" is not a layer in the HyPerCol.\n",
-                    this->getKeyword(), name, maskLayerName);
+            pvErrorNoExit().printf("%s: maskLayerName \"%s\" is not a layer in the HyPerCol.\n",
+                  getDescription_c(), maskLayerName);
          }
          MPI_Barrier(parent->icCommunicator()->communicator());
          exit(EXIT_FAILURE);
@@ -74,8 +74,8 @@ int AbstractNormProbe::communicateInitInfo() {
       if (maskLoc->nxGlobal != loc->nxGlobal || maskLoc->nyGlobal != loc->nyGlobal) {
          if (parent->columnId()==0) {
             pvErrorNoExit(maskLayerBadSize);
-            maskLayerBadSize.printf("%s \"%s\": maskLayerName \"%s\" does not have the same x and y dimensions.\n",
-                    this->getKeyword(), name, maskLayerName);
+            maskLayerBadSize.printf("%s: maskLayerName \"%s\" does not have the same x and y dimensions.\n",
+                  getDescription_c(), maskLayerName);
             maskLayerBadSize.printf("    original (nx=%d, ny=%d, nf=%d) versus (nx=%d, ny=%d, nf=%d)\n",
                     maskLoc->nxGlobal, maskLoc->nyGlobal, maskLoc->nf, loc->nxGlobal, loc->nyGlobal, loc->nf);
          }
@@ -86,8 +86,8 @@ int AbstractNormProbe::communicateInitInfo() {
       if(maskLoc->nf != 1 && maskLoc->nf != loc->nf){
          if (parent->columnId()==0) {
             pvErrorNoExit(maskLayerBadSize);
-            maskLayerBadSize.printf("%s \"%s\": maskLayerName \"%s\" must either have the same number of features as this layer, or one feature.\n",
-                    this->getKeyword(), name, maskLayerName);
+            maskLayerBadSize.printf("%s: maskLayerName \"%s\" must either have the same number of features as this layer, or one feature.\n",
+                  getDescription_c(), maskLayerName);
             maskLayerBadSize.printf("    original (nx=%d, ny=%d, nf=%d) versus (nx=%d, ny=%d, nf=%d)\n",
                     maskLoc->nxGlobal, maskLoc->nyGlobal, maskLoc->nf, loc->nxGlobal, loc->nyGlobal, loc->nf);
          }

--- a/src/io/BaseConnectionProbe.cpp
+++ b/src/io/BaseConnectionProbe.cpp
@@ -52,8 +52,8 @@ int BaseConnectionProbe::setTargetConn(const char * connName) {
    int status = PV_SUCCESS;
    targetConn = getParent()->getConnFromName(connName);
    if (targetConn==NULL) {
-      pvErrorNoExit().printf("BaseConnectionProbe \"%s\", rank %d process: targetConnection \"%s\" is not a connection in the HyPerCol.\n",
-            name, getParent()->columnId(), connName);
+      pvErrorNoExit().printf("%s, rank %d process: targetConnection \"%s\" is not a connection in the HyPerCol.\n",
+            getDescription_c(), getParent()->columnId(), connName);
       status = PV_FAILURE;
    }
    MPI_Barrier(getParent()->icCommunicator()->communicator());

--- a/src/io/BaseHyPerConnProbe.cpp
+++ b/src/io/BaseHyPerConnProbe.cpp
@@ -33,8 +33,8 @@ int BaseHyPerConnProbe::communicateInitInfo() {
    targetHyPerConn = dynamic_cast<HyPerConn *>(targetConn);
    if (targetHyPerConn==NULL) {
       if (parent->columnId()==0) {
-         pvErrorNoExit().printf("%s \"%s\": targetConn \"%s\" must be a HyPerConn or HyPerConn-derived class.\n",
-               this->getKeyword(), this->getName(), targetConn->getName());
+         pvErrorNoExit().printf("%s: targetConn \"%s\" must be a HyPerConn or HyPerConn-derived class.\n",
+               getDescription_c(), targetConn->getName());
       }
       status = PV_FAILURE;
    }

--- a/src/io/BaseProbe.cpp
+++ b/src/io/BaseProbe.cpp
@@ -141,12 +141,12 @@ void BaseProbe::ioParam_triggerFlag(enum ParamsIOFlag ioFlag) {
       parent->ioParamValue(ioFlag, name, "triggerFlag", &flagFromParams, flagFromParams);
       if (parent->columnId()==0) {
          pvWarn(triggerFlagDeprecated);
-         triggerFlagDeprecated.printf("Layer \"%s\": triggerFlag has been deprecated.\n", name);
+         triggerFlagDeprecated.printf("%s: triggerFlag has been deprecated.\n", getDescription_c());
          triggerFlagDeprecated.printf("   If triggerLayerName is a nonempty string, triggering will be on;\n");
          triggerFlagDeprecated.printf("   if triggerLayerName is empty or null, triggering will be off.\n");
          if (flagFromParams!=triggerFlag) {
             pvErrorNoExit(triggerFlagError);
-            triggerFlagError.printf("Layer \"%s\" Error: triggerLayerName=", name);
+            triggerFlagError.printf("%s: triggerLayerName=", getDescription_c());
             if (triggerLayerName) { triggerFlagError.printf("\"%s\"", triggerLayerName); }
             else { triggerFlagError.printf("NULL"); }
             triggerFlagError.printf(" implies triggerFlag=%s but triggerFlag was set in params to %s\n",

--- a/src/io/ColumnEnergyProbe.cpp
+++ b/src/io/ColumnEnergyProbe.cpp
@@ -56,8 +56,8 @@ int ColumnEnergyProbe::addTerm(BaseProbe * probe) {
       if (newNumValues < 0) {
          status = PV_FAILURE;
          if (parent->columnId()==0) {
-            pvErrorNoExit().printf("%s \"%s\": probe \"%s\" cannot be used as a term of the energy probe (getNumValue() returned a negative number).\n",
-               getKeyword(), getName(), probe->getName());
+            pvErrorNoExit().printf("%s: %s cannot be used as a term of the energy probe (getNumValue() returned a negative number).\n",
+                  getDescription_c(), probe->getDescription_c());
          }
          MPI_Barrier(parent->icCommunicator()->communicator());
          exit(EXIT_FAILURE);
@@ -65,8 +65,8 @@ int ColumnEnergyProbe::addTerm(BaseProbe * probe) {
       if (newNumValues != this->getNumValues()) {
          status = setNumValues(newNumValues);
          if (status != PV_SUCCESS) {
-            pvErrorNoExit().printf("%s \"%s\": unable to allocate memory for %d probe values: %s\n",
-                  this->getKeyword(), this->getName(), newNumValues, strerror(errno));
+            pvErrorNoExit().printf("%s: unable to allocate memory for %d probe values: %s\n",
+                  getDescription_c(), newNumValues, strerror(errno));
             exit(EXIT_FAILURE);
          }
       }
@@ -74,8 +74,8 @@ int ColumnEnergyProbe::addTerm(BaseProbe * probe) {
    else {
       if (probe->getNumValues() != this->getNumValues()) {
          if (this->getParent()->columnId()==0) {
-            pvErrorNoExit().printf("Failed to add terms to %s \%s\":  new probe \"%s\" returns %d values, but previous probes return %d values\n",
-                  getKeyword(), getName(), probe->getName(), probe->getNumValues(), this->getNumValues());
+            pvErrorNoExit().printf("Failed to add terms to %s:  new probe \"%s\" returns %d values, but previous probes return %d values\n",
+                  getDescription_c(), probe->getName(), probe->getNumValues(), this->getNumValues());
          }
          MPI_Barrier(this->getParent()->icCommunicator()->communicator());
          exit(EXIT_FAILURE);
@@ -85,16 +85,16 @@ int ColumnEnergyProbe::addTerm(BaseProbe * probe) {
    int newNumTerms = numTerms+(size_t) 1;
    if (newNumTerms<=numTerms) {
       if (this->getParent()->columnId()==0) {
-         pvErrorNoExit().printf("How did you manage to add %zu terms to %s \"%s\"?  Unable to add any more!\n",
-               numTerms, getKeyword(), getName());
+         pvErrorNoExit().printf("How did you manage to add %zu terms to %s?  Unable to add any more!\n",
+               numTerms, getDescription_c());
       }
       MPI_Barrier(this->getParent()->icCommunicator()->communicator());
       exit(EXIT_FAILURE);
    }
    BaseProbe ** newTermsArray = (BaseProbe **) realloc(terms, (numTerms+(size_t) 1)*sizeof(BaseProbe *));
    if (newTermsArray==NULL) {
-      pvErrorNoExit().printf("%s \"%s\": unable to add term %zu (\"%s\"): %s\n",
-         getKeyword(), getName(), numTerms+(size_t) 1, probe->getName(),
+      pvErrorNoExit().printf("%s: unable to add term %zu (\"%s\"): %s\n",
+            getDescription_c(), numTerms+(size_t) 1, probe->getName(),
          strerror(errno));
       exit(EXIT_FAILURE);
    }

--- a/src/io/FirmThresholdCostFnLCAProbe.cpp
+++ b/src/io/FirmThresholdCostFnLCAProbe.cpp
@@ -25,16 +25,16 @@ int FirmThresholdCostFnLCAProbe::communicateInitInfo() {
    HyPerLCALayer * targetLCALayer = dynamic_cast<HyPerLCALayer *>(targetLayer);
    if (targetLCALayer==nullptr) {
       if (parent->columnId()==0) {
-         pvErrorNoExit().printf("%s \"%s\": targetLayer \"%s\" is not an LCA layer.\n",
-               getKeyword(), getName(), getTargetName());
+         pvErrorNoExit().printf("%s: targetLayer \"%s\" is not an LCA layer.\n",
+               getDescription_c(), getTargetName());
       }
       MPI_Barrier(parent->icCommunicator()->communicator());
       exit(EXIT_FAILURE);
    }
    if (targetLCALayer->layerListsVerticesInParams()==true) {
       if (parent->columnId()==0) {
-         pvErrorNoExit().printf("%s \"%s\": LCAProbes require targetLayer \"%s\" to use VThresh etc. instead of verticesV/verticesV.\n",
-               getKeyword(), getName(), getTargetName());
+         pvErrorNoExit().printf("%s: LCAProbes require targetLayer \"%s\" to use VThresh etc. instead of verticesV/verticesV.\n",
+               getDescription_c(), getTargetName());
       }
       MPI_Barrier(parent->icCommunicator()->communicator());
       exit(EXIT_FAILURE);

--- a/src/io/KernelProbe.cpp
+++ b/src/io/KernelProbe.cpp
@@ -72,7 +72,7 @@ int KernelProbe::communicateInitInfo() {
    assert(targetHyPerConn);
    if(getTargetHyPerConn()->usingSharedWeights()==false) {
       if (parent->columnId()==0) {
-         pvErrorNoExit().printf("KernelProbe \"%s\": connection \"%s\" is not using shared weights.\n", name, targetConn->getName());
+         pvErrorNoExit().printf("%s: %s is not using shared weights.\n", getDescription_c(), targetConn->getDescription_c());
       }
       status = PV_FAILURE;
    }

--- a/src/io/L0NormLCAProbe.cpp
+++ b/src/io/L0NormLCAProbe.cpp
@@ -25,16 +25,16 @@ int L0NormLCAProbe::communicateInitInfo() {
    HyPerLCALayer * targetLCALayer = dynamic_cast<HyPerLCALayer *>(targetLayer);
    if (targetLCALayer==NULL) {
       if (parent->columnId()==0) {
-         pvErrorNoExit().printf("%s \"%s\": targetLayer \"%s\" is not an LCA layer.\n",
-               getKeyword(), getName(), getTargetName());
+         pvErrorNoExit().printf("%s: targetLayer \"%s\" is not an LCA layer.\n",
+               getDescription_c(), getTargetName());
       }
       MPI_Barrier(parent->icCommunicator()->communicator());
       exit(EXIT_FAILURE);
    }
    if (targetLCALayer->layerListsVerticesInParams()==true) {
       if (parent->columnId()==0) {
-         pvErrorNoExit().printf("%s \"%s\": LCAProbes require targetLayer \"%s\" to use VThresh etc. instead of verticesV/verticesV.\n",
-               getKeyword(), getName(), getTargetName());
+         pvErrorNoExit().printf("%s: LCAProbes require targetLayer \"%s\" to use VThresh etc. instead of verticesV/verticesV.\n",
+               getDescription_c(), getTargetName());
       }
       MPI_Barrier(parent->icCommunicator()->communicator());
       exit(EXIT_FAILURE);

--- a/src/io/L1NormLCAProbe.cpp
+++ b/src/io/L1NormLCAProbe.cpp
@@ -25,16 +25,16 @@ int L1NormLCAProbe::communicateInitInfo() {
    HyPerLCALayer * targetLCALayer = dynamic_cast<HyPerLCALayer *>(targetLayer);
    if (targetLCALayer==NULL) {
       if (parent->columnId()==0) {
-         pvErrorNoExit().printf("%s \"%s\": targetLayer \"%s\" is not an LCA layer.\n",
-               getKeyword(), getName(), getTargetName());
+         pvErrorNoExit().printf("%s: targetLayer \"%s\" is not an LCA layer.\n",
+               getDescription_c(), getTargetName());
       }
       MPI_Barrier(parent->icCommunicator()->communicator());
       exit(EXIT_FAILURE);
    }
    if (targetLCALayer->layerListsVerticesInParams()==true) {
       if (parent->columnId()==0) {
-         pvErrorNoExit().printf("%s \"%s\": LCAProbes require targetLayer \"%s\" to use VThresh etc. instead of verticesV/verticesV.\n",
-               getKeyword(), getName(), getTargetName());
+         pvErrorNoExit().printf("%s: LCAProbes require targetLayer \"%s\" to use VThresh etc. instead of verticesV/verticesV.\n",
+               getDescription_c(), getTargetName());
       }
       MPI_Barrier(parent->icCommunicator()->communicator());
       exit(EXIT_FAILURE);

--- a/src/io/LayerProbe.cpp
+++ b/src/io/LayerProbe.cpp
@@ -68,8 +68,8 @@ int LayerProbe::setTargetLayer(const char * layerName) {
    targetLayer = parent->getLayerFromName(layerName);
    if (targetLayer==NULL) {
       if (parent->columnId()==0) {
-         pvErrorNoExit().printf("%s \"%s\": targetLayer \"%s\" is not a layer in the column.\n",
-               this->getKeyword(), name, layerName);
+         pvErrorNoExit().printf("%s: targetLayer \"%s\" is not a layer in the column.\n",
+               getDescription_c(), layerName);
       }
       MPI_Barrier(parent->icCommunicator()->communicator());
       exit(EXIT_FAILURE);

--- a/src/io/QuotientColProbe.cpp
+++ b/src/io/QuotientColProbe.cpp
@@ -77,10 +77,10 @@ int QuotientColProbe::communicateInitInfo() {
       status = PV_FAILURE;
       if (parent->columnId()==0) {
          if (numerProbe==NULL) {
-            pvErrorNoExit().printf("%s \"%s\": numerator probe \"%s\" could not be found.\n", getKeyword(), getName(), numerator);
+            pvErrorNoExit().printf("%s: numerator probe \"%s\" could not be found.\n", getDescription_c(), numerator);
          }
          if (denomProbe==NULL) {
-            pvErrorNoExit().printf("%s \"%s\": denominator probe \"%s\" could not be found.\n", getKeyword(), getName(), denominator);
+            pvErrorNoExit().printf("%s: denominator probe \"%s\" could not be found.\n", getDescription_c(), denominator);
          }
       }
    }

--- a/src/io/QuotientColProbe.cpp
+++ b/src/io/QuotientColProbe.cpp
@@ -89,16 +89,16 @@ int QuotientColProbe::communicateInitInfo() {
       int dNumValues = denomProbe->getNumValues();
       if (nNumValues != dNumValues) {
          if (parent->columnId()==0) {
-            pvErrorNoExit().printf("%s \"%s\": numerator probe \"%s\" and denominator probe \"%s\" have differing numbers of values (%d vs. %d)\n",
-                  getKeyword(), getName(), numerator, denominator, nNumValues, dNumValues);
+            pvErrorNoExit().printf("%s: numerator probe \"%s\" and denominator probe \"%s\" have differing numbers of values (%d vs. %d)\n",
+                  getDescription_c(), numerator, denominator, nNumValues, dNumValues);
          }
          MPI_Barrier(this->getParent()->icCommunicator()->communicator());
          exit(EXIT_FAILURE);
       }
       status = setNumValues(nNumValues);
       if (status != PV_SUCCESS) {
-         pvErrorNoExit().printf("%s \"%s\": unable to allocate memory for %d values: %s\n",
-               this->getKeyword(), this->getName(), nNumValues, strerror(errno));
+         pvErrorNoExit().printf("%s: unable to allocate memory for %d values: %s\n",
+               this->getDescription_c(), nNumValues, strerror(errno));
          exit(EXIT_FAILURE);
       }
    }

--- a/src/io/RequireAllZeroActivityProbe.cpp
+++ b/src/io/RequireAllZeroActivityProbe.cpp
@@ -70,7 +70,7 @@ int RequireAllZeroActivityProbe::outputState(double timed) {
 void RequireAllZeroActivityProbe::nonzeroFoundMessage(double badTime, bool isRoot, bool fatalError) {
    if (isRoot) {
       std::stringstream message("");
-      message << getKeyword() << " \"" << name << "\": Nonzero activity found at time " << badTime << "\n";
+      message << getDescription_c() << ": Nonzero activity found at time " << badTime << "\n";
       if (fatalError) {
          pvError() << message.str();
       }

--- a/src/io/StatsProbe.cpp
+++ b/src/io/StatsProbe.cpp
@@ -174,8 +174,8 @@ void StatsProbe::ioParam_buffer(enum ParamsIOFlag ioFlag) {
          if (getParent()->columnId()==0) {
             const char * bufnameinparams = getParent()->parameters()->stringValue(getName(), "buffer");
             assert(bufnameinparams);
-            pvErrorNoExit().printf("%s \"%s\": buffer \"%s\" is not recognized.\n",
-                  this->getKeyword(), getName(), bufnameinparams);
+            pvErrorNoExit().printf("%s: buffer \"%s\" is not recognized.\n",
+                  getDescription_c(), bufnameinparams);
          }
          MPI_Barrier(getParent()->icCommunicator()->communicator());
          exit(EXIT_FAILURE);

--- a/src/layers/ANNErrorLayer.cpp
+++ b/src/layers/ANNErrorLayer.cpp
@@ -87,8 +87,8 @@ int ANNErrorLayer::setVertices() {
       verticesV = (pvpotentialdata_t *) malloc((size_t) numVertices * sizeof(*verticesV));
       verticesA = (pvadata_t *) malloc((size_t) numVertices * sizeof(*verticesA));
       if (verticesV==NULL || verticesA==NULL) {
-         pvError().printf("%s \"%s\": unable to allocate memory for vertices: %s\n",
-               getKeyword(), name, strerror(errno));
+         pvError().printf("%s: unable to allocate memory for vertices: %s\n",
+               getDescription_c(), strerror(errno));
       }
       verticesV[0] = -VThresh; verticesA[0] = -VThresh;
       verticesV[1] = -VThresh; verticesA[1] = 0.0;
@@ -101,8 +101,8 @@ int ANNErrorLayer::setVertices() {
       verticesV = (pvpotentialdata_t *) malloc((size_t) numVertices * sizeof(*verticesV));
       verticesA = (pvadata_t *) malloc((size_t) numVertices * sizeof(*verticesA));
       if (verticesV==NULL || verticesA==NULL) {
-         pvError().printf("%s \"%s\": unable to allocate memory for vertices: %s\n",
-               getKeyword(), name, strerror(errno));
+         pvError().printf("%s: unable to allocate memory for vertices: %s\n",
+               getDescription_c(), strerror(errno));
       }
       verticesV[0] = 0.0f; verticesA[0] = 0.0f;
    }
@@ -113,8 +113,8 @@ int ANNErrorLayer::checkVertices() const {
    int status = PV_SUCCESS;
    if (VThresh < 0 && VThresh > -0.999*max_pvvdata_t) { // 0.999 is to allow for imprecision from params files using 3.40282e+38 instead of infinity
       if (parent->columnId()==0) {
-         pvErrorNoExit().printf("%s \"%s\": VThresh cannot be negative (value is %f).\n",
-                  this->getKeyword(), this->getName(), VThresh);
+         pvErrorNoExit().printf("%s: VThresh cannot be negative (value is %f).\n",
+               getDescription_c(), VThresh);
       }
       status = PV_FAILURE;
    }

--- a/src/layers/ANNLayer.cpp
+++ b/src/layers/ANNLayer.cpp
@@ -124,16 +124,16 @@ void ANNLayer::ioParam_verticesV(enum ParamsIOFlag ioFlag) {
    if (ioFlag==PARAMS_IO_READ) {
       if (numVerticesTmp==0) {
          if (this->getParent()->columnId()==0) {
-            pvErrorNoExit().printf("%s \"%s\" error: verticesV cannot be empty\n",
-                  this->getKeyword(), this->getName());
+            pvErrorNoExit().printf("%s: verticesV cannot be empty\n",
+                  getDescription_c());
          }
          MPI_Barrier(this->getParent()->icCommunicator()->communicator());
          exit(EXIT_FAILURE);
       }
       if (numVertices !=0 && numVerticesTmp != numVertices) {
          if (this->getParent()->columnId()==0) {
-            pvErrorNoExit().printf("%s \"%s\" error: verticesV (%d elements) and verticesA (%d elements) must have the same lengths.\n",
-                  this->getKeyword(), this->getName(), numVerticesTmp, numVertices);
+            pvErrorNoExit().printf("%s: verticesV (%d elements) and verticesA (%d elements) must have the same lengths.\n",
+                  getDescription_c(), numVerticesTmp, numVertices);
          }
          MPI_Barrier(this->getParent()->icCommunicator()->communicator());
          exit(EXIT_FAILURE);
@@ -150,16 +150,16 @@ void ANNLayer::ioParam_verticesA(enum ParamsIOFlag ioFlag) {
    if (ioFlag==PARAMS_IO_READ) {
       if (numVerticesA==0) {
          if (this->getParent()->columnId()==0) {
-            pvErrorNoExit().printf("%s \"%s\" error: verticesA cannot be empty\n",
-                  this->getKeyword(), this->getName());
+            pvErrorNoExit().printf("%s: verticesA cannot be empty\n",
+                  getDescription_c());
          }
          MPI_Barrier(this->getParent()->icCommunicator()->communicator());
          exit(EXIT_FAILURE);
       }
       if (numVertices !=0 && numVerticesA != numVertices) {
          if (this->getParent()->columnId()==0) {
-            pvErrorNoExit().printf("%s \"%s\" error: verticesV (%d elements) and verticesA (%d elements) must have the same lengths.\n",
-                  this->getKeyword(), this->getName(), numVertices, numVerticesA);
+            pvErrorNoExit().printf("%s: verticesV (%d elements) and verticesA (%d elements) must have the same lengths.\n",
+                  getDescription_c(), numVertices, numVerticesA);
          }
          MPI_Barrier(this->getParent()->icCommunicator()->communicator());
          exit(EXIT_FAILURE);
@@ -218,8 +218,8 @@ int ANNLayer::setVertices() {
       VThresh += VWidth;
       VWidth = -VWidth;
       if (parent->columnId()==0) {
-         pvWarn().printf("%s \"%s\": interpreting negative VWidth as setting VThresh=%f and VWidth=%f\n",
-               getKeyword(), name, VThresh, VWidth);
+         pvWarn().printf("%s: interpreting negative VWidth as setting VThresh=%f and VWidth=%f\n",
+               getDescription_c(), VThresh, VWidth);
       }
    }
 
@@ -229,12 +229,12 @@ int ANNLayer::setVertices() {
    if (AMin > limfromright) {
       if (parent->columnId()==0) {
          if (VWidth==0) {
-            pvWarn().printf("%s \"%s\": nonmonotonic transfer function, jumping from %f to %f at Vthresh=%f\n",
-                  getKeyword(), name, AMin, limfromright, VThresh);
+            pvWarn().printf("%s: nonmonotonic transfer function, jumping from %f to %f at Vthresh=%f\n",
+                  getDescription_c(), AMin, limfromright, VThresh);
          }
          else {
-            pvWarn().printf("%s \"%s\": nonmonotonic transfer function, changing from %f to %f as V goes from VThresh=%f to VThresh+VWidth=%f\n",
-                  getKeyword(), name, AMin, limfromright, VThresh, VThresh+VWidth);
+            pvWarn().printf("%s: nonmonotonic transfer function, changing from %f to %f as V goes from VThresh=%f to VThresh+VWidth=%f\n",
+                  getDescription_c(), AMin, limfromright, VThresh, VThresh+VWidth);
          }
       }
    }
@@ -326,8 +326,8 @@ int ANNLayer::setVertices() {
    verticesV = (pvpotentialdata_t *) malloc((size_t) numVertices * sizeof(*verticesV));
    verticesA = (pvadata_t *) malloc((size_t) numVertices * sizeof(*verticesA));
    if (verticesV==NULL || verticesA==NULL) {
-      pvErrorNoExit().printf("%s \"%s\": unable to allocate memory for vertices:%s\n",
-            getKeyword(), name, strerror(errno));
+      pvErrorNoExit().printf("%s: unable to allocate memory for vertices:%s\n",
+            getDescription_c(), strerror(errno));
       exit(EXIT_FAILURE);
    }
    memcpy(verticesV, &vectorV[0], numVertices * sizeof(*verticesV));
@@ -341,8 +341,8 @@ void ANNLayer::setSlopes() {
    pvAssert(verticesA!=nullptr);
    pvAssert(verticesV!=nullptr);
    slopes = (float *) pvMallocError((size_t)(numVertices+1)*sizeof(*slopes),
-         "%s \"%s\": unable to allocate memory for transfer function slopes: %s\n",
-         this->getKeyword(), name, strerror(errno));
+         "%s: unable to allocate memory for transfer function slopes: %s\n",
+         getDescription_c(), strerror(errno));
    slopes[0] = slopeNegInf;
    for (int k=1; k<numVertices; k++) {
       float V1 = verticesV[k-1];
@@ -365,14 +365,14 @@ int ANNLayer::checkVertices() const {
       if (verticesV[v] < verticesV[v-1]) {
          status = PV_FAILURE;
          if (this->getParent()->columnId()==0) {
-            pvErrorNoExit().printf("%s \"%s\": vertices %d and %d: V-coordinates decrease from %f to %f.\n",
-                  this->getKeyword(), this->getName(), v, v+1, verticesV[v-1], verticesV[v]);
+            pvErrorNoExit().printf("%s: vertices %d and %d: V-coordinates decrease from %f to %f.\n",
+                  getDescription_c(), v, v+1, verticesV[v-1], verticesV[v]);
          }
       }
       if (verticesA[v] < verticesA[v-1]) {
          if (this->getParent()->columnId()==0) {
-            pvWarn().printf("%s \"%s\": vertices %d and %d: A-coordinates decrease from %f to %f.\n",
-                  this->getKeyword(), this->getName(), v, v+1, verticesA[v-1], verticesA[v]);
+            pvWarn().printf("%s: vertices %d and %d: A-coordinates decrease from %f to %f.\n",
+                  getDescription_c(), v, v+1, verticesA[v-1], verticesA[v]);
          }
       }
    }

--- a/src/layers/BackgroundLayer.cpp
+++ b/src/layers/BackgroundLayer.cpp
@@ -42,8 +42,8 @@ int BackgroundLayer::communicateInitInfo() {
    originalLayer = parent->getLayerFromName(originalLayerName);
    if (originalLayer==NULL) {
       if (parent->columnId()==0) {
-         pvErrorNoExit().printf("%s \"%s\": originalLayerName \"%s\" is not a layer in the HyPerCol.\n",
-                 getKeyword(), name, originalLayerName);
+         pvErrorNoExit().printf("%s: originalLayerName \"%s\" is not a layer in the HyPerCol.\n",
+               getDescription_c(), originalLayerName);
       }
       MPI_Barrier(parent->icCommunicator()->communicator());
       exit(EXIT_FAILURE);
@@ -55,8 +55,8 @@ int BackgroundLayer::communicateInitInfo() {
    if (srcLoc->nxGlobal != loc->nxGlobal || srcLoc->nyGlobal != loc->nyGlobal) {
       if (parent->columnId()==0) {
          pvErrorNoExit(errorMessage);
-         errorMessage.printf("%s \"%s\": originalLayerName \"%s\" does not have the same X/Y dimensions.\n",
-                 getKeyword(), name, originalLayerName);
+         errorMessage.printf("%s: originalLayerName \"%s\" does not have the same X/Y dimensions.\n",
+               getDescription_c(), originalLayerName);
          errorMessage.printf("    original (nx=%d, ny=%d, nf=%d) versus (nx=%d, ny=%d, nf=%d)\n",
                  srcLoc->nxGlobal, srcLoc->nyGlobal, srcLoc->nf, loc->nxGlobal, loc->nyGlobal, loc->nf);
       }
@@ -66,8 +66,8 @@ int BackgroundLayer::communicateInitInfo() {
    if ((srcLoc->nf + 1)*repFeatureNum != loc->nf) {
       if (parent->columnId()==0) {
          pvErrorNoExit(errorMessage);
-         errorMessage.printf("%s \"%s\": nf must have (n+1)*repFeatureNum (%d) features in BackgroundLayer \"%s\", where n is the orig layer number of features.\n",
-                 getKeyword(), name, (srcLoc->nf+1)*repFeatureNum, originalLayerName);
+         errorMessage.printf("%s: nf must have (n+1)*repFeatureNum (%d) features in BackgroundLayer \"%s\", where n is the orig layer number of features.\n",
+               getDescription_c(), (srcLoc->nf+1)*repFeatureNum, originalLayerName);
          errorMessage.printf("    original (nx=%d, ny=%d, nf=%d) versus (nx=%d, ny=%d, nf=%d)\n",
                  srcLoc->nxGlobal, srcLoc->nyGlobal, srcLoc->nf, loc->nxGlobal, loc->nyGlobal, loc->nf);
       }

--- a/src/layers/BaseInput.cpp
+++ b/src/layers/BaseInput.cpp
@@ -174,8 +174,8 @@ void BaseInput::ioParam_aspectRatioAdjustment(enum ParamsIOFlag ioFlag) {
       }
       if (strcmp(aspectRatioAdjustment, "crop") && strcmp(aspectRatioAdjustment, "pad")) {
          if (parent->columnId()==0) {
-            pvErrorNoExit().printf("%s \"%s\": aspectRatioAdjustment must be either \"crop\" or \"pad\".\n",
-                  getKeyword(), name);
+            pvErrorNoExit().printf("%s: aspectRatioAdjustment must be either \"crop\" or \"pad\".\n",
+                  getDescription_c());
          }
          MPI_Barrier(parent->icCommunicator()->communicator());
          exit(EXIT_FAILURE);
@@ -199,8 +199,8 @@ void BaseInput::ioParam_interpolationMethod(enum ParamsIOFlag ioFlag) {
          }
          else {
             if (parent->columnId()==0) {
-               pvErrorNoExit().printf("%s \"%s\": interpolationMethod must be either \"bicubic\" or \"nearestNeighbor\".\n",
-                     getKeyword(), name);
+               pvErrorNoExit().printf("%s: interpolationMethod must be either \"bicubic\" or \"nearestNeighbor\".\n",
+                     getDescription_c());
             }
             MPI_Barrier(parent->icCommunicator()->communicator());
             exit(EXIT_FAILURE);
@@ -300,8 +300,8 @@ void BaseInput::ioParam_biasConstraintMethod(enum ParamsIOFlag ioFlag) {
    if (jitterFlag) {
       parent->ioParamValue(ioFlag, name, "biasConstraintMethod", &biasConstraintMethod, biasConstraintMethod);
       if (ioFlag == PARAMS_IO_READ && (biasConstraintMethod <0 || biasConstraintMethod >3)) {
-         pvError().printf("%s \"%s\": biasConstraintMethod allowed values are 0 (ignore), 1 (mirror BC), 2 (threshold), 3 (circular BC)\n",
-               getKeyword(), getName());
+         pvError().printf("%s: biasConstraintMethod allowed values are 0 (ignore), 1 (mirror BC), 2 (threshold), 3 (circular BC)\n",
+               getDescription_c());
       }
    }
 }
@@ -311,7 +311,7 @@ void BaseInput::ioParam_offsetConstraintMethod(enum ParamsIOFlag ioFlag) {
    if (jitterFlag) {
       parent->ioParamValue(ioFlag, name, "offsetConstraintMethod", &offsetConstraintMethod, 0/*default*/);
       if (ioFlag == PARAMS_IO_READ && (offsetConstraintMethod <0 || offsetConstraintMethod >3) ) {
-         pvError().printf("Image layer \"%s\": offsetConstraintMethod allowed values are 0 (ignore), 1 (mirror BC), 2 (threshold), 3 (circular BC)\n", getName());
+         pvError().printf("%s: offsetConstraintMethod allowed values are 0 (ignore), 1 (mirror BC), 2 (threshold), 3 (circular BC)\n", getDescription_c());
       }
    }
 }
@@ -384,12 +384,12 @@ int BaseInput::allocateDataStructures() {
          if (nchars >= PV_PATH_MAX) {
             pvError().printf("Path for jitter positions \"%s/%s_jitter.txt is too long.\n", parent->getOutputPath(), getName());
          }
-         pvInfo().printf("Image layer \"%s\" will write jitter positions to %s\n",getName(), file_name);
+         pvInfo().printf("%s will write jitter positions to %s\n", getDescription_c(), file_name);
          fp_pos = PV_fopen(file_name,"w",parent->getVerifyWrites());
          if(fp_pos == NULL) {
-            pvError().printf("Image \"%s\" unable to open file \"%s\" for writing jitter positions.\n", getName(), file_name);
+            pvError().printf("%s unable to open file \"%s\" for writing jitter positions.\n", getDescription_c(), file_name);
          }
-         fprintf(fp_pos->fp,"Layer \"%s\", t=%f, bias x=%d y=%d, offset x=%d y=%d\n",getName(),parent->simulationTime(),biases[0],biases[1],
+         fprintf(fp_pos->fp,"%s, t=%f, bias x=%d y=%d, offset x=%d y=%d\n",getDescription_c(),parent->simulationTime(),biases[0],biases[1],
                getOffsetX(this->offsetAnchor, this->offsets[0]),getOffsetY(this->offsetAnchor, this->offsets[1]));
       }
    }
@@ -440,8 +440,8 @@ int BaseInput::scatterInput(int batchIndex) {
          imageColorType = COLORTYPE_GRAYSCALE;
       }
       if (imageLoc.nf != nf) {
-         pvError().printf("%s \"%s\": imageLoc has %d features but layer has %d features.\n",
-               getKeyword(), name, imageLoc.nf, nf);
+         pvError().printf("%s: imageLoc has %d features but layer has %d features.\n",
+               getDescription_c(), imageLoc.nf, nf);
       }
 
       resizeInput();
@@ -1124,8 +1124,8 @@ bool BaseInput::constrainOffsets() {
 
 int BaseInput::requireChannel(int channelNeeded, int * numChannelsResult) {
    if (parent->columnId()==0) {
-      pvErrorNoExit().printf("%s \"%s\" cannot be a post-synaptic layer.\n",
-            getKeyword(), name);
+      pvErrorNoExit().printf("%s cannot be a post-synaptic layer.\n",
+            getDescription_c());
    }
    *numChannelsResult = 0;
    return PV_FAILURE;
@@ -1135,7 +1135,7 @@ int BaseInput::initRandState() {
    assert(randState==NULL);
    randState = new Random(parent, 1);
    if (randState==NULL) {
-      pvError().printf("%s \"%s\" error in rank %d process: unable to create object of class Random.\n", getKeyword(), name, parent->columnId());
+      pvError().printf("%s: rank %d process unable to create object of class Random.\n", getDescription_c(), parent->columnId());
    }
    return PV_SUCCESS;
 }

--- a/src/layers/BaseInput.cpp
+++ b/src/layers/BaseInput.cpp
@@ -141,7 +141,7 @@ void BaseInput::ioParam_offsetAnchor(enum ParamsIOFlag ioFlag){
       int status = checkValidAnchorString();
       if (status != PV_SUCCESS) {
          if (parent->columnId()==0) {
-            pvErrorNoExit().printf("%s \"%s\": offsetAnchor must be a two-letter string.  The first character must be \"t\", \"c\", or \"b\" (for top, center or bottom); and the second character must be \"l\", \"c\", or \"r\" (for left, center or right).\n", getKeyword(), getName());
+            pvErrorNoExit().printf("%s: offsetAnchor must be a two-letter string.  The first character must be \"t\", \"c\", or \"b\" (for top, center or bottom); and the second character must be \"l\", \"c\", or \"r\" (for left, center or right).\n", getDescription_c());
          }
          MPI_Barrier(parent->icCommunicator()->communicator());
          exit(EXIT_FAILURE);

--- a/src/layers/BinningLayer.cpp
+++ b/src/layers/BinningLayer.cpp
@@ -48,8 +48,8 @@ void BinningLayer::ioParam_originalLayerName(enum ParamsIOFlag ioFlag) {
    assert(originalLayerName);
    if (ioFlag==PARAMS_IO_READ && originalLayerName[0]=='\0') {
       if (parent->columnId()==0) {
-         pvErrorNoExit().printf("%s \"%s\": originalLayerName must be set.\n",
-                 getKeyword(), name);
+         pvErrorNoExit().printf("%s: originalLayerName must be set.\n",
+               getDescription_c());
       }
       MPI_Barrier(parent->icCommunicator()->communicator());
       exit(EXIT_FAILURE);
@@ -61,8 +61,8 @@ void BinningLayer::ioParam_binMaxMin(enum ParamsIOFlag ioFlag) {
    parent->ioParamValue(ioFlag, name, "binMin", &binMin, binMin);
    if(ioFlag == PARAMS_IO_READ && binMax <= binMin){
       if (parent->columnId()==0) {
-         pvErrorNoExit().printf("%s \"%s\": binMax (%f) must be greater than binMin (%f).\n",
-            getKeyword(), name, binMax, binMin);
+         pvErrorNoExit().printf("%s: binMax (%f) must be greater than binMin (%f).\n",
+               getDescription_c(), binMax, binMin);
       }
       MPI_Barrier(parent->icCommunicator()->communicator());
       exit(EXIT_FAILURE);
@@ -96,8 +96,8 @@ int BinningLayer::communicateInitInfo() {
    originalLayer = parent->getLayerFromName(originalLayerName);
    if (originalLayer==NULL) {
       if (parent->columnId()==0) {
-         pvErrorNoExit().printf("%s \"%s\": originalLayerName \"%s\" is not a layer in the HyPerCol.\n",
-                 getKeyword(), name, originalLayerName);
+         pvErrorNoExit().printf("%s: originalLayerName \"%s\" is not a layer in the HyPerCol.\n",
+               getDescription_c(), originalLayerName);
       }
       MPI_Barrier(parent->icCommunicator()->communicator());
       exit(EXIT_FAILURE);
@@ -113,8 +113,8 @@ int BinningLayer::communicateInitInfo() {
    if (srcLoc->nxGlobal != loc->nxGlobal || srcLoc->nyGlobal != loc->nyGlobal) {
       if (parent->columnId()==0) {
          pvErrorNoExit(errorMessage);
-         errorMessage.printf("%s \"%s\": originalLayerName \"%s\" does not have the same dimensions.\n",
-                 getKeyword(), name, originalLayerName);
+         errorMessage.printf("%s: originalLayerName \"%s\" does not have the same dimensions.\n",
+               getDescription_c(), originalLayerName);
          errorMessage.printf("    original (nx=%d, ny=%d) versus (nx=%d, ny=%d)\n",
                  srcLoc->nxGlobal, srcLoc->nyGlobal, loc->nxGlobal, loc->nyGlobal);
       }
@@ -122,8 +122,8 @@ int BinningLayer::communicateInitInfo() {
       exit(EXIT_FAILURE);
    }
    if(srcLoc->nf != 1){
-      pvErrorNoExit().printf("%s \"%s\": originalLayerName \"%s\" can only have 1 feature.\n",
-         getKeyword(), name, originalLayerName);
+      pvErrorNoExit().printf("%s: originalLayerName \"%s\" can only have 1 feature.\n",
+            getDescription_c(), originalLayerName);
    }
    assert(srcLoc->nx==loc->nx && srcLoc->ny==loc->ny);
    return status;

--- a/src/layers/CloneVLayer.cpp
+++ b/src/layers/CloneVLayer.cpp
@@ -52,8 +52,8 @@ int CloneVLayer::communicateInitInfo() {
    originalLayer = parent->getLayerFromName(originalLayerName);
    if (originalLayer==NULL) {
       if (parent->columnId()==0) {
-         pvErrorNoExit().printf("%s \"%s\": originalLayerName \"%s\" is not a layer in the HyPerCol.\n",
-                 getKeyword(), name, originalLayerName);
+         pvErrorNoExit().printf("%s: originalLayerName \"%s\" is not a layer in the HyPerCol.\n",
+               getDescription_c(), originalLayerName);
       }
       MPI_Barrier(parent->icCommunicator()->communicator());
       exit(EXIT_FAILURE);
@@ -65,8 +65,8 @@ int CloneVLayer::communicateInitInfo() {
    if (srcLoc->nxGlobal != loc->nxGlobal || srcLoc->nyGlobal != loc->nyGlobal || srcLoc->nf != loc->nf) {
       if (parent->columnId()==0) {
          pvErrorNoExit(errorMessage);
-         errorMessage.printf("%s \"%s\": originalLayerName \"%s\" does not have the same dimensions.\n",
-                 getKeyword(), name, originalLayerName);
+         errorMessage.printf("%s: originalLayerName \"%s\" does not have the same dimensions.\n",
+               getDescription_c(), originalLayerName);
          errorMessage.printf("    original (nx=%d, ny=%d, nf=%d) versus (nx=%d, ny=%d, nf=%d)\n",
                  srcLoc->nxGlobal, srcLoc->nyGlobal, srcLoc->nf, loc->nxGlobal, loc->nyGlobal, loc->nf);
       }
@@ -103,15 +103,15 @@ int CloneVLayer::allocateV() {
    assert(originalLayer && originalLayer->getCLayer());
    clayer->V = originalLayer->getV();
    if (getV()==NULL) {
-      pvError().printf("%s \"%s\": originalLayer \"%s\" has a null V buffer in rank %d process.\n",
-              getKeyword(), name, originalLayerName, parent->columnId());
+      pvError().printf("%s: originalLayer \"%s\" has a null V buffer in rank %d process.\n",
+            getDescription_c(), originalLayerName, parent->columnId());
    }
    return PV_SUCCESS;
 }
 
 int CloneVLayer::requireChannel(int channelNeeded, int * numChannelsResult) {
    if (parent->columnId()==0) {
-      pvErrorNoExit().printf("%s \"%s\": layers derived from CloneVLayer do not have GSyn channels (requireChannel called with channel %d)\n", getKeyword(), name, channelNeeded);
+      pvErrorNoExit().printf("%s: layers derived from CloneVLayer do not have GSyn channels (requireChannel called with channel %d)\n", getDescription_c(), channelNeeded);
    }
    return PV_FAILURE;
 }

--- a/src/layers/FilenameParsingGroundTruthLayer.cpp
+++ b/src/layers/FilenameParsingGroundTruthLayer.cpp
@@ -87,8 +87,8 @@ int FilenameParsingGroundTruthLayer::communicateInitInfo() {
    movieLayer = dynamic_cast<Movie *>(parent->getLayerFromName(movieLayerName));
    if(movieLayer==NULL) {
       if (parent->columnId()==0) {
-         pvErrorNoExit().printf("%s \"%s\": movieLayerName \"%s\" is not a layer in the HyPerCol.\n",
-            getKeyword(), name, movieLayerName); 
+         pvErrorNoExit().printf("%s: movieLayerName \"%s\" is not a layer in the HyPerCol.\n",
+               getDescription_c(), movieLayerName);
       }
       exit(EXIT_FAILURE);
    }

--- a/src/layers/HyPerLCALayer.cpp
+++ b/src/layers/HyPerLCALayer.cpp
@@ -114,7 +114,7 @@ void HyPerLCALayer::ioParam_timeConstantTau(enum ParamsIOFlag ioFlag) {
 void HyPerLCALayer::ioParam_selfInteract(enum ParamsIOFlag ioFlag) {
    parent->ioParamValue(ioFlag, name, "selfInteract", &selfInteract, selfInteract);
    if (ioFlag==PARAMS_IO_READ && parent->columnId() == 0) {
-      pvInfo() << getKeyword() << "\"" << name << "\"" << ": selfInteract flag is " << (selfInteract ? "true" : "false") << std::endl;
+      pvInfo() << getDescription() << ": selfInteract flag is " << (selfInteract ? "true" : "false") << std::endl;
    }   
 }
 

--- a/src/layers/HyPerLayer.cpp
+++ b/src/layers/HyPerLayer.cpp
@@ -519,7 +519,7 @@ int HyPerLayer::allocateBuffer(T ** buf, int bufsize, const char * bufname) {
    int status = PV_SUCCESS;
    *buf = (T *) calloc(bufsize, sizeof(T));
    if(*buf == NULL) {
-      pvErrorNoExit().printf("Layer \"%s\" error in rank %d process: unable to allocate memory for %s: %s.\n", name, parent->columnId(), bufname, strerror(errno));
+      pvErrorNoExit().printf("%s: rank %d process unable to allocate memory for %s: %s.\n", getDescription_c(), parent->columnId(), bufname, strerror(errno));
       status = PV_FAILURE;
    }
    return status;
@@ -799,8 +799,8 @@ void HyPerLayer::ioParam_updateGpu(enum ParamsIOFlag ioFlag) {
    parent->ioParamValue(ioFlag, name, "updateGpu", &updateGpu, updateGpu, false/*warnIfAbsent*/);
    if (ioFlag==PARAMS_IO_READ && updateGpu) {
       if (parent->columnId()==0) {
-         pvErrorNoExit().printf("%s \"%s\": updateGpu is set to true, but PetaVision was compiled without GPU acceleration.\n",
-               getKeyword(), getName());
+         pvErrorNoExit().printf("%s: updateGpu is set to true, but PetaVision was compiled without GPU acceleration.\n",
+               getDescription_c());
       }
       MPI_Barrier(parent->icCommunicator()->communicator());
       exit(EXIT_FAILURE);
@@ -823,7 +823,7 @@ void HyPerLayer::ioParam_nf(enum ParamsIOFlag ioFlag) {
 void HyPerLayer::ioParam_phase(enum ParamsIOFlag ioFlag) {
    parent->ioParamValue(ioFlag, name, "phase", &phase, phase);
    if (ioFlag == PARAMS_IO_READ && phase<0) {
-      if (parent->columnId()==0) pvError().printf("Error in layer \"%s\": phase must be >= 0 (given value was %d).\n", name, phase);
+      if (parent->columnId()==0) pvError().printf("%s: phase must be >= 0 (given value was %d).\n", getDescription_c(), phase);
    }
 }
 
@@ -849,7 +849,7 @@ void HyPerLayer::ioParam_InitVType(enum ParamsIOFlag ioFlag) {
    if (ioFlag == PARAMS_IO_READ) {
       initVObject = new InitV(parent, name);
       if( initVObject == NULL ) {
-         pvErrorNoExit().printf("%s \"%s\": unable to create InitV object\n", getKeyword(), name);
+         pvErrorNoExit().printf("%s: unable to create InitV object\n", getDescription_c());
          abort();
       }
    }
@@ -863,8 +863,8 @@ void HyPerLayer::ioParam_triggerLayerName(enum ParamsIOFlag ioFlag) {
    if (ioFlag==PARAMS_IO_READ) {
       if (triggerLayerName && !strcmp(name, triggerLayerName)) {
          if (parent->columnId()==0) {
-            pvErrorNoExit().printf("%s \"%s\": triggerLayerName cannot be the same as the name of the layer itself.\n",
-                  getKeyword(), name);
+            pvErrorNoExit().printf("%s: triggerLayerName cannot be the same as the name of the layer itself.\n",
+                  getDescription_c());
          }
          MPI_Barrier(parent->icCommunicator()->communicator());
          exit(EXIT_FAILURE);
@@ -885,7 +885,7 @@ void HyPerLayer::ioParam_triggerFlag(enum ParamsIOFlag ioFlag) {
       parent->ioParamValue(ioFlag, name, "triggerFlag", &flagFromParams, flagFromParams);
       if (parent->columnId()==0) {
          pvWarn(triggerFlagMessage);
-         triggerFlagMessage.printf("Layer \"%s\": triggerFlag has been deprecated.\n", name);
+         triggerFlagMessage.printf("%s: triggerFlag has been deprecated.\n", getDescription_c());
          triggerFlagMessage.printf("   If triggerLayerName is a nonempty string, triggering will be on;\n");
          triggerFlagMessage.printf("   if triggerLayerName is empty or null, triggering will be off.\n");
          if (parent->columnId()==0) {
@@ -911,7 +911,9 @@ void HyPerLayer::ioParam_triggerOffset(enum ParamsIOFlag ioFlag) {
    if (triggerFlag) {
       parent->ioParamValue(ioFlag, name, "triggerOffset", &triggerOffset, triggerOffset);
       if(triggerOffset < 0){
-         pvError().printf("%s \"%s\" error in rank %d process: TriggerOffset (%f) must be positive\n", getKeyword(), name, parent->columnId(), triggerOffset);
+         if (parent->columnId()==0) {
+            pvError().printf("%s: TriggerOffset (%f) must be positive\n", getDescription_c(), triggerOffset);
+         }
       }
    }
 }
@@ -935,8 +937,8 @@ void HyPerLayer::ioParam_triggerBehavior(enum ParamsIOFlag ioFlag) {
       }
       else {
          if (parent->columnId()==0) {
-            pvErrorNoExit().printf("%s \"%s\": triggerBehavior=\"%s\" is unrecognized.\n",
-                  getKeyword(), name, triggerBehavior);
+            pvErrorNoExit().printf("%s: triggerBehavior=\"%s\" is unrecognized.\n",
+                  getDescription_c(), triggerBehavior);
          }
          MPI_Barrier(parent->icCommunicator()->communicator());
          exit(EXIT_FAILURE);
@@ -971,8 +973,8 @@ void HyPerLayer::ioParam_initialWriteTime(enum ParamsIOFlag ioFlag) {
          }
          if (parent->columnId()==0) {
             pvWarn(warningMessage);
-            warningMessage.printf("%s \"%s\": initialWriteTime %fis earlier than start time %f.  Adjusting initialWriteTime:\n",
-                  getKeyword(), name, initialWriteTime, start_time);
+            warningMessage.printf("%s: initialWriteTime %f is earlier than start time %f.  Adjusting initialWriteTime:\n",
+                  getDescription_c(), initialWriteTime, start_time);
             warningMessage.printf("    initialWriteTime adjusted to %f\n",initialWriteTime);
          }
       }
@@ -1114,8 +1116,8 @@ int HyPerLayer::communicateInitInfo()
       triggerLayer = parent->getLayerFromName(triggerLayerName);
       if (triggerLayer==NULL) {
          if (parent->columnId()==0) {
-            pvErrorNoExit().printf("%s \"%s\": triggerLayerName \"%s\" is not a layer in the HyPerCol.\n",
-                  getKeyword(), name, triggerLayerName);
+            pvErrorNoExit().printf("%s: triggerLayerName \"%s\" is not a layer in the HyPerCol.\n",
+                  getDescription_c(), triggerLayerName);
          }
          MPI_Barrier(parent->icCommunicator()->communicator());
          exit(EXIT_FAILURE);
@@ -1132,8 +1134,8 @@ int HyPerLayer::communicateInitInfo()
             triggerResetLayer = parent->getLayerFromName(triggerResetLayerName);
             if (triggerResetLayer==NULL) {
                if (parent->columnId()==0) {
-                  pvErrorNoExit().printf("%s \"%s\": triggerResetLayerName \"%s\" is not a layer in the HyPerCol.\n",
-                        getKeyword(), name, triggerResetLayerName);
+                  pvErrorNoExit().printf("%s: triggerResetLayerName \"%s\" is not a layer in the HyPerCol.\n",
+                        getDescription_c(), triggerResetLayerName);
                }
                MPI_Barrier(parent->icCommunicator()->communicator());
                exit(EXIT_FAILURE);
@@ -1146,8 +1148,8 @@ int HyPerLayer::communicateInitInfo()
          if (triggerLoc->nxGlobal != localLoc->nxGlobal || triggerLoc->nyGlobal != localLoc->nyGlobal || triggerLoc->nf != localLoc->nf) {
             if (parent->columnId()==0) {
                pvError(errorMessage);
-               errorMessage.printf("%s \"%s\": triggerResetLayer \"%s\" has incompatible dimensions.\n",
-                     getKeyword(), name, resetLayerName);
+               errorMessage.printf("%s: triggerResetLayer \"%s\" has incompatible dimensions.\n",
+                     getDescription_c(), resetLayerName);
                errorMessage.printf("    \"%s\" is %d-by-%d-by-%d and \"%s\" is %d-by-%d-by-%d.\n",
                      name, localLoc->nxGlobal, localLoc->nyGlobal, localLoc->nf,
                      resetLayerName, triggerLoc->nxGlobal, triggerLoc->nyGlobal, triggerLoc->nf);
@@ -1198,8 +1200,8 @@ int HyPerLayer::openOutputStateFile() {
    if (numCommBatches != 1) {
       int sz = snprintf(appendCommBatchIdx, 32, "_%d", parent->commBatch());
       if (sz >= 32) {
-         pvError().printf("%s \"%s\": Unable to create file name for outputState file: comm batch index %d is too long.\n",
-               getKeyword(), name, parent->commBatch());
+         pvError().printf("%s: Unable to create file name for outputState file: comm batch index %d is too long.\n",
+               getDescription_c(), parent->commBatch());
       }
    }
    else { // numCommBatches is one; insert the empty string instead.
@@ -1223,8 +1225,8 @@ int HyPerLayer::openOutputStateFile() {
       break;
    }
    if (sz >= PV_PATH_MAX) {
-      pvError().printf("%s \"%s\": Unable to create file name for outputState file: file name with comm batch index %d is too long.\n",
-            getKeyword(), name, parent->commBatch());
+      pvError().printf("%s: Unable to create file name for outputState file: file name with comm batch index %d is too long.\n",
+            getDescription_c(), parent->commBatch());
    }
 
    // initialize writeActivityCalls and writeSparseActivityCalls
@@ -1345,7 +1347,7 @@ int HyPerLayer::allocateDataStructures()
    if(triggerFlag){
       double deltaUpdateTime = getDeltaUpdateTime();
       if(deltaUpdateTime != -1 && triggerOffset >= deltaUpdateTime){ 
-         pvError().printf("%s \"%s\" error in rank %d process: TriggerOffset (%f) must be lower than the change in update time (%f) \n", getKeyword(), name, parent->columnId(), triggerOffset, deltaUpdateTime);
+         pvError().printf("%s error in rank %d process: TriggerOffset (%f) must be lower than the change in update time (%f) \n", getDescription_c(), parent->columnId(), triggerOffset, deltaUpdateTime);
       }
    }
 
@@ -1424,7 +1426,7 @@ int HyPerLayer::allocateDataStructures()
       status = PV_SUCCESS;
    }
    else{
-      pvError().printf("Connection \"%s\" unable to allocate device memory in rank %d process: %s\n", getName(), getParent()->columnId(), strerror(errno));
+      pvError().printf("%s unable to allocate device memory in rank %d process: %s\n", getDescription_c(), getParent()->columnId(), strerror(errno));
    }
    if(updateGpu){
       //This function needs to be overwritten as needed on a subclass basis
@@ -1488,7 +1490,7 @@ int HyPerLayer::requireMarginWidth(int marginWidthNeeded, int * marginWidthResul
       if (xmargin < marginWidthNeeded) {
          assert(clayer);
          if (parent->columnId()==0) {
-            pvInfo().printf("Layer \"%s\": adjusting x-margin width from %d to %d\n", name, xmargin, marginWidthNeeded);
+            pvInfo().printf("%s: adjusting x-margin width from %d to %d\n", getDescription_c(), xmargin, marginWidthNeeded);
          }
          xmargin = marginWidthNeeded;
          halo->lt = xmargin;
@@ -1513,7 +1515,7 @@ int HyPerLayer::requireMarginWidth(int marginWidthNeeded, int * marginWidthResul
       if (ymargin < marginWidthNeeded) {
          assert(clayer);
          if (parent->columnId()==0) {
-            pvInfo().printf("Layer \"%s\": adjusting y-margin width from %d to %d\n", name, ymargin, marginWidthNeeded);
+            pvInfo().printf("%s: adjusting y-margin width from %d to %d\n", getDescription_c(), ymargin, marginWidthNeeded);
          }
          ymargin = marginWidthNeeded;
          halo->dn = ymargin;
@@ -1731,8 +1733,8 @@ int HyPerLayer::resetStateOnTrigger() {
    pvpotentialdata_t * V = getV();
    if (V==NULL) {
       if (parent->columnId()==0) {
-         pvErrorNoExit().printf("%s \"%s\": triggerBehavior is \"resetStateOnTrigger\" but layer does not have a membrane potential.\n",
-               getKeyword(), name);
+         pvErrorNoExit().printf("%s: triggerBehavior is \"resetStateOnTrigger\" but layer does not have a membrane potential.\n",
+               getDescription_c());
       }
       MPI_Barrier(parent->icCommunicator()->communicator());
       exit(EXIT_FAILURE);
@@ -2123,7 +2125,7 @@ int HyPerLayer::outputState(double timef, bool last)
       }
    }
    if (status!=PV_SUCCESS) {
-      pvError().printf("%s \"%s\": outputState failed on rank %d process.\n", getKeyword(), name, parent->columnId());
+      pvError().printf("%s: outputState failed on rank %d process.\n", getDescription_c(), parent->columnId());
    }
 
    io_timer->stop();
@@ -2172,7 +2174,7 @@ int HyPerLayer::readDelaysFromCheckpoint(const char * cpDir, double * timeptr) {
 int HyPerLayer::checkpointRead(const char * cpDir, double * timeptr) {
    int status = readStateFromCheckpoint(cpDir, timeptr);
    if (status != PV_SUCCESS) {
-      pvError().printf("Layer \"%s\": rank %d process failed to read state from checkpoint directory \"%s\"\n", getName(), parent->columnId(), cpDir);
+      pvError().printf("%s: rank %d process failed to read state from checkpoint directory \"%s\"\n", getDescription_c(), parent->columnId(), cpDir);
    }
    InterColComm * icComm = parent->icCommunicator();
    parent->readScalarFromFile(cpDir, getName(), "lastUpdateTime", &lastUpdateTime, parent->simulationTime()-parent->getDeltaTime());

--- a/src/layers/HyPerLayer.cpp
+++ b/src/layers/HyPerLayer.cpp
@@ -602,7 +602,7 @@ int HyPerLayer::setLayerLoc(PVLayerLoc * layerLoc, float nxScale, float nyScale,
    MPI_Barrier(icComm->communicator()); // If there is an error, make sure that MPI doesn't kill the run before process 0 reports the error.
    if (status != PV_SUCCESS) {
       if (parent->columnId()==0) {
-         pvErrorNoExit().printf("setLayerLoc failed for %s \"%s\".\n", getKeyword(), getName());
+         pvErrorNoExit().printf("setLayerLoc failed for %s.\n", getDescription_c());
       }
       exit(EXIT_FAILURE);
    }

--- a/src/layers/Image.cpp
+++ b/src/layers/Image.cpp
@@ -96,7 +96,7 @@ int Image::retrieveData(double timef, double dt, int batchIndex)
    //Using member varibles here
    status = readImage(inputPath);
    if(status != PV_SUCCESS) {
-      pvErrorNoExit().printf("%s \"%s\": readImage failed at t=%f for batchIndex %d\n", getKeyword(), name, timef, batchIndex);
+      pvErrorNoExit().printf("%s: readImage failed at t=%f for batchIndex %d\n", getDescription_c(), timef, batchIndex);
    }
    return status;
 }
@@ -527,7 +527,7 @@ int Image::readImage(const char * filename)
 
    status = readImageFileGDAL(path, &imageLoc);
    if (status != PV_SUCCESS) {
-      pvError().printf("Image::readImage failed for layer \"%s\"\n", getName());
+      pvError().printf("Image::readImage failed for %s\n", getDescription_c());
    }
 
    if (usingTempFile) {

--- a/src/layers/ImageFromMemoryBuffer.cpp
+++ b/src/layers/ImageFromMemoryBuffer.cpp
@@ -32,7 +32,7 @@ int ImageFromMemoryBuffer::initialize(char const * name, HyPerCol * hc) {
    return BaseInput::initialize(name, hc);
    if (useImageBCflag && autoResizeFlag) {
       if (parent->columnId()==0) {
-         pvErrorNoExit().printf("%s \"%s\": setting both useImageBCflag and autoResizeFlag has not yet been implemented.\n", getKeyword(), name);
+         pvErrorNoExit().printf("%s: setting both useImageBCflag and autoResizeFlag has not yet been implemented.\n", getDescription_c());
       }
       MPI_Barrier(parent->icCommunicator()->communicator());
       exit(EXIT_FAILURE);
@@ -106,8 +106,8 @@ int ImageFromMemoryBuffer::setMemoryBuffer(pixeltype const * externalBuffer, int
    this->offsetAnchor = strdup(offsetAnchor);
    if (checkValidAnchorString()!=PV_SUCCESS) {
       if (parent->columnId()==0) {
-         pvErrorNoExit().printf("%s \"%s\": setMemoryBuffer called with invalid anchor string \"%s\"",
-               getKeyword(), name, offsetAnchor);
+         pvErrorNoExit().printf("%s: setMemoryBuffer called with invalid anchor string \"%s\"",
+               getDescription_c(), offsetAnchor);
       }
       MPI_Barrier(parent->icCommunicator()->communicator());
       exit(EXIT_FAILURE);

--- a/src/layers/ImagePvp.cpp
+++ b/src/layers/ImagePvp.cpp
@@ -94,7 +94,7 @@ int ImagePvp::retrieveData(double timef, double dt, int batchIndex)
    int status = PV_SUCCESS;
    status = readPvp(inputPath, pvpFrameIdx);
    if(status != PV_SUCCESS) {
-      pvErrorNoExit().printf("%s \"%s\": retrieveData failed at t=%f with batchIndex %d\n", getKeyword(), name, timef, batchIndex);
+      pvErrorNoExit().printf("%s: retrieveData failed at t=%f with batchIndex %d\n", getDescription_c(), timef, batchIndex);
    }
    return status;
 }

--- a/src/layers/InitV.cpp
+++ b/src/layers/InitV.cpp
@@ -106,8 +106,8 @@ int InitV::calcV(HyPerLayer * layer) {
    const PVLayerLoc * loc = layer->getLayerLoc();
    pvdata_t * V = layer->getV();
    if (V == NULL) {
-      pvErrorNoExit().printf("%s \"%s\": InitV called but membrane potential V is null.\n",
-            layer->getKeyword(), layer->getName());
+      pvErrorNoExit().printf("%s: InitV called but membrane potential V is null.\n",
+            layer->getDescription_c());
       exit(EXIT_FAILURE);
    }
    switch(initVTypeCode) {

--- a/src/layers/LCALIFLayer.cpp
+++ b/src/layers/LCALIFLayer.cpp
@@ -235,9 +235,10 @@ int LCALIFLayer::checkpointWrite(const char * cpDir) {
    int lenbase = snprintf(basepath, PV_PATH_MAX, "%s/%s", cpDir, name);
    if (lenbase+strlen("_integratedSpikeCount.pvp") >= PV_PATH_MAX) { // currently _integratedSpikeCount.pvp is the longest suffix needed
       if (icComm->commRank()==0) {
-         pvErrorNoExit().printf("LCALIFLayer::checkpointWrite error in layer \"%s\".  Base pathname \"%s/%s_\" too long.\n", name, cpDir, name);
+         pvError().printf("LCALIFLayer::checkpointWrite error in getDescription_c.  Base pathname \"%s/%s_\" too long.\n", getDescription_c(), cpDir, name);
       }
-      abort();
+      MPI_Barrier(parent->icCommunicator()->communicator());
+      exit(EXIT_FAILURE);
    }
    double timed = (double) parent->simulationTime();
    int chars_needed = snprintf(filename, PV_PATH_MAX, "%s_integratedSpikeCount.pvp", basepath);

--- a/src/layers/LIF.cpp
+++ b/src/layers/LIF.cpp
@@ -370,7 +370,7 @@ void LIF::ioParam_method(enum ParamsIOFlag ioFlag) {
       free(methodString);
       methodString = strdup(default_method);
       if (methodString==NULL) {
-         pvError().printf("%s \"%s\" error: unable to set method string: %s\n", getKeyword(), name, strerror(errno));
+         pvError().printf("%s: unable to set method string: %s\n", getDescription_c(), strerror(errno));
       }
    }
    method = methodString ? methodString[0] : 'a'; // Default is ARMA; 'beginning' and 'original' are deprecated.
@@ -406,7 +406,7 @@ int LIF::allocateDataStructures() {
    // // a random state variable is needed for every neuron/clthread
    randState = new Random(parent, getLayerLoc(), false/*isExtended*/);
    if (randState == NULL) {
-      pvError().printf("LIF::initialize error.  Layer \"%s\" unable to create object of Random class.\n", getName());
+      pvError().printf("LIF::initialize:  %s unable to create object of Random class.\n", getDescription_c());
    }
 
    int numNeurons = getNumNeuronsAllBatches();
@@ -422,8 +422,8 @@ int LIF::allocateBuffers() {
    assert(status==PV_SUCCESS);
    Vth = (pvdata_t *) calloc((size_t) getNumNeuronsAllBatches(), sizeof(pvdata_t));
    if(Vth == NULL) {
-      pvError().printf("LIF layer \"%s\" rank %d process unable to allocate memory for Vth: %s\n",
-              name, parent->columnId(), strerror(errno));
+      pvError().printf("%s: rank %d process unable to allocate memory for Vth: %s\n",
+            getDescription_c(), parent->columnId(), strerror(errno));
    }
    return HyPerLayer::allocateBuffers();
 }
@@ -433,8 +433,8 @@ int LIF::allocateConductances(int num_channels) {
    const int numNeurons = getNumNeuronsAllBatches();
    G_E = (pvdata_t *) calloc((size_t) (getNumNeuronsAllBatches()*numChannels), sizeof(pvdata_t));
    if(G_E == NULL) {
-      pvError().printf("LIF layer \"%s\" rank %d process unable to allocate memory for %d conductances: %s\n",
-              name, parent->columnId(), num_channels, strerror(errno));
+      pvError().printf("%s: rank %d process unable to allocate memory for %d conductances: %s\n",
+            getDescription_c(), parent->columnId(), num_channels, strerror(errno));
    }
 
    G_I  = G_E + 1*numNeurons;

--- a/src/layers/LIFGap.cpp
+++ b/src/layers/LIFGap.cpp
@@ -213,8 +213,8 @@ int LIFGap::allocateConductances(int num_channels) {
    int status = LIF::allocateConductances(num_channels-1); // CHANNEL_GAP doesn't have a conductance per se.
    gapStrength = (pvgsyndata_t *) calloc((size_t) getNumNeuronsAllBatches(), sizeof(*gapStrength));
    if(gapStrength == NULL) {
-      pvError().printf("%s layer \"%s\": rank %d process unable to allocate memory for gapStrength: %s\n",
-              getKeyword(), getName(), parent->columnId(), strerror(errno));
+      pvError().printf("%s: rank %d process unable to allocate memory for gapStrength: %s\n",
+            getDescription_c(), parent->columnId(), strerror(errno));
    }
    return status;
 }
@@ -240,7 +240,7 @@ int LIFGap::calcGapStrength() {
       HyPerConn * conn = dynamic_cast<HyPerConn *>(parent->getConnection(c));
       if (conn->postSynapticLayer() != this || conn->getChannel() != CHANNEL_GAP) { continue; }
       if (conn->getPlasticityFlag() && parent->columnId()==0) {
-         pvWarn().printf("%s: connection \"%s\" on CHANNEL_GAP has plasticity flag set to true\n", getDescription_c(), conn->getName());
+         pvWarn().printf("%s: %s on CHANNEL_GAP has plasticity flag set to true\n", getDescription_c(), conn->getDescription_c());
       }
       HyPerLayer * pre = conn->preSynapticLayer();
       const int sy = conn->getPostNonextStrides()->sy;

--- a/src/layers/LIFGap.cpp
+++ b/src/layers/LIFGap.cpp
@@ -240,7 +240,7 @@ int LIFGap::calcGapStrength() {
       HyPerConn * conn = dynamic_cast<HyPerConn *>(parent->getConnection(c));
       if (conn->postSynapticLayer() != this || conn->getChannel() != CHANNEL_GAP) { continue; }
       if (conn->getPlasticityFlag() && parent->columnId()==0) {
-         pvWarn().printf("%s \"%s\": connection \"%s\" on CHANNEL_GAP has plasticity flag set to true\n", getKeyword(), getName(), conn->getName());
+         pvWarn().printf("%s: connection \"%s\" on CHANNEL_GAP has plasticity flag set to true\n", getDescription_c(), conn->getName());
       }
       HyPerLayer * pre = conn->preSynapticLayer();
       const int sy = conn->getPostNonextStrides()->sy;

--- a/src/layers/MaskLayer.cpp
+++ b/src/layers/MaskLayer.cpp
@@ -62,8 +62,8 @@ void MaskLayer::ioParam_maskMethod(enum ParamsIOFlag ioFlag) {
    }
    else{
       if (parent->columnId()==0) {
-         pvErrorNoExit().printf("%s \"%s\": \"%s\" is not a valid maskMethod. Options are \"layer\", \"invertLayer\", \"maskFeatures\", or \"noMaskFeatures\".\n",
-                 getKeyword(), name, maskMethod);
+         pvErrorNoExit().printf("%s: \"%s\" is not a valid maskMethod. Options are \"layer\", \"invertLayer\", \"maskFeatures\", or \"noMaskFeatures\".\n",
+               getDescription_c(), maskMethod);
       }
       exit(-1);
    }
@@ -82,8 +82,8 @@ void MaskLayer::ioParam_featureIdxs(enum ParamsIOFlag ioFlag) {
       parent->ioParamArray(ioFlag, name, "featureIdxs", &features, &numSpecifiedFeatures);
       if(numSpecifiedFeatures == 0){
          if (parent->columnId()==0) {
-            pvErrorNoExit().printf("%s \"%s\": MaskLayer must specify at least one feature for maskMethod \"%s\".\n",
-                    getKeyword(), name, maskMethod);
+            pvErrorNoExit().printf("%s: MaskLayer must specify at least one feature for maskMethod \"%s\".\n",
+                  getDescription_c(), maskMethod);
          }
          exit(-1);
       }
@@ -96,8 +96,8 @@ int MaskLayer::communicateInitInfo() {
       maskLayer = parent->getLayerFromName(maskLayerName);
       if (maskLayer==NULL) {
          if (parent->columnId()==0) {
-            pvErrorNoExit().printf("%s \"%s\": maskLayerName \"%s\" is not a layer in the HyPerCol.\n",
-                    getKeyword(), name, maskLayerName);
+            pvErrorNoExit().printf("%s: maskLayerName \"%s\" is not a layer in the HyPerCol.\n",
+                  getDescription_c(), maskLayerName);
          }
          MPI_Barrier(parent->icCommunicator()->communicator());
          exit(EXIT_FAILURE);
@@ -109,8 +109,8 @@ int MaskLayer::communicateInitInfo() {
       if (maskLoc->nxGlobal != loc->nxGlobal || maskLoc->nyGlobal != loc->nyGlobal) {
          if (parent->columnId()==0) {
             pvErrorNoExit(errorMessage);
-            errorMessage.printf("%s \"%s\": maskLayerName \"%s\" does not have the same x and y dimensions.\n",
-                    getKeyword(), name, maskLayerName);
+            errorMessage.printf("%s: maskLayerName \"%s\" does not have the same x and y dimensions.\n",
+                  getDescription_c(), maskLayerName);
             errorMessage.printf("    original (nx=%d, ny=%d, nf=%d) versus (nx=%d, ny=%d, nf=%d)\n",
                     maskLoc->nxGlobal, maskLoc->nyGlobal, maskLoc->nf, loc->nxGlobal, loc->nyGlobal, loc->nf);
          }
@@ -121,8 +121,8 @@ int MaskLayer::communicateInitInfo() {
       if(maskLoc->nf != 1 && maskLoc->nf != loc->nf){
          if (parent->columnId()==0) {
             pvErrorNoExit(errorMessage);
-            errorMessage.printf("%s \"%s\": maskLayerName \"%s\" must either have the same number of features as this layer, or one feature.\n",
-                    getKeyword(), name, maskLayerName);
+            errorMessage.printf("%s: maskLayerName \"%s\" must either have the same number of features as this layer, or one feature.\n",
+                  getDescription_c(), maskLayerName);
             errorMessage.printf("    original (nx=%d, ny=%d, nf=%d) versus (nx=%d, ny=%d, nf=%d)\n",
                     maskLoc->nxGlobal, maskLoc->nyGlobal, maskLoc->nf, loc->nxGlobal, loc->nyGlobal, loc->nf);
          }

--- a/src/layers/Movie.cpp
+++ b/src/layers/Movie.cpp
@@ -148,7 +148,8 @@ int Movie::checkpointWrite(const char * cpDir){
  * Notes:
  * - writeImages, offsetX, offsetY are initialized by Image::initialize()
  */
-int Movie::initialize(const char * name, HyPerCol * hc) { int status = Image::initialize(name, hc);
+int Movie::initialize(const char * name, HyPerCol * hc) {
+   int status = Image::initialize(name, hc);
    if (status != PV_SUCCESS) {
       pvError().printf("Image::initialize failed on Movie layer \"%s\".  Exiting.\n", name);
    }
@@ -183,8 +184,8 @@ int Movie::initialize(const char * name, HyPerCol * hc) { int status = Image::in
           if(getParent()->getCheckpointReadFlag()){
              struct stat statbuf;
              if (PV_stat(timestampFilename.c_str(), &statbuf) != 0) {
-                pvWarn().printf("%s \"%s\": timestamp file \"%s\" unable to be found.  Creating new file.\n",
-                      getKeyword(), name, timestampFilename.c_str());
+                pvWarn().printf("%s: timestamp file \"%s\" unable to be found.  Creating new file.\n",
+                      getDescription_c(), timestampFilename.c_str());
                 timestampFile = PV::PV_fopen(timestampFilename.c_str(), "w", parent->getVerifyWrites());
              }
              else {
@@ -281,16 +282,16 @@ int Movie::allocateDataStructures() {
    
    batchPos = (long*) malloc(parent->getNBatch() * sizeof(long));
    if(batchPos==NULL) {
-      pvError().printf("%s \"%s\" error allocating memory for batchPos (batch size %d): %s\n",
-            name, getKeyword(), parent->getNBatch(), strerror(errno));
+      pvError().printf("%s: unable to allocate memory for batchPos (batch size %d): %s\n",
+            getDescription_c(), parent->getNBatch(), strerror(errno));
    }
    for(int b = 0; b < parent->getNBatch(); b++){
       batchPos[b] = 0L;
    }
    frameNumbers = (int*) calloc(parent->getNBatch(), sizeof(int));
    if (frameNumbers==NULL) {
-      pvError().printf("%s \"%s\" error allocating memory for frameNumbers (batch size %d): %s\n",
-            name, getKeyword(), parent->getNBatch(), strerror(errno));
+      pvError().printf("%s: unable to allocate memory for frameNumbers (batch size %d): %s\n",
+            getDescription_c(), parent->getNBatch(), strerror(errno));
    }
 
    //Calculate file positions for beginning of each frame
@@ -517,7 +518,7 @@ bool Movie::updateImage(double time, double dt)
             size_t len = outStrStream.str().length();
             int status = PV_fwrite(outStrStream.str().c_str(), sizeof(char), len, timestampFile)==len ? PV_SUCCESS : PV_FAILURE;
             if (status != PV_SUCCESS) {
-               pvError().printf("%s \"%s\" error: Movie::updateState failed to write to timestamp file.\n", getKeyword(), name);
+               pvError().printf("%s: Movie::updateState failed to write to timestamp file.\n", getDescription_c());
             }
             //Flush buffer
             fflush(timestampFile->fp);
@@ -554,7 +555,7 @@ const char * Movie::getNextFileName(int n_skip, int batchIdx) {
       outFilename = advanceFileName(batchIdx);
    }
    if (echoFramePathnameFlag){
-      pvInfo().printf("%s \"%s\": t=%f, batch element %d: loading %s\n", getKeyword(), name, parent->simulationTime(), batchIdx, outFilename);
+      pvInfo().printf("%s: t=%f, batch element %d: loading %s\n", getDescription_c(), parent->simulationTime(), batchIdx, outFilename);
    }
    return outFilename;
 }

--- a/src/layers/MoviePvp.cpp
+++ b/src/layers/MoviePvp.cpp
@@ -96,7 +96,7 @@ int MoviePvp::checkpointWrite(const char * cpDir){
 int MoviePvp::initialize(const char * name, HyPerCol * hc) {
    int status = ImagePvp::initialize(name, hc);
    if (status != PV_SUCCESS) {
-      pvError().printf("Image::initialize failed on Movie layer \"%s\".  Exiting.\n", name);
+      pvError().printf("Image::initialize failed on %s.  Exiting.\n", getDescription_c());
    }
 
    //Update on first timestep
@@ -118,8 +118,8 @@ int MoviePvp::initialize(const char * name, HyPerCol * hc) {
           if(getParent()->getCheckpointReadFlag()){
              struct stat statbuf;
              if (PV_stat(timestampFilename.c_str(), &statbuf) != 0) {
-                pvWarn().printf("%s \"%s\": timestamp file \"%s\" unable to be found.  Creating new file.\n",
-                      getKeyword(), name, timestampFilename.c_str());
+                pvWarn().printf("%s: timestamp file \"%s\" unable to be found.  Creating new file.\n",
+                      getDescription_c(), timestampFilename.c_str());
                 timestampFile = PV::PV_fopen(timestampFilename.c_str(), "w", parent->getVerifyWrites());
              }
              else {
@@ -415,7 +415,7 @@ bool MoviePvp::updateImage(double time, double dt)
              size_t len = outStrStream.str().length();
              int status = PV_fwrite(outStrStream.str().c_str(), sizeof(char), len, timestampFile)==len ? PV_SUCCESS : PV_FAILURE;
              if (status != PV_SUCCESS) {
-                pvError().printf("%s \"%s\" error: Movie::updateState failed to write to timestamp file.\n", getKeyword(), name);
+                pvError().printf("%s: Movie::updateState failed to write to timestamp file.\n", getDescription_c());
              }
              //Flush buffer
              fflush(timestampFile->fp);

--- a/src/layers/Patterns.cpp
+++ b/src/layers/Patterns.cpp
@@ -90,7 +90,7 @@ int Patterns::initialize(const char * name, HyPerCol * hc) {
          pvInfo().printf("write position to %s\n",file_name);
          patternsFile = PV_fopen(file_name,"a",parent->getVerifyWrites());
          if(patternsFile == NULL) {
-            pvError().printf("Patterns layer \"%s\" unable to open \"%s\" for writing: error %s\n", name, file_name, strerror(errno));
+            pvError().printf("%s unable to open \"%s\" for writing: error %s\n", getDescription_c(), file_name, strerror(errno));
          }
       }
       else {
@@ -1178,7 +1178,7 @@ int Patterns::checkpointWrite(const char * cpDir) {
          pvErrorNoExit().printf("Unable to write to \"%s\"\n", filename);
       }
       if (status != PV_SUCCESS) {
-         pvError().printf("Patterns::checkpointWrite: %s \"%s\" failed writing to %s\n", getKeyword(), name, pvstream->name);
+         pvError().printf("Patterns::checkpointWrite: %s failed writing to %s\n", getDescription_c(), pvstream->name);
       }
       sprintf(filename, "%s/%s_PatternState.txt", cpDir, name);
       pvstream = PV_fopen(filename, "w", parent->getVerifyWrites());

--- a/src/layers/PtwiseLinearTransferLayer.cpp
+++ b/src/layers/PtwiseLinearTransferLayer.cpp
@@ -107,16 +107,16 @@ void PtwiseLinearTransferLayer::ioParam_verticesV(enum ParamsIOFlag ioFlag) {
    if (ioFlag==PARAMS_IO_READ) {
       if (numVerticesTmp==0) {
          if (this->getParent()->columnId()==0) {
-            pvErrorNoExit().printf("%s \"%s\" error: verticesV cannot be empty\n",
-                  this->getKeyword(), this->getName());
+            pvErrorNoExit().printf("%s: verticesV cannot be empty\n",
+                  getDescription_c());
          }
          MPI_Barrier(this->getParent()->icCommunicator()->communicator());
          exit(EXIT_FAILURE);
       }
       if (numVertices !=0 && numVerticesTmp != numVertices) {
          if (this->getParent()->columnId()==0) {
-            pvErrorNoExit().printf("%s \"%s\" error: verticesV (%d elements) and verticesA (%d elements) must have the same lengths.\n",
-                  this->getKeyword(), this->getName(), numVerticesTmp, numVertices);
+            pvErrorNoExit().printf("%s: verticesV (%d elements) and verticesA (%d elements) must have the same lengths.\n",
+                  getDescription_c(), numVerticesTmp, numVertices);
          }
          MPI_Barrier(this->getParent()->icCommunicator()->communicator());
          exit(EXIT_FAILURE);
@@ -132,16 +132,16 @@ void PtwiseLinearTransferLayer::ioParam_verticesA(enum ParamsIOFlag ioFlag) {
    if (ioFlag==PARAMS_IO_READ) {
       if (numVerticesA==0) {
          if (this->getParent()->columnId()==0) {
-            pvErrorNoExit().printf("%s \"%s\" error: verticesA cannot be empty\n",
-                  this->getKeyword(), this->getName());
+            pvErrorNoExit().printf("%s: verticesA cannot be empty\n",
+                  getDescription_c());
          }
          MPI_Barrier(this->getParent()->icCommunicator()->communicator());
          exit(EXIT_FAILURE);
       }
       if (numVertices !=0 && numVerticesA != numVertices) {
          if (this->getParent()->columnId()==0) {
-            pvErrorNoExit().printf("%s \"%s\" error: verticesV (%d elements) and verticesA (%d elements) must have the same lengths.\n",
-                  this->getKeyword(), this->getName(), numVertices, numVerticesA);
+            pvErrorNoExit().printf("%s: verticesV (%d elements) and verticesA (%d elements) must have the same lengths.\n",
+                  getDescription_c(), numVertices, numVerticesA);
          }
          MPI_Barrier(this->getParent()->icCommunicator()->communicator());
          exit(EXIT_FAILURE);
@@ -255,8 +255,8 @@ int PtwiseLinearTransferLayer::checkVertices() {
       if (verticesV[v] < verticesV[v-1]) {
          status = PV_FAILURE;
          if (this->getParent()->columnId()==0) {
-            pvErrorNoExit().printf("%s \"%s\": vertices %d and %d: V-coordinates decrease from %f to %f.\n",
-                  this->getKeyword(), this->getName(), v, v+1, verticesV[v-1], verticesV[v]);
+            pvErrorNoExit().printf("%s: vertices %d and %d: V-coordinates decrease from %f to %f.\n",
+                  getDescription_c(), v, v+1, verticesV[v-1], verticesV[v]);
          }
       }
    }
@@ -269,8 +269,8 @@ int PtwiseLinearTransferLayer::setSlopes() {
    assert(verticesV!=NULL);
    slopes = (float *) malloc((size_t)(numVertices+1)*sizeof(*slopes));
    if (slopes == NULL) {
-      pvErrorNoExit().printf("%s \"%s\": unable to allocate memory for transfer function slopes: %s\n",
-            this->getKeyword(), name, strerror(errno));
+      pvErrorNoExit().printf("%s: unable to allocate memory for transfer function slopes: %s\n",
+            getDescription_c(), strerror(errno));
       exit(EXIT_FAILURE);
       
    }

--- a/src/layers/Retina.cpp
+++ b/src/layers/Retina.cpp
@@ -336,13 +336,14 @@ void Retina::ioParam_backgroundRate(enum ParamsIOFlag ioFlag) {
       }
    }
    // noiseOffFreq and poissonBlankProb was deprecated Jan 24, 2013 and marked obsolete Jun 27, 2016.
-   // After a reasonable fade time, remove the above if-statement and keep the ioParamValue call below.
+   // After a reasonable fade time, remove the above if-statement and keep the ioParamValue call below
+   // and the sanity check following it.
    parent->ioParamValue(ioFlag, name, "backgroundRate", &probBaseParam, 0.0f);
    if (ioFlag==PARAMS_IO_READ) {
       assert(!parent->parameters()->presentAndNotBeenRead(name, "foregroundRate"));
       if (probBaseParam > probStimParam) {
-         pvError().printf("Error in %s \"%s\": backgroundRate cannot be greater than foregroundRate.\n",
-               getKeyword(), name);
+         pvError().printf("%s: backgroundRate cannot be greater than foregroundRate.\n",
+               getDescription_c());
          exit(EXIT_FAILURE);
       }
    }
@@ -426,7 +427,7 @@ int Retina::checkpointWrite(const char * cpDir) {
    int chars_needed = snprintf(filename, PV_PATH_MAX, "%s/%s_rand_state.bin", cpDir, name);
    if(chars_needed >= PV_PATH_MAX) {
       if (parent->icCommunicator()->commRank()==0) {
-         pvErrorNoExit().printf("HyPerLayer::checkpointWrite for layer \"%s\":  base pathname \"%s/%s_rand_state.bin\" too long.\n", name, cpDir, name);
+         pvErrorNoExit().printf("HyPerLayer::checkpointWrite for %s:  base pathname \"%s/%s_rand_state.bin\" too long.\n", getDescription_c(), cpDir, name);
       }
       abort();
    }

--- a/src/layers/SegmentLayer.cpp
+++ b/src/layers/SegmentLayer.cpp
@@ -52,8 +52,8 @@ void SegmentLayer::ioParam_segmentMethod(enum ParamsIOFlag ioFlag) {
    //How do we segment across MPI margins?
    else{
       if (parent->columnId()==0) {
-         pvErrorNoExit().printf("%s \"%s\": segmentMethod %s not recognized. Current options are \"none\".\n",
-                 getKeyword(), name, segmentMethod);
+         pvErrorNoExit().printf("%s: segmentMethod %s not recognized. Current options are \"none\".\n",
+                 getDescription_c(), segmentMethod);
       }
       MPI_Barrier(parent->icCommunicator()->communicator());
       exit(EXIT_FAILURE);
@@ -65,8 +65,8 @@ void SegmentLayer::ioParam_originalLayerName(enum ParamsIOFlag ioFlag) {
    assert(originalLayerName);
    if (ioFlag==PARAMS_IO_READ && originalLayerName[0]=='\0') {
       if (parent->columnId()==0) {
-         pvErrorNoExit().printf("%s \"%s\": originalLayerName must be set.\n",
-                 getKeyword(), name);
+         pvErrorNoExit().printf("%s: originalLayerName must be set.\n",
+                 getDescription_c());
       }
       MPI_Barrier(parent->icCommunicator()->communicator());
       exit(EXIT_FAILURE);
@@ -79,8 +79,8 @@ int SegmentLayer::communicateInitInfo() {
    originalLayer = parent->getLayerFromName(originalLayerName);
    if (originalLayer==NULL) {
       if (parent->columnId()==0) {
-         pvErrorNoExit().printf("%s \"%s\": originalLayerName \"%s\" is not a layer in the HyPerCol.\n",
-                 getKeyword(), name, originalLayerName);
+         pvErrorNoExit().printf("%s: originalLayerName \"%s\" is not a layer in the HyPerCol.\n",
+                 getDescription_c(), originalLayerName);
       }
       MPI_Barrier(parent->icCommunicator()->communicator());
       exit(EXIT_FAILURE);
@@ -101,8 +101,8 @@ int SegmentLayer::communicateInitInfo() {
    if (srcLoc->nxGlobal != thisLoc->nxGlobal || srcLoc->nyGlobal != thisLoc->nyGlobal) {
       if (parent->columnId()==0) {
          pvErrorNoExit(errorMessage);
-         errorMessage.printf("%s \"%s\": originalLayer \"%s\" does not have the same x and y dimensions as this layer.\n",
-                 getKeyword(), name, originalLayerName);
+         errorMessage.printf("%s: originalLayer \"%s\" does not have the same x and y dimensions as this layer.\n",
+                 getDescription_c(), originalLayerName);
          errorMessage.printf("    original (nx=%d, ny=%d) versus (nx=%d, ny=%d)\n",
                  srcLoc->nxGlobal, srcLoc->nyGlobal, thisLoc->nxGlobal, thisLoc->nyGlobal);
       }
@@ -113,8 +113,8 @@ int SegmentLayer::communicateInitInfo() {
    //This layer must have only 1 feature
    if(thisLoc->nf != 1){
       if (parent->columnId()==0) {
-         pvErrorNoExit().printf("%s \"%s\": SegmentLayer must have 1 feature.\n",
-                 getKeyword(), name);
+         pvErrorNoExit().printf("%s: SegmentLayer must have 1 feature.\n",
+                 getDescription_c());
       }
       MPI_Barrier(parent->icCommunicator()->communicator());
       exit(EXIT_FAILURE);
@@ -123,8 +123,8 @@ int SegmentLayer::communicateInitInfo() {
    //If segmentMethod is none, we also need to make sure the srcLayer also has nf == 1
    if(strcmp(segmentMethod, "none") == 0 && srcLoc->nf != 1){
       if (parent->columnId()==0) {
-         pvErrorNoExit().printf("%s \"%s\": Source layer must have 1 feature with segmentation method \"none\".\n",
-                 getKeyword(), name);
+         pvErrorNoExit().printf("%s: Source layer must have 1 feature with segmentation method \"none\".\n",
+                 getDescription_c());
       }
       MPI_Barrier(parent->icCommunicator()->communicator());
       exit(EXIT_FAILURE);

--- a/src/layers/Segmentify.cpp
+++ b/src/layers/Segmentify.cpp
@@ -51,8 +51,8 @@ void Segmentify::ioParam_inputMethod(enum ParamsIOFlag ioFlag) {
    }
    else{
       if (parent->columnId()==0) {
-         pvErrorNoExit().printf("%s \"%s\": inputMethod must be \"average\", \"sum\", or \"max\".\n",
-                 getKeyword(), name);
+         pvErrorNoExit().printf("%s: inputMethod must be \"average\", \"sum\", or \"max\".\n",
+                 getDescription_c());
       }
       MPI_Barrier(parent->icCommunicator()->communicator());
       exit(EXIT_FAILURE);
@@ -67,8 +67,8 @@ void Segmentify::ioParam_outputMethod(enum ParamsIOFlag ioFlag) {
    }
    else{
       if (parent->columnId()==0) {
-         pvErrorNoExit().printf("%s \"%s\": outputMethod must be \"centriod\" or \"fill\".\n",
-                 getKeyword(), name);
+         pvErrorNoExit().printf("%s: outputMethod must be \"centriod\" or \"fill\".\n",
+                 getDescription_c());
       }
       MPI_Barrier(parent->icCommunicator()->communicator());
       exit(EXIT_FAILURE);
@@ -80,8 +80,8 @@ void Segmentify::ioParam_originalLayerName(enum ParamsIOFlag ioFlag) {
    assert(originalLayerName);
    if (ioFlag==PARAMS_IO_READ && originalLayerName[0]=='\0') {
       if (parent->columnId()==0) {
-         pvErrorNoExit().printf("%s \"%s\": originalLayerName must be set.\n",
-                 getKeyword(), name);
+         pvErrorNoExit().printf("%s: originalLayerName must be set.\n",
+                 getDescription_c());
       }
       MPI_Barrier(parent->icCommunicator()->communicator());
       exit(EXIT_FAILURE);
@@ -93,8 +93,8 @@ void Segmentify::ioParam_segmentLayerName(enum ParamsIOFlag ioFlag) {
    assert(segmentLayerName);
    if (ioFlag==PARAMS_IO_READ && segmentLayerName[0]=='\0') {
       if (parent->columnId()==0) {
-         pvErrorNoExit().printf("%s \"%s\": segmentLayerName must be set.\n",
-                 getKeyword(), name);
+         pvErrorNoExit().printf("%s: segmentLayerName must be set.\n",
+                 getDescription_c());
       }
       MPI_Barrier(parent->icCommunicator()->communicator());
       exit(EXIT_FAILURE);
@@ -108,8 +108,8 @@ int Segmentify::communicateInitInfo() {
    originalLayer = parent->getLayerFromName(originalLayerName);
    if (originalLayer==NULL) {
       if (parent->columnId()==0) {
-         pvErrorNoExit().printf("%s \"%s\": originalLayerName \"%s\" is not a layer in the HyPerCol.\n",
-                 getKeyword(), name, originalLayerName);
+         pvErrorNoExit().printf("%s: originalLayerName \"%s\" is not a layer in the HyPerCol.\n",
+                 getDescription_c(), originalLayerName);
       }
       MPI_Barrier(parent->icCommunicator()->communicator());
       exit(EXIT_FAILURE);
@@ -122,8 +122,8 @@ int Segmentify::communicateInitInfo() {
    HyPerLayer* tmpLayer = parent->getLayerFromName(segmentLayerName);
    if (tmpLayer==NULL) {
       if (parent->columnId()==0) {
-         pvErrorNoExit().printf("%s \"%s\": segmentLayerName \"%s\" is not a layer in the HyPerCol.\n",
-                 getKeyword(), name, segmentLayerName);
+         pvErrorNoExit().printf("%s: segmentLayerName \"%s\" is not a layer in the HyPerCol.\n",
+                 getDescription_c(), segmentLayerName);
       }
       MPI_Barrier(parent->icCommunicator()->communicator());
       exit(EXIT_FAILURE);
@@ -131,8 +131,8 @@ int Segmentify::communicateInitInfo() {
    segmentLayer = dynamic_cast <SegmentLayer*>(tmpLayer);
    if (segmentLayer==NULL) {
       if (parent->columnId()==0) {
-         pvErrorNoExit().printf("%s \"%s\": segmentLayerName \"%s\" is not a SegmentLayer.\n",
-                 getKeyword(), name, segmentLayerName);
+         pvErrorNoExit().printf("%s: segmentLayerName \"%s\" is not a SegmentLayer.\n",
+                 getDescription_c(), segmentLayerName);
       }
       MPI_Barrier(parent->icCommunicator()->communicator());
       exit(EXIT_FAILURE);
@@ -156,8 +156,8 @@ int Segmentify::communicateInitInfo() {
    if (srcLoc->nf != thisLoc->nf) {
       if (parent->columnId()==0) {
          pvErrorNoExit(errorMessage);
-         errorMessage.printf("%s \"%s\": originalLayer \"%s\" does not have the same feature dimension as this layer.\n",
-                 getKeyword(), name, originalLayerName);
+         errorMessage.printf("%s: originalLayer \"%s\" does not have the same feature dimension as this layer.\n",
+                 getDescription_c(), originalLayerName);
          errorMessage.printf("    original (nf=%d) versus (nf=%d)\n",
                  srcLoc->nf, thisLoc->nf);
       }
@@ -168,8 +168,8 @@ int Segmentify::communicateInitInfo() {
    //Segment layer must have 1 feature
    if(segLoc->nf != 1){
       if (parent->columnId()==0) {
-         pvErrorNoExit().printf("%s \"%s\": segmentLayer \"%s\" can only have 1 feature.\n",
-         getKeyword(), name, segmentLayerName);
+         pvErrorNoExit().printf("%s: segmentLayer \"%s\" can only have 1 feature.\n",
+         getDescription_c(), segmentLayerName);
       }
       MPI_Barrier(parent->icCommunicator()->communicator());
       exit(EXIT_FAILURE);

--- a/src/layers/SigmoidLayer.cpp
+++ b/src/layers/SigmoidLayer.cpp
@@ -45,7 +45,7 @@ int SigmoidLayer::initialize(const char * name, HyPerCol * hc) {
 
    if (SigmoidAlpha < 0.0f || SigmoidAlpha > 1.0f) {
       if (parent->columnId()==0) {
-         pvErrorNoExit().printf("%s \"%s\": SigmoidAlpha cannot be negative or greater than 1.\n", getKeyword(), name);
+         pvErrorNoExit().printf("%s: SigmoidAlpha cannot be negative or greater than 1.\n", getDescription_c());
       }
       MPI_Barrier(parent->icCommunicator()->communicator());
       exit(EXIT_FAILURE);

--- a/src/layers/WTALayer.cpp
+++ b/src/layers/WTALayer.cpp
@@ -33,8 +33,8 @@ int WTALayer::communicateInitInfo() {
    originalLayer = parent->getLayerFromName(originalLayerName);
    if (originalLayer==NULL) {
       if (parent->columnId()==0) {
-         pvErrorNoExit().printf("%s \"%s\": originalLayerName \"%s\" is not a layer in the HyPerCol.\n",
-                 getKeyword(), name, originalLayerName);
+         pvErrorNoExit().printf("%s: originalLayerName \"%s\" is not a layer in the HyPerCol.\n",
+                 getDescription_c(), originalLayerName);
       }
       MPI_Barrier(parent->icCommunicator()->communicator());
       exit(EXIT_FAILURE);
@@ -50,8 +50,8 @@ int WTALayer::communicateInitInfo() {
    if (srcLoc->nxGlobal != loc->nxGlobal || srcLoc->nyGlobal != loc->nyGlobal) {
       if (parent->columnId()==0) {
          pvErrorNoExit(errorMessage);
-         errorMessage.printf("%s \"%s\": originalLayerName \"%s\" does not have the same dimensions.\n",
-                 getKeyword(), name, originalLayerName);
+         errorMessage.printf("%s: originalLayerName \"%s\" does not have the same dimensions.\n",
+                 getDescription_c(), originalLayerName);
          errorMessage.printf("    original (nx=%d, ny=%d) versus (nx=%d, ny=%d)\n",
                  srcLoc->nxGlobal, srcLoc->nyGlobal, loc->nxGlobal, loc->nyGlobal);
       }
@@ -59,8 +59,8 @@ int WTALayer::communicateInitInfo() {
       exit(EXIT_FAILURE);
    }
    if(getLayerLoc()->nf != 1){
-      pvErrorNoExit().printf("%s \"%s\": WTALayer can only have 1 feature.\n",
-         getKeyword(), name);
+      pvErrorNoExit().printf("%s: WTALayer can only have 1 feature.\n",
+         getDescription_c());
    }
    assert(srcLoc->nx==loc->nx && srcLoc->ny==loc->ny);
    return status;
@@ -92,8 +92,8 @@ void WTALayer::ioParam_originalLayerName(enum ParamsIOFlag ioFlag) {
    assert(originalLayerName);
    if (ioFlag==PARAMS_IO_READ && originalLayerName[0]=='\0') {
       if (parent->columnId()==0) {
-         pvErrorNoExit().printf("%s \"%s\": originalLayerName must be set.\n",
-                 getKeyword(), name);
+         pvErrorNoExit().printf("%s: originalLayerName must be set.\n",
+                 getDescription_c());
       }
       MPI_Barrier(parent->icCommunicator()->communicator());
       exit(EXIT_FAILURE);
@@ -105,8 +105,8 @@ void WTALayer::ioParam_binMaxMin(enum ParamsIOFlag ioFlag) {
    parent->ioParamValue(ioFlag, name, "binMin", &binMin, binMin);
    if(ioFlag == PARAMS_IO_READ && binMax <= binMin){
       if (parent->columnId()==0) {
-         pvErrorNoExit().printf("%s \"%s\": binMax (%f) must be greater than binMin (%f).\n",
-            getKeyword(), name, binMax, binMin);
+         pvErrorNoExit().printf("%s: binMax (%f) must be greater than binMin (%f).\n",
+            getDescription_c(), binMax, binMin);
       }
       MPI_Barrier(parent->icCommunicator()->communicator());
       exit(EXIT_FAILURE);

--- a/src/normalizers/NormalizeBase.cpp
+++ b/src/normalizers/NormalizeBase.cpp
@@ -40,6 +40,19 @@ int NormalizeBase::initialize(const char * name, HyPerCol * hc) {
    return status;
 }
 
+int NormalizeBase::setDescription() {
+   description.clear();
+   char const * method = parent->parameters()->stringValue(name, "normalizeMethod", false/*do not warn if absent*/);
+   if (method==nullptr) {
+      description.append("weight normalizer ");
+   }
+   else {
+      description.append(method);
+   }
+   description.append(" \"").append(name).append("\"");
+   return PV_SUCCESS;
+}
+
 int NormalizeBase::ioParamsFillGroup(enum ParamsIOFlag ioFlag) {
    ioParam_strength(ioFlag);
    ioParam_normalizeArborsIndividually(ioFlag);
@@ -71,7 +84,7 @@ void NormalizeBase::communicateInitInfo() {
 HyPerConn * NormalizeBase::getTargetConn() {
    BaseConnection * baseConn = parent->getConnFromName(name);
    HyPerConn * targetConn = dynamic_cast<HyPerConn *>(baseConn);
-   pvAssertMessage(targetConn, "%s \"%s\": target connection \"%s\" is not a HyPerConn\n", getKeyword(), name, name);
+   pvAssertMessage(targetConn, "%s: target connection \"%s\" is not a HyPerConn\n", getDescription_c(), name);
    return targetConn;
 }
 
@@ -198,13 +211,13 @@ int NormalizeBase::addConnToList(HyPerConn * newConn) {
       newList = (HyPerConn **) malloc(sizeof(*connectionList)*(numConnections+1));
    }
    if (newList==NULL) {
-      pvError().printf("Normalizer \"%s\" unable to add connection \"%s\" as connection number %d : %s\n", name, newConn->getName(), numConnections+1, strerror(errno));
+      pvError().printf("%s unable to add %s as connection number %d : %s\n", getDescription_c(), newConn->getDescription_c(), numConnections+1, strerror(errno));
    }
    connectionList = newList;
    connectionList[numConnections] = newConn;
    numConnections++;
    if (parent->columnId()==0) {
-      pvInfo().printf("Adding connection \"%s\" to normalizer group \"%s\".\n", newConn->getName(), this->getName());
+      pvInfo().printf("Adding %s to normalizer group \"%s\".\n", newConn->getDescription_c(), this->getName());
    }
    return PV_SUCCESS;
 }

--- a/src/normalizers/NormalizeBase.hpp
+++ b/src/normalizers/NormalizeBase.hpp
@@ -52,6 +52,7 @@ public:
 protected:
    NormalizeBase();
    int initialize(const char * name, HyPerCol * hc);
+   virtual int setDescription();
 
    virtual void ioParam_strength(enum ParamsIOFlag ioFlag);
    virtual void ioParam_normalizeArborsIndividually(enum ParamsIOFlag ioFlag);

--- a/src/normalizers/NormalizeContrastZeroMean.cpp
+++ b/src/normalizers/NormalizeContrastZeroMean.cpp
@@ -59,15 +59,15 @@ int NormalizeContrastZeroMean::normalizeWeights() {
       HyPerConn * conn = connectionList[c];
       if (conn->numberOfAxonalArborLists() != conn0->numberOfAxonalArborLists()) {
          if (parent->columnId() == 0) {
-            pvErrorNoExit().printf("Normalizer %s: All connections in the normalization group must have the same number of arbors (Connection \"%s\" has %d; connection \"%s\" has %d).\n",
-                  this->getName(), conn0->getName(), conn0->numberOfAxonalArborLists(), conn->getName(), conn->numberOfAxonalArborLists());
+            pvErrorNoExit().printf("%s: All connections in the normalization group must have the same number of arbors (%s has %d; %s has %d).\n",
+                  getDescription_c(), conn0->getDescription_c(), conn0->numberOfAxonalArborLists(), conn->getDescription_c(), conn->numberOfAxonalArborLists());
          }
          status = PV_FAILURE;
       }
       if (conn->getNumDataPatches() != conn0->getNumDataPatches()) {
          if (parent->columnId() == 0) {
-            pvErrorNoExit().printf("Normalizer %s: All connections in the normalization group must have the same number of data patches (Connection \"%s\" has %d; connection \"%s\" has %d).\n",
-                  this->getName(), conn0->getName(), conn0->getNumDataPatches(), conn->getName(), conn->getNumDataPatches());
+            pvErrorNoExit().printf("%s: All connections in the normalization group must have the same number of data patches (%s has %d; %s has %d).\n",
+                  getDescription_c(), conn0->getDescription_c(), conn0->getNumDataPatches(), conn->getDescription_c(), conn->getNumDataPatches());
          }
          status = PV_FAILURE;
       }

--- a/src/normalizers/NormalizeGroup.cpp
+++ b/src/normalizers/NormalizeGroup.cpp
@@ -50,8 +50,8 @@ void NormalizeGroup::communicateInitInfo() {
    groupHead = parent->getNormalizerFromName(normalizeGroupName);
    if (groupHead==nullptr) {
       if (parent->columnId()==0) {
-         pvErrorNoExit().printf("%s \"%s\" error: normalizeGroupName \"%s\" is not a recognized normalizer.\n",
-               getKeyword(), name, normalizeGroupName);
+         pvErrorNoExit().printf("%s: normalizeGroupName \"%s\" is not a recognized normalizer.\n",
+               getDescription_c(), normalizeGroupName);
       }
       MPI_Barrier(parent->icCommunicator()->communicator());
       exit(EXIT_FAILURE);

--- a/src/normalizers/NormalizeL2.cpp
+++ b/src/normalizers/NormalizeL2.cpp
@@ -47,7 +47,7 @@ int NormalizeL2::normalizeWeights() {
    float scale_factor = 1.0f;
    if (normalizeFromPostPerspective) {
       if (conn0->usingSharedWeights()==false) {
-         pvError().printf("NormalizeL2 error for connection \"%s\": normalizeFromPostPerspective is true but connection does not use shared weights.\n", conn0->getName());
+         pvError().printf("NormalizeL2 error for %s: normalizeFromPostPerspective is true but connection does not use shared weights.\n", conn0->getDescription_c());
       }
       scale_factor = ((float) conn0->postSynapticLayer()->getNumNeurons())/((float) conn0->preSynapticLayer()->getNumNeurons());
    }

--- a/src/normalizers/NormalizeMax.cpp
+++ b/src/normalizers/NormalizeMax.cpp
@@ -48,7 +48,7 @@ int NormalizeMax::normalizeWeights() {
    float scale_factor = 1.0f;
    if (normalizeFromPostPerspective) {
       if (conn0->usingSharedWeights()==false) {
-         pvError().printf("NormalizeMax error for connection \"%s\": normalizeFromPostPerspective is true but connection does not use shared weights.\n", getName());
+         pvError().printf("NormalizeMax error for %s: normalizeFromPostPerspective is true but connection does not use shared weights.\n", getDescription_c());
       }
       scale_factor = ((float) conn0->postSynapticLayer()->getNumNeurons())/((float) conn0->preSynapticLayer()->getNumNeurons());
    }

--- a/src/normalizers/NormalizeMultiply.cpp
+++ b/src/normalizers/NormalizeMultiply.cpp
@@ -79,22 +79,22 @@ int NormalizeMultiply::normalizeWeights() {
       // Do we need to require sharedWeights be the same for all connections in the group?
       if (conn->usingSharedWeights()!=conn0->usingSharedWeights()) {
          if (parent->columnId() == 0) {
-            pvErrorNoExit().printf("Normalizer %s: All connections in the normalization group must have the same sharedWeights (Connection \"%s\" has %d; connection \"%s\" has %d).\n",
-                  this->getName(), conn0->getName(), conn0->usingSharedWeights(), conn->getName(), conn->usingSharedWeights());
+            pvErrorNoExit().printf("%s: All connections in the normalization group must have the same sharedWeights (%s has %d; %s has %d).\n",
+                  this->getDescription_c(), conn0->getDescription_c(), conn0->usingSharedWeights(), conn->getDescription_c(), conn->usingSharedWeights());
          }
          status = PV_FAILURE;
       }
       if (conn->numberOfAxonalArborLists() != conn0->numberOfAxonalArborLists()) {
          if (parent->columnId() == 0) {
-            pvErrorNoExit().printf("Normalizer %s: All connections in the normalization group must have the same number of arbors (Connection \"%s\" has %d; connection \"%s\" has %d).\n",
-                  this->getName(), conn0->getName(), conn0->numberOfAxonalArborLists(), conn->getName(), conn->numberOfAxonalArborLists());
+            pvErrorNoExit().printf("%s: All connections in the normalization group must have the same number of arbors (%s has %d; %s has %d).\n",
+                  this->getDescription_c(), conn0->getDescription_c(), conn0->numberOfAxonalArborLists(), conn->getDescription_c(), conn->numberOfAxonalArborLists());
          }
          status = PV_FAILURE;
       }
       if (conn->getNumDataPatches() != conn0->getNumDataPatches()) {
          if (parent->columnId() == 0) {
-            pvErrorNoExit().printf("Normalizer %s: All connections in the normalization group must have the same number of data patches (Connection \"%s\" has %d; connection \"%s\" has %d).\n",
-                  this->getName(), conn0->getName(), conn0->getNumDataPatches(), conn->getName(), conn->getNumDataPatches());
+            pvErrorNoExit().printf("%s: All connections in the normalization group must have the same number of data patches (%s has %d; %s has %d).\n",
+                  this->getDescription_c(), conn0->getDescription_c(), conn0->getNumDataPatches(), conn->getDescription_c(), conn->getNumDataPatches());
          }
          status = PV_FAILURE;
       }

--- a/src/normalizers/NormalizeSum.cpp
+++ b/src/normalizers/NormalizeSum.cpp
@@ -48,7 +48,7 @@ int NormalizeSum::normalizeWeights() {
    float scale_factor = 1.0f;
    if (normalizeFromPostPerspective) {
       if (conn0->usingSharedWeights()==false) {
-         pvError().printf("NormalizeSum error for connection \"%s\": normalizeFromPostPerspective is true but connection does not use shared weights.\n", getName());
+         pvError().printf("NormalizeSum error for %s: normalizeFromPostPerspective is true but connection does not use shared weights.\n", getDescription_c());
       }
       scale_factor = ((float) conn0->postSynapticLayer()->getNumNeurons())/((float) conn0->preSynapticLayer()->getNumNeurons());
    }
@@ -73,7 +73,7 @@ int NormalizeSum::normalizeWeights() {
                accumulateSum(dataStartPatch, weights_per_patch, &sum);
 			}
 			if (fabs(sum) <= minSumTolerated) {
-			   pvWarn().printf("NormalizeSum for connection \"%s\": sum of weights in patch %d of arbor %d is within minSumTolerated=%f of zero. Weights in this patch unchanged.\n", getName(), patchindex, arborID, minSumTolerated);
+			   pvWarn().printf("NormalizeSum for %s: sum of weights in patch %d of arbor %d is within minSumTolerated=%f of zero. Weights in this patch unchanged.\n", getDescription_c(), patchindex, arborID, minSumTolerated);
 			   break;
 			}
             for (int c=0; c<numConnections; c++) {
@@ -103,7 +103,7 @@ int NormalizeSum::normalizeWeights() {
             }
          }
          if (fabs(sum) <= minSumTolerated) {
-            pvWarn().printf("NormalizeSum for connection \"%s\": sum of weights in patch %d is within minSumTolerated=%f of zero.  Weights in this patch unchanged.\n", getName(), patchindex, minSumTolerated);
+            pvWarn().printf("NormalizeSum for %s: sum of weights in patch %d is within minSumTolerated=%f of zero.  Weights in this patch unchanged.\n", getDescription_c(), patchindex, minSumTolerated);
             break;
 
          }

--- a/src/weightinit/InitWeights.cpp
+++ b/src/weightinit/InitWeights.cpp
@@ -47,6 +47,19 @@ int InitWeights::initialize(char const * name, HyPerCol * hc) {
    return PV_SUCCESS;
 }
 
+int InitWeights::setDescription() {
+   description.clear();
+   char const * initType = parent->parameters()->stringValue(name, "weightInitType", false/*do not warn if absent*/);
+   if (initType==nullptr) {
+      description.append("weight initializer ");
+   }
+   else {
+      description.append(initType);
+   }
+   description.append(" \"").append(name).append("\"");
+   return PV_SUCCESS;
+}
+
 int InitWeights::ioParamsFillGroup(enum ParamsIOFlag ioFlag) {
    // Read/write any params from the params file, typically
    // parent->ioParamValue(ioFlag, name, "param_name", &param, default_value);
@@ -107,7 +120,7 @@ int InitWeights::initializeWeights(PVPatch *** patches, pvwdata_t ** dataStart,
    int numPatches = callingConn->getNumDataPatches();
    if (inputParams->present(callingConn->getName(), "initFromLastFlag")) {
       if (callingConn->getParent()->columnId()==0) {
-         pvErrorNoExit().printf("Connection \"%s\": initFromLastFlag is obsolete.\n", callingConn->getName());
+         pvErrorNoExit().printf("%s: initFromLastFlag is obsolete.\n", callingConn->getDescription_c());
       }
       if (inputParams->value(callingConn->getName(), "initFromLastFlag")) {
          if (callingConn->getParent()->columnId()==0) {

--- a/src/weightinit/InitWeights.hpp
+++ b/src/weightinit/InitWeights.hpp
@@ -55,6 +55,7 @@ public:
 protected:
    InitWeights();
    int initialize(const char * name, HyPerCol * hc);
+   virtual int setDescription();
    virtual int initRNGs(bool isKernel) { return PV_SUCCESS; }
    virtual int zeroWeightsOutsideShrunkenPatch(PVPatch *** patches);
    virtual int readListOfArborFiles(PVPatch *** patches, pvwdata_t ** dataStart,int numPatches,

--- a/tests/DatastoreDelayTest/src/DatastoreDelayTestProbe.cpp
+++ b/tests/DatastoreDelayTest/src/DatastoreDelayTestProbe.cpp
@@ -51,12 +51,12 @@ int DatastoreDelayTestProbe::outputState(double timed) {
       pvdata_t * V = l->getV();
       for( int k=0; k<l->getNumNeuronsAllBatches(); k++ ) {
          if( V[k] != correctValue ) {
-            outputStream->printf("Layer \"%s\": timef = %f, neuron %d: value is %f instead of %d\n", l->getName(), timed, k, V[k], (int) correctValue);
+            outputStream->printf("%s: timef = %f, neuron %d: value is %f instead of %d\n", l->getDescription_c(), timed, k, V[k], (int) correctValue);
             status = PV_FAILURE;
          }
       }
       if( status == PV_SUCCESS) {
-         outputStream->printf("Layer \"%s\": timef = %f, all neurons have correct value %d\n", l->getName(), timed, (int) correctValue);
+         outputStream->printf("%s: timef = %f, all neurons have correct value %d\n", l->getDescription_c(), timed, (int) correctValue);
       }
    }
    assert(status == PV_SUCCESS);

--- a/tests/GenericSystemTest/src/main.cpp
+++ b/tests/GenericSystemTest/src/main.cpp
@@ -276,8 +276,8 @@ int assertAllZeroes(HyPerCol * hc, int argc, char * argv[]) {
    if (allzeroProbe->getNonzeroFound()) {
       if (hc->columnId()==0) {
          double t = allzeroProbe->getNonzeroTime();
-         pvErrorNoExit().printf("%s \"%s\" had at least one nonzero activity value, beginning at time %f\n",
-               layer->getKeyword(), targetLayerName, t);
+         pvErrorNoExit().printf("%s had at least one nonzero activity value, beginning at time %f\n",
+               layer->getDescription_c(), t);
       }
       MPI_Barrier(hc->icCommunicator()->communicator());
       exit(EXIT_FAILURE);

--- a/tests/KernelActivationTest/src/KernelActivationTest.cpp
+++ b/tests/KernelActivationTest/src/KernelActivationTest.cpp
@@ -112,7 +112,7 @@ int dumponeweight(HyPerConn * conn) {
                       errorfound = true;
                       for( int k=0; k<72; k++ ) { pvInfo().printf("="); }
                       errorMessage.printf("\n");
-                      errorMessage.printf("Rank %d, Connection \"%s\":\n",rank, conn->getName());
+                      errorMessage.printf("Rank %d, %s:\n",rank, conn->getDescription_c());
                   }
                   errorMessage.printf("Rank %d, Patch %d, x=%d, y=%d, f=%d: weight=%f, correct=%f, off by a factor of %f\n", rank, p, x, y, f, wgt, correct, wgt/correct);
                   status = PV_FAILURE;
@@ -122,7 +122,7 @@ int dumponeweight(HyPerConn * conn) {
       }
    }
    if( status == PV_SUCCESS ) {
-      pvInfo().printf("Rank %d, connection \"%s\": Weights are correct.\n", rank, conn->getName());
+      pvInfo().printf("Rank %d, %s: Weights are correct.\n", rank, conn->getDescription_c());
    }
    return status;
 }

--- a/tests/LCATest/src/main.cpp
+++ b/tests/LCATest/src/main.cpp
@@ -252,8 +252,8 @@ int assertAllZeroes(HyPerCol * hc, int argc, char * argv[]) {
    if (allzeroProbe->getNonzeroFound()) {
       if (hc->columnId()==0) {
          double t = allzeroProbe->getNonzeroTime();
-         pvErrorNoExit().printf("%s \"%s\" had at least one nonzero activity value, beginning at time %f\n",
-               layer->getKeyword(), targetLayerName, t);
+         pvErrorNoExit().printf("%s had at least one nonzero activity value, beginning at time %f\n",
+               layer->getDescription_c(), t);
       }
       MPI_Barrier(hc->icCommunicator()->communicator());
       exit(EXIT_FAILURE);

--- a/tests/MaskLayerTest/src/MaskTestLayer.cpp
+++ b/tests/MaskLayerTest/src/MaskTestLayer.cpp
@@ -31,8 +31,8 @@ void MaskTestLayer::ioParam_maskMethod(enum ParamsIOFlag ioFlag) {
    }
    else{
       if (parent->columnId()==0) {
-         pvErrorNoExit().printf("%s \"%s\" error: \"%s\" is not a valid maskMethod. Options are \"invertLayer\", \"maskFeatures\", or \"noMaskFeatures\".\n",
-                 getKeyword(), name, maskMethod);
+         pvErrorNoExit().printf("%s: \"%s\" is not a valid maskMethod. Options are \"invertLayer\", \"maskFeatures\", or \"noMaskFeatures\".\n",
+               getDescription_c(), maskMethod);
       }
       exit(-1);
    }

--- a/tests/MomentumLCATest/src/main.cpp
+++ b/tests/MomentumLCATest/src/main.cpp
@@ -252,8 +252,8 @@ int assertAllZeroes(HyPerCol * hc, int argc, char * argv[]) {
    if (allzeroProbe->getNonzeroFound()) {
       if (hc->columnId()==0) {
          double t = allzeroProbe->getNonzeroTime();
-         pvErrorNoExit().printf("%s \"%s\" had at least one nonzero activity value, beginning at time %f\n",
-               layer->getKeyword(), targetLayerName, t);
+         pvErrorNoExit().printf("%s had at least one nonzero activity value, beginning at time %f\n",
+               layer->getDescription_c(), t);
       }
       MPI_Barrier(hc->icCommunicator()->communicator());
       exit(EXIT_FAILURE);

--- a/tests/MomentumTest/src/MomentumConnTestProbe.cpp
+++ b/tests/MomentumTest/src/MomentumConnTestProbe.cpp
@@ -47,11 +47,11 @@ int MomentumConnTestProbe::outputState(double timed) {
       return PV_SUCCESS;
    }
    assert(getTargetConn()!=NULL);
-   outputStream->printf("    Time %f, connection \"%s\":\n", timed, getTargetName());
+   outputStream->printf("    Time %f, %s:\n", timed, getTargetConn()->getDescription_c());
    const pvwdata_t * w = c->get_wDataHead(getArbor(), getKernelIndex());
    const pvdata_t * dw = c->get_dwDataHead(getArbor(), getKernelIndex());
    if( getOutputPlasticIncr() && dw == NULL ) {
-      pvError().printf("MomentumConnTestProbe \"%s\": connection \"%s\" has dKernelData(%d,%d) set to null.\n", getName(), getTargetName(), getKernelIndex(), getArbor());
+      pvError().printf("%s: %s has dKernelData(%d,%d) set to null.\n", getDescription_c(), getTargetConn()->getDescription_c(), getKernelIndex(), getArbor());
    }
    int nxp = c->xPatchSize();
    int nyp = c->yPatchSize();

--- a/tests/MovieSystemTest/src/TestAllZerosProbe.cpp
+++ b/tests/MovieSystemTest/src/TestAllZerosProbe.cpp
@@ -19,7 +19,7 @@ TestAllZerosProbe::TestAllZerosProbe(const char * probeName, HyPerCol * hc) {
 int TestAllZerosProbe::outputState(double timed) {
    int status = StatsProbe::outputState(timed);
    if (status != PV_SUCCESS) {
-      pvError().printf("!!Time %f: TestAllZerosProbe::outputState failed for layer \"%s\"\n", timed, getTargetLayer()->getName());
+      pvError().printf("!!Time %f: TestAllZerosProbe::outputState failed for %s\n", timed, getTargetLayer()->getDescription_c());
    }
    InterColComm * icComm = getTargetLayer()->getParent()->icCommunicator();
    const int rcvProc = 0;
@@ -28,7 +28,7 @@ int TestAllZerosProbe::outputState(double timed) {
    }
    for(int b = 0; b < parent->getNBatch(); b++){
       if (nnz[b] != 0) {
-         pvError().printf("!!Time %f batch %d: layer \"%s\" is not all zeroes.\n", timed, b, getTargetLayer()->getName());
+         pvError().printf("!!Time %f batch %d: %s is not all zeroes.\n", timed, b, getTargetLayer()->getDescription_c());
       }
    }
    return status;

--- a/tests/NormalizeSubclassSystemTest/src/NormalizeL3.cpp
+++ b/tests/NormalizeSubclassSystemTest/src/NormalizeL3.cpp
@@ -45,7 +45,7 @@ int NormalizeL3::normalizeWeights() {
    float scale_factor = 1.0f;
    if (normalizeFromPostPerspective) {
       if (conn0->usingSharedWeights()==false) {
-         pvError().printf("NormalizeL3 error for connection \"%s\": normalizeFromPostPerspective is true but connection does not use shared weights.\n", conn0->getName());
+         pvError().printf("NormalizeL3 error for %s: normalizeFromPostPerspective is true but connection does not use shared weights.\n", conn0->getDescription_c());
       }
       scale_factor = ((float) conn0->postSynapticLayer()->getNumNeurons())/((float) conn0->preSynapticLayer()->getNumNeurons());
    }

--- a/tests/ParamsLuaTest/src/ColumnArchive.cpp
+++ b/tests/ParamsLuaTest/src/ColumnArchive.cpp
@@ -171,7 +171,7 @@ void ColumnArchive::addCol(PV::HyPerCol * hc, pvdata_t layerTolerance, pvwdata_t
       if (baseConn==nullptr) { pvError() << "Connection with index " << c << " is null.\n"; }
       PV::HyPerConn * conn = dynamic_cast<PV::HyPerConn*>(baseConn);
       if (conn==nullptr) {
-         pvError() << baseConn->getKeyword() << "\"" << baseConn->getName() << "\" is not a HyPerConn.\n";
+         pvError() << baseConn->getDescription() << " is not a HyPerConn.\n";
       }
       addConn(conn, connTolerance);
    }

--- a/tests/PlasticConnTest/src/PlasticConnTestProbe.cpp
+++ b/tests/PlasticConnTest/src/PlasticConnTestProbe.cpp
@@ -37,11 +37,11 @@ int PlasticConnTestProbe::outputState(double timed) {
       return PV_SUCCESS;
    }
    assert(getTargetConn()!=NULL);
-   outputStream->printf("    Time %f, connection \"%s\":\n", timed, getTargetName());
+   outputStream->printf("    Time %f, %s:\n", timed, getTargetConn()->getDescription_c());
    const pvwdata_t * w = c->get_wDataHead(getArbor(), getKernelIndex());
    const pvdata_t * dw = c->get_dwDataHead(getArbor(), getKernelIndex());
    if( getOutputPlasticIncr() && dw == NULL ) {
-      pvError().printf("PlasticConnTestProbe \"%s\": connection \"%s\" has dKernelData(%d,%d) set to null.\n", getName(), getTargetName(), getKernelIndex(), getArbor());
+      pvError().printf("%s: %s has dKernelData(%d,%d) set to null.\n", getDescription_c(), getTargetConn()->getDescription_c(), getKernelIndex(), getArbor());
    }
    int nxp = c->xPatchSize();
    int nyp = c->yPatchSize();

--- a/tests/PlasticTransposeConnTest/src/TestAllZerosProbe.cpp
+++ b/tests/PlasticTransposeConnTest/src/TestAllZerosProbe.cpp
@@ -19,7 +19,7 @@ TestAllZerosProbe::TestAllZerosProbe(const char * probeName, HyPerCol * hc) {
 int TestAllZerosProbe::outputState(double timed) {
    int status = StatsProbe::outputState(timed);
    if (status != PV_SUCCESS) {
-      pvError().printf("!!Time %f: TestAllZerosProbe::outputState failed for layer \"%s\"\n", timed, getTargetLayer()->getName());
+      pvError().printf("!!Time %f: TestAllZerosProbe::outputState failed for %s\n", timed, getTargetLayer()->getDescription_c());
    }
    InterColComm * icComm = getTargetLayer()->getParent()->icCommunicator();
    const int rcvProc = 0;
@@ -28,7 +28,7 @@ int TestAllZerosProbe::outputState(double timed) {
    }
    for(int b = 0; b < parent->getNBatch(); b++){
       if (nnz[b] != 0) {
-         pvError().printf("!!Time %f batch %d: layer \"%s\" is not all zeroes.\n", timed, b, getTargetLayer()->getName());
+         pvError().printf("!!Time %f batch %d: %s is not all zeroes.\n", timed, b, getTargetLayer()->getDescription_c());
       }
    }
    return status;

--- a/tests/ReceiveFromPostTest/src/ReceiveFromPostProbe.cpp
+++ b/tests/ReceiveFromPostTest/src/ReceiveFromPostProbe.cpp
@@ -54,8 +54,8 @@ int ReceiveFromPostProbe::outputState(double timed){
       }
       //For roundoff errors
       if(fabs(A[i]) >= tolerance) {
-         pvErrorNoExit().printf("%s Layer \"%s\" activity outside of tolerance %f: extended index %d has activity %f\n",
-               getMessage(), getTargetLayer()->getName(), tolerance, i, A[i]);
+         pvErrorNoExit().printf("%s %s activity outside of tolerance %f: extended index %d has activity %f\n",
+               getMessage(), getTargetLayer()->getDescription_c(), tolerance, i, A[i]);
          status = PV_FAILURE;
       }
       if (status != PV_SUCCESS) {

--- a/tests/RescaleLayerTest/src/RescaleLayerTestProbe.cpp
+++ b/tests/RescaleLayerTest/src/RescaleLayerTestProbe.cpp
@@ -92,7 +92,7 @@ int RescaleLayerTestProbe::outputState(double timed)
 
          bool iscolinear = colinear(nk, ny, origStrideYExtended, rescaleStrideYExtended, origData, rescaledData, tolerance, NULL, NULL, NULL);
          if (!iscolinear) {
-            pvErrorNoExit().printf("RescaleLayerTestProbe \"%s\": Rescale layer \"%s\" data is not a linear rescaling of original membrane potential.\n", getName(), targetRescaleLayer->getName());
+            pvErrorNoExit().printf("%s: %s data is not a linear rescaling of original membrane potential.\n", getDescription_c(), targetRescaleLayer->getDescription_c());
             status = PV_FAILURE;
          }
       }
@@ -112,11 +112,11 @@ int RescaleLayerTestProbe::outputState(double timed)
          }
 
          if (fabs(avg[b]-targetMean)>tolerance) {
-            pvErrorNoExit().printf("RescaleLayerTestProbe \"%s\": RescaleLayer \"%s\" has mean %f instead of target mean %f\n", getName(), targetRescaleLayer->getName(), (double)avg[b], targetMean);
+            pvErrorNoExit().printf("%s: %s has mean %f instead of target mean %f\n", getDescription_c(), targetRescaleLayer->getDescription_c(), (double)avg[b], targetMean);
             status = PV_FAILURE;
          }
          if (sigma[b]>tolerance && fabs(sigma[b]-targetStd)>tolerance) {
-            pvErrorNoExit().printf("RescaleLayerTestProbe \"%s\": RescaleLayer \"%s\" has std.dev. %f instead of target std.dev. %f\n", getName(), targetRescaleLayer->getName(), (double)sigma[b], targetStd);
+            pvErrorNoExit().printf("%s: %s has std.dev. %f instead of target std.dev. %f\n", getDescription_c(), targetRescaleLayer->getDescription_c(), (double)sigma[b], targetStd);
             status = PV_FAILURE;
          }
 
@@ -138,7 +138,7 @@ int RescaleLayerTestProbe::outputState(double timed)
 
          bool iscolinear = colinear(nk, ny, origStrideYExtended, rescaleStrideYExtended, origData, rescaledData, tolerance, NULL, NULL, NULL);
          if (!iscolinear) {
-            pvErrorNoExit().printf("RescaleLayerTestProbe \"%s\": Rescale layer \"%s\" data is not a linear rescaling of original membrane potential.\n", getName(), targetRescaleLayer->getName());
+            pvErrorNoExit().printf("%s: %s data is not a linear rescaling of original membrane potential.\n", getDescription_c(), targetRescaleLayer->getDescription_c());
             status = PV_FAILURE;
          }
       }

--- a/tests/ShrunkenPatchFlagTest/src/TestAllZerosProbe.cpp
+++ b/tests/ShrunkenPatchFlagTest/src/TestAllZerosProbe.cpp
@@ -19,7 +19,7 @@ TestAllZerosProbe::TestAllZerosProbe(const char * probeName, HyPerCol * hc) {
 int TestAllZerosProbe::outputState(double timed) {
    int status = StatsProbe::outputState(timed);
    if (status != PV_SUCCESS) {
-      pvError().printf("!!Time %f: TestAllZerosProbe::outputState failed for layer \"%s\"\n", timed, getTargetLayer()->getName());
+      pvError().printf("!!Time %f: TestAllZerosProbe::outputState failed for %s\n", timed, getTargetLayer()->getDescription_c());
    }
    InterColComm * icComm = getTargetLayer()->getParent()->icCommunicator();
    const int rcvProc = 0;
@@ -28,7 +28,7 @@ int TestAllZerosProbe::outputState(double timed) {
    }
    for(int b = 0; b < parent->getNBatch(); b++){
       if (nnz[b] != 0) {
-         pvError().printf("!!Time %f batch %d: layer \"%s\" is not all zeroes.\n", timed, b, getTargetLayer()->getName());
+         pvError().printf("!!Time %f batch %d: %s is not all zeroes.\n", timed, b, getTargetLayer()->getDescription_c());
       }
    }
    return status;

--- a/tests/ShrunkenPatchTest/src/ShrunkenPatchTestProbe.cpp
+++ b/tests/ShrunkenPatchTest/src/ShrunkenPatchTestProbe.cpp
@@ -84,7 +84,7 @@ int ShrunkenPatchTestProbe::outputState(double timed) {
       int xScaleLog2 = getTargetLayer()->getCLayer()->xScale;
 
       if (xScaleLog2>=0) {
-         pvError().printf("ShrunkenPatchTestProbe \"%s\" error: layer \"%s\" must have nxScale > 1.\n", probeName, l->getName());
+         pvError().printf("%s: layer \"%s\" must have nxScale > 1.\n", getDescription_c(), l->getName());
       }
       int cell_size = (int) nearbyintf(powf(2.0f, -xScaleLog2));
       int kx0 = (loc->kx0)/cell_size;
@@ -123,8 +123,8 @@ int ShrunkenPatchTestProbe::outputState(double timed) {
          if (fabs(buf[kex]-correctValues[x])>tol) {
             int y = kyPos(k,loc->nx, loc->ny, loc->nf);
             int f = featureIndex(k,loc->nx,loc->ny,loc->nf);
-            pvError().printf("Layer \"%s\": Incorrect value %f (should be %f) in process %d, x=%d, y=%d, f=%d\n",
-                  l->getName(), buf[kex], correctValues[x], getTargetLayer()->getParent()->columnId(), x, y, f);
+            pvError().printf("%s: Incorrect value %f (should be %f) in process %d, x=%d, y=%d, f=%d\n",
+                  l->getDescription_c(), buf[kex], correctValues[x], getTargetLayer()->getParent()->columnId(), x, y, f);
          }
       }
    }

--- a/tests/StochasticReleaseTest/src/StochasticReleaseTestProbe.cpp
+++ b/tests/StochasticReleaseTest/src/StochasticReleaseTestProbe.cpp
@@ -96,7 +96,7 @@ int StochasticReleaseTestProbe::outputState(double timed) {
          }
          for (long int k=0; k<N; k++) {
             if (pvalues[k]*(N-k)<0.05) {
-               pvErrorNoExit().printf("layer \"%s\" FAILED: p-value %ld out of %ld (ordered by size) with Holm-Bonferroni correction = %f\n", getTargetLayer()->getName(), k, N, pvalues[k]*(N-k));
+               pvErrorNoExit().printf("%s: p-value %ld out of %ld (ordered by size) with Holm-Bonferroni correction = %f\n", getTargetLayer()->getDescription_c(), k, N, pvalues[k]*(N-k));
                status = PV_FAILURE;
             }
          }

--- a/tests/TotalEnergyTest/src/main.cpp
+++ b/tests/TotalEnergyTest/src/main.cpp
@@ -252,8 +252,8 @@ int assertAllZeroes(HyPerCol * hc, int argc, char * argv[]) {
    if (allzeroProbe->getNonzeroFound()) {
       if (hc->columnId()==0) {
          double t = allzeroProbe->getNonzeroTime();
-         pvErrorNoExit().printf("%s \"%s\" had at least one nonzero activity value, beginning at time %f\n",
-               layer->getKeyword(), targetLayerName, t);
+         pvErrorNoExit().printf("%s had at least one nonzero activity value, beginning at time %f\n",
+               layer->getDescription_c(), t);
       }
       MPI_Barrier(hc->icCommunicator()->communicator());
       exit(EXIT_FAILURE);

--- a/tests/WriteActivitySparseTest/src/TestAllZerosProbe.cpp
+++ b/tests/WriteActivitySparseTest/src/TestAllZerosProbe.cpp
@@ -19,7 +19,7 @@ TestAllZerosProbe::TestAllZerosProbe(const char * probeName, HyPerCol * hc) {
 int TestAllZerosProbe::outputState(double timed) {
    int status = StatsProbe::outputState(timed);
    if (status != PV_SUCCESS) {
-      pvError().printf("!!Time %f: TestAllZerosProbe::outputState failed for layer \"%s\"\n", timed, getTargetLayer()->getName());
+      pvError().printf("!!Time %f: TestAllZerosProbe::outputState failed for %s\n", timed, getTargetLayer()->getDescription_c());
    }
    InterColComm * icComm = getTargetLayer()->getParent()->icCommunicator();
    const int rcvProc = 0;
@@ -28,7 +28,7 @@ int TestAllZerosProbe::outputState(double timed) {
    }
    for(int b = 0; b < parent->getNBatch(); b++){
       if (nnz[b] != 0) {
-         pvError().printf("!!Time %f batch %d: layer \"%s\" is not all zeroes.\n", timed, b, getTargetLayer()->getName());
+         pvError().printf("!!Time %f batch %d: %s is not all zeroes.\n", timed, b, getTargetLayer()->getDescription_c());
       }
    }
    return status;

--- a/tests/WriteActivitySparseTest/src/TestNotAlwaysAllZerosProbe.cpp
+++ b/tests/WriteActivitySparseTest/src/TestNotAlwaysAllZerosProbe.cpp
@@ -24,7 +24,7 @@ TestNotAlwaysAllZerosProbe::TestNotAlwaysAllZerosProbe(const char * probeName, H
 int TestNotAlwaysAllZerosProbe::outputState(double timed) {
    int status = StatsProbe::outputState(timed);
    if (status != PV_SUCCESS) {
-      pvError().printf("!!Time %f: TestNotAlwaysAllZerosProbe::outputState failed for layer \"%s\"\n", timed, getTargetLayer()->getName());
+      pvError().printf("!!Time %f: TestNotAlwaysAllZerosProbe::outputState failed for %s\n", timed, getTargetLayer()->getDescription_c());
    }
    for(int b = 0; b < parent->getNBatch(); b++){
       if (nnz[b] != 0) {

--- a/tests/WriteSparseFileTest/src/main.cpp
+++ b/tests/WriteSparseFileTest/src/main.cpp
@@ -254,8 +254,8 @@ int assertAllZeroes(HyPerCol * hc, int argc, char * argv[]) {
    if (allzeroProbe->getNonzeroFound()) {
       if (hc->columnId()==0) {
          double t = allzeroProbe->getNonzeroTime();
-         pvErrorNoExit().printf("%s \"%s\" had at least one nonzero activity value, beginning at time %f\n",
-               layer->getKeyword(), targetLayerName, t);
+         pvErrorNoExit().printf("%s had at least one nonzero activity value, beginning at time %f\n",
+               layer->getDescription_c(), t);
       }
       MPI_Barrier(hc->icCommunicator()->communicator());
       exit(EXIT_FAILURE);


### PR DESCRIPTION
There are many places in the code where the name and type of an object is printed, along the lines of
`...printf("...%s \"%s\"...", ..., getKeyword(), getName(), ...)` or
`... << getKeyword() << " \"" << getName() << "\"" << ...`

This pull request adds a description data member to BaseObject, and two get-methods, getDescription() and getDescription_c().  The description member is a std::string.  getDescription() returns a reference to the string, and getDescription_c() returns a c-style pointer to the string contents.  The above code snippets are then replaced by
`...printf("...%s...", ..., getDescription_c(), ...)` or
`... << getDescription() << ...`

In addition, there are several places where printing something like 'Connection "name"' or 'Layer "name"' has been replaced by printing the description.

Generally, the description is `keyword "name"`, with the following exceptions:
- privateTransposeConn returns `privateTransposeConn for "name"`
- weight normalizers return `method "name"`, where `method` is the value of the `normalizeMethod` parameter.
- weight initializers return `inittype "name"`, where `inittype` is the value of the `weightInitType` parameter.
