### PR TITLE
Fixing bugs regarding initializing from checkpoint.

### DIFF
--- a/src/columns/HyPerCol.cpp
+++ b/src/columns/HyPerCol.cpp
@@ -1072,8 +1072,7 @@ void HyPerCol::ioParam_initializeFromCheckpointDir(enum ParamsIOFlag ioFlag) {
 
 void HyPerCol::ioParam_defaultInitializeFromCheckpointFlag(enum ParamsIOFlag ioFlag) {
    assert(!params->presentAndNotBeenRead(name, "initializeFromCheckpointDir"));
-   assert(initializeFromCheckpointDir); // Should never be null after ioParam_initializeFromCheckpoint is called: an empty string serves as turning the feature off
-   if (initializeFromCheckpointDir[0] != '\0') {
+   if (initializeFromCheckpointDir != nullptr && initializeFromCheckpointDir[0] != '\0') {
       ioParamValue(ioFlag, name, "defaultInitializeFromCheckpointFlag", &defaultInitializeFromCheckpointFlag, defaultInitializeFromCheckpointFlag, true/*warn if absent*/);
    }
 

--- a/src/layers/HyPerLayer.cpp
+++ b/src/layers/HyPerLayer.cpp
@@ -684,6 +684,9 @@ int HyPerLayer::initializeState() {
       if (initializeFromCheckpointFlag) {
          status = readStateFromCheckpoint(parent->getInitializeFromCheckpointDir(), NULL);
       }
+      else {
+         status = setInitialValues();
+      }
    }
    else {
       status = setInitialValues();


### PR DESCRIPTION
This pull request addresses issue #88, fixing the following bugs:
- the assert failure if initializeFromCheckpointDir is null.
- the failure to set initial values if initializeFromCheckpointDir is set and the layer's initializeFromCheckpointFlag is false.
