### PR TITLE
Marginfix

### DIFF
--- a/src/connections/CloneConn.cpp
+++ b/src/connections/CloneConn.cpp
@@ -251,8 +251,8 @@ int CloneConn::communicateInitInfo() {
    pre->synchronizeMarginWidth(originalConn->preSynapticLayer());
 
    //// Make sure the original's and the clone's margin widths stay equal
-   //originalConn->postSynapticLayer()->synchronizeMarginWidth(post);
-   //post->synchronizeMarginWidth(originalConn->postSynapticLayer());
+   originalConn->postSynapticLayer()->synchronizeMarginWidth(post);
+   post->synchronizeMarginWidth(originalConn->postSynapticLayer());
 
    //Redudant read in case it's a clone of a clone
 

--- a/src/connections/CloneConn.cpp
+++ b/src/connections/CloneConn.cpp
@@ -250,10 +250,13 @@ int CloneConn::communicateInitInfo() {
    originalConn->preSynapticLayer()->synchronizeMarginWidth(pre);
    pre->synchronizeMarginWidth(originalConn->preSynapticLayer());
 
-   //// Make sure the original's and the clone's margin widths stay equal
-   originalConn->postSynapticLayer()->synchronizeMarginWidth(post);
-   post->synchronizeMarginWidth(originalConn->postSynapticLayer());
-
+   // Make sure the original's and the clone's margin widths stay equal
+   // Only if this layer receives from post for patch to data LUT
+   if(getUpdateGSynFromPostPerspective())
+   {
+      originalConn->postSynapticLayer()->synchronizeMarginWidth(post);
+      post->synchronizeMarginWidth(originalConn->postSynapticLayer());
+   }
    //Redudant read in case it's a clone of a clone
 
    return status;


### PR DESCRIPTION
Fixes a bug when a Clone / TransposeConn's postLayer had a different margin size than the original connection
