### PR TITLE
Updates to DataStore to eliminate casting of buffers

### DIFF
--- a/src/columns/DataStore.cpp
+++ b/src/columns/DataStore.cpp
@@ -16,56 +16,38 @@
 namespace PV
 {
 
-/**
- * @numBuffers
- * @bufSize
- * @numLevels
- */
-DataStore::DataStore(int numBuffers, int numItems, size_t dataSize, int numLevels, bool isSparse_flag)
+DataStore::DataStore(int numBuffers, int numItems, int numLevels, bool isSparse_flag)
 {
    assert(numLevels > 0 && numBuffers > 0);
    this->curLevel = 0; // Publisher::publish decrements levels when writing, so first level written to is numLevels - 1;
    this->numItems = numItems;
-   this->dataSize = dataSize;
-   this->bufSize = numItems * dataSize;
    this->numLevels = numLevels;
    this->numBuffers = numBuffers;
-   this->recvBuffers = (char*) calloc(numBuffers * numLevels * numItems * dataSize, sizeof(char));
-   if (this->recvBuffers==NULL) {
-      pvError().printf("DataStore unable to allocate data buffer for %d items, %d buffers and %d levels: %s\n", numItems, numBuffers, numLevels, strerror(errno));
-   }
-   this->lastUpdateTimes = (double *) malloc(numBuffers * numLevels * sizeof(double));
-   if (this->lastUpdateTimes==NULL) {
-      pvError().printf("DataStore unable to allocate lastUpdateTimes buffer for %d buffers and %d levels: %s\n", numBuffers, numLevels, strerror(errno));
-   }
-   double infvalue = std::numeric_limits<double>::infinity();
-   for (int lvl=0; lvl<numLevels*numBuffers; lvl++) {
-      lastUpdateTimes[lvl] = -infvalue;
-   }
 
+   //Level (delay) spins slower than bufferId (batch element)
+   mBuffer.resize(numLevels);
+   for(auto& v : mBuffer) {
+      v.resize(numBuffers*numItems);
+   }
+   mLastUpdateTimes.resize(numLevels);
+   for(auto& v : mLastUpdateTimes) {
+      v.resize(numBuffers, -std::numeric_limits<double>::infinity());
+   }
    this->isSparse_flag = isSparse_flag;
-   if(this->isSparse_flag){
-      this->activeIndices = (unsigned int*) calloc(numBuffers * numLevels * numItems, sizeof(unsigned int));
-      if (this->activeIndices==NULL) {
-         pvError().printf("DataStore unable to allocate activeIndices buffer for %d items, %d buffers and %d levels: %s\n", numItems, numBuffers, numLevels, strerror(errno));
+   if(this->isSparse_flag) {
+      mActiveIndices.resize(numLevels);
+      for(auto& v : mActiveIndices) {
+         v.resize(numBuffers*numItems);
       }
-      this->numActive = (long *) calloc(numBuffers * numLevels, sizeof(long));
-      if (this->numActive==NULL) {
-         pvError().printf("DataStore unable to allocate numActive buffer for %d buffers and %d levels: %s\n", numBuffers, numLevels, strerror(errno));
+      mNumActive.resize(numLevels);
+      for(auto& v : mNumActive) {
+         v.resize(numBuffers);
       }
    }
-   else{
-      this->activeIndices = NULL;
-      this->numActive = NULL;
+   else {
+      mActiveIndices.clear();
+      mNumActive.clear();
    }
-}
-
-DataStore::~DataStore()
-{
-   free(recvBuffers);
-   free(activeIndices);
-   free(numActive);
-   free(lastUpdateTimes);
 }
 
 }

--- a/src/columns/DataStore.cpp
+++ b/src/columns/DataStore.cpp
@@ -19,10 +19,10 @@ namespace PV
 DataStore::DataStore(int numBuffers, int numItems, int numLevels, bool isSparse_flag)
 {
    assert(numLevels > 0 && numBuffers > 0);
-   this->curLevel = 0; // Publisher::publish decrements levels when writing, so first level written to is numLevels - 1;
-   this->numItems = numItems;
-   this->numLevels = numLevels;
-   this->numBuffers = numBuffers;
+   this->mCurrentLevel = 0; // Publisher::publish decrements levels when writing, so first level written to is numLevels - 1;
+   this->mNumItems = numItems;
+   this->mNumLevels = numLevels;
+   this->mNumBuffers = numBuffers;
 
    //Level (delay) spins slower than bufferId (batch element)
    mBuffer.resize(numLevels);
@@ -33,8 +33,8 @@ DataStore::DataStore(int numBuffers, int numItems, int numLevels, bool isSparse_
    for(auto& v : mLastUpdateTimes) {
       v.resize(numBuffers, -std::numeric_limits<double>::infinity());
    }
-   this->isSparse_flag = isSparse_flag;
-   if(this->isSparse_flag) {
+   this->mSparseFlag = isSparse_flag;
+   if(this->mSparseFlag) {
       mActiveIndices.resize(numLevels);
       for(auto& v : mActiveIndices) {
          v.resize(numBuffers*numItems);

--- a/src/columns/DataStore.hpp
+++ b/src/columns/DataStore.hpp
@@ -24,27 +24,27 @@ public:
 
    virtual ~DataStore() {}
 
-   int numberOfLevels()  {return numLevels;}
-   int numberOfBuffers() {return numBuffers;}
+   int getNumLevels() const {return mNumLevels;}
+   int getNumBuffers() const {return mNumBuffers;}
    int newLevelIndex() {
-      return (curLevel = (numLevels + curLevel - 1) % numLevels);
+      return (mCurrentLevel = (mNumLevels + mCurrentLevel - 1) % mNumLevels);
    }
 
    //Level (delay) spins slower than bufferId (batch element)
 
    pvdata_t * buffer(int bufferId, int level) {
-      return &mBuffer[levelIndex(level)].at(bufferId*numItems);
+      return &mBuffer[levelIndex(level)].at(bufferId*mNumItems);
    }
 
    pvdata_t * buffer(int bufferId) {
-      return &mBuffer[curLevel].at(bufferId*numItems);
+      return &mBuffer[mCurrentLevel].at(bufferId*mNumItems);
    }
 
-   double getLastUpdateTime(int bufferId, int level) {
+   double getLastUpdateTime(int bufferId, int level) const {
       return mLastUpdateTimes[levelIndex(level)].at(bufferId);
    }
 
-   double getLastUpdateTime(int bufferId) {
+   double getLastUpdateTime(int bufferId) const {
       return mLastUpdateTimes[levelIndex(0)].at(bufferId);
    }
 
@@ -53,47 +53,47 @@ public:
    }
 
    void setLastUpdateTime(int bufferId, double t) {
-      mLastUpdateTimes[curLevel].at(bufferId) = t;
+      mLastUpdateTimes[mCurrentLevel].at(bufferId) = t;
    }
 
-   bool isSparse() {return isSparse_flag;}
+   bool isSparse() const {return mSparseFlag;}
 
    unsigned int* activeIndicesBuffer(int bufferId, int level) {
-      return &mActiveIndices[levelIndex(level)].at(bufferId*numItems);
+      return &mActiveIndices[levelIndex(level)].at(bufferId*mNumItems);
    }
 
    unsigned int* activeIndicesBuffer(int bufferId) {
-      return &mActiveIndices[curLevel].at(bufferId*numItems);
+      return &mActiveIndices[mCurrentLevel].at(bufferId*mNumItems);
    }
 
    void setNumActive(int bufferId, long numActive) {
-      mNumActive[curLevel].at(bufferId) = numActive;
+      mNumActive[mCurrentLevel].at(bufferId) = numActive;
    }
 
-   long * numActiveBuffer(int bufferId, int level){
+   long * numActiveBuffer(int bufferId, int level) {
       return &mNumActive[levelIndex(level)].at(bufferId);
    }
 
-   long * numActiveBuffer(int bufferId){
-      return &mNumActive[curLevel].at(bufferId);
+   long * numActiveBuffer(int bufferId) {
+      return &mNumActive[mCurrentLevel].at(bufferId);
    }
 
-   int getNumItems(){ return numItems;}
+   int getNumItems() const { return mNumItems;}
 
 private:
-   int levelIndex(int level) { return ((level + curLevel) % numLevels); }
+   int levelIndex(int level) const { return ((level + mCurrentLevel) % mNumLevels); }
 
 private:
-   int   numItems;
-   int   curLevel;
-   int   numLevels;
-   int   numBuffers;
-   bool  isSparse_flag;
+   int   mNumItems;
+   int   mCurrentLevel;
+   int   mNumLevels;
+   int   mNumBuffers;
+   bool  mSparseFlag;
 
-   std::vector<std::vector<pvdata_t> > mBuffer;
-   std::vector<std::vector<long> > mNumActive;
+   std::vector<std::vector<pvdata_t> >     mBuffer;
+   std::vector<std::vector<long> >         mNumActive;
    std::vector<std::vector<unsigned int> > mActiveIndices;
-   std::vector<std::vector<double> > mLastUpdateTimes;
+   std::vector<std::vector<double> >       mLastUpdateTimes;
 };
 
 } // NAMESPACE

--- a/src/columns/DataStore.hpp
+++ b/src/columns/DataStore.hpp
@@ -33,49 +33,49 @@ public:
    //Level (delay) spins slower than bufferId (batch element)
 
    pvdata_t * buffer(int bufferId, int level) {
-      return mBuffer[levelIndex(level)].data()+bufferId*numItems;
+      return &mBuffer[levelIndex(level)].at(bufferId*numItems);
    }
 
    pvdata_t * buffer(int bufferId) {
-      return mBuffer[curLevel].data()+bufferId*numItems;
+      return &mBuffer[curLevel].at(bufferId*numItems);
    }
 
    double getLastUpdateTime(int bufferId, int level) {
-      return mLastUpdateTimes[levelIndex(level)][bufferId];
+      return mLastUpdateTimes[levelIndex(level)].at(bufferId);
    }
 
    double getLastUpdateTime(int bufferId) {
-      return mLastUpdateTimes[levelIndex(0)][bufferId];
+      return mLastUpdateTimes[levelIndex(0)].at(bufferId);
    }
 
    void setLastUpdateTime(int bufferId, int level, double t) {
-      mLastUpdateTimes[levelIndex(level)][bufferId] = t;
+      mLastUpdateTimes[levelIndex(level)].at(bufferId) = t;
    }
 
    void setLastUpdateTime(int bufferId, double t) {
-      mLastUpdateTimes[curLevel][bufferId] = t;
+      mLastUpdateTimes[curLevel].at(bufferId) = t;
    }
 
    bool isSparse() {return isSparse_flag;}
 
    unsigned int* activeIndicesBuffer(int bufferId, int level) {
-      return mActiveIndices[levelIndex(level)].data()+bufferId*numItems;
+      return &mActiveIndices[levelIndex(level)].at(bufferId*numItems);
    }
 
    unsigned int* activeIndicesBuffer(int bufferId) {
-      return mActiveIndices[curLevel].data()+bufferId*numItems;
+      return &mActiveIndices[curLevel].at(bufferId*numItems);
    }
 
    void setNumActive(int bufferId, long numActive) {
-      mNumActive[curLevel][bufferId] = numActive;
+      mNumActive[curLevel].at(bufferId) = numActive;
    }
 
    long * numActiveBuffer(int bufferId, int level){
-      return mNumActive[levelIndex(level)].data()+bufferId;
+      return &mNumActive[levelIndex(level)].at(bufferId);
    }
 
    long * numActiveBuffer(int bufferId){
-      return mNumActive[curLevel].data()+bufferId;
+      return &mNumActive[curLevel].at(bufferId);
    }
 
    int getNumItems(){ return numItems;}

--- a/src/columns/DataStore.hpp
+++ b/src/columns/DataStore.hpp
@@ -9,8 +9,10 @@
 #define DATASTORE_HPP_
 
 #include "include/pv_arch.h"
+#include "include/pv_types.h"
 #include <cstdlib>
 #include <cstring>
+#include <vector>
 
 namespace PV
 {
@@ -18,73 +20,80 @@ namespace PV
 class DataStore
 {
 public:
-   DataStore(int numBuffers, int numItems, size_t dataSize, int numLevels, bool isSparse);
+   DataStore(int numBuffers, int numItems, int numLevels, bool isSparse);
 
-   virtual ~DataStore();
-
-   size_t size()         {return bufSize;}
+   virtual ~DataStore() {}
 
    int numberOfLevels()  {return numLevels;}
    int numberOfBuffers() {return numBuffers;}
-   int lastLevelIndex()
-         {return ((numLevels + curLevel + 1) % numLevels);}
-   int levelIndex(int level)
-         {return ((level + curLevel) % numLevels);}
-   int newLevelIndex()
-         {return (curLevel = (numLevels + curLevel - 1) % numLevels);}
+   int newLevelIndex() {
+      return (curLevel = (numLevels + curLevel - 1) % numLevels);
+   }
 
-   //Levels (delays) spins slower than bufferId (batches)
+   //Level (delay) spins slower than bufferId (batch element)
 
-   void* buffer(int bufferId, int level)
-         {return (recvBuffers + levelIndex(level)*numBuffers*bufSize + bufferId * bufSize);}
-   void* buffer(int bufferId)
-         {return (recvBuffers + curLevel*numBuffers*bufSize + bufferId * bufSize);}
+   pvdata_t * buffer(int bufferId, int level) {
+      return mBuffer[levelIndex(level)].data()+bufferId*numItems;
+   }
 
-   double getLastUpdateTime(int bufferId, int level) 
-      { return lastUpdateTimes[levelIndex(level) * numBuffers + bufferId]; }
-   double getLastUpdateTime(int bufferId) 
-      { return lastUpdateTimes[levelIndex(0) * numBuffers + bufferId]; }
+   pvdata_t * buffer(int bufferId) {
+      return mBuffer[curLevel].data()+bufferId*numItems;
+   }
 
-   void setLastUpdateTime(int bufferId, int level, double t) 
-      { lastUpdateTimes[levelIndex(level)*numBuffers + bufferId] = t; }
-   void setLastUpdateTime(int bufferId, double t) 
-      { lastUpdateTimes[levelIndex(0)*numBuffers + bufferId] = t; }
+   double getLastUpdateTime(int bufferId, int level) {
+      return mLastUpdateTimes[levelIndex(level)][bufferId];
+   }
 
-   size_t bufferOffset(int bufferId, int level=0)
-         {return (levelIndex(level)*numBuffers*bufSize + bufferId*bufSize);}
+   double getLastUpdateTime(int bufferId) {
+      return mLastUpdateTimes[levelIndex(0)][bufferId];
+   }
+
+   void setLastUpdateTime(int bufferId, int level, double t) {
+      mLastUpdateTimes[levelIndex(level)][bufferId] = t;
+   }
+
+   void setLastUpdateTime(int bufferId, double t) {
+      mLastUpdateTimes[curLevel][bufferId] = t;
+   }
+
    bool isSparse() {return isSparse_flag;}
 
-   unsigned int* activeIndicesBuffer(int bufferId, int level)
-         {return (activeIndices + levelIndex(level)*numBuffers*numItems + bufferId*numItems);}
+   unsigned int* activeIndicesBuffer(int bufferId, int level) {
+      return mActiveIndices[levelIndex(level)].data()+bufferId*numItems;
+   }
 
-   unsigned int* activeIndicesBuffer(int bufferId){
-      return (activeIndices + curLevel*numBuffers*numItems + bufferId*numItems);
+   unsigned int* activeIndicesBuffer(int bufferId) {
+      return mActiveIndices[curLevel].data()+bufferId*numItems;
+   }
+
+   void setNumActive(int bufferId, long numActive) {
+      mNumActive[curLevel][bufferId] = numActive;
    }
 
    long * numActiveBuffer(int bufferId, int level){
-      //return (numActive + bufferId*numLevels + levelIndex(level));
-      return (numActive + levelIndex(level)*numBuffers + bufferId);
+      return mNumActive[levelIndex(level)].data()+bufferId;
    }
 
    long * numActiveBuffer(int bufferId){
-      return (numActive + curLevel*numBuffers + bufferId);
+      return mNumActive[curLevel].data()+bufferId;
    }
 
    int getNumItems(){ return numItems;}
 
 private:
-   size_t dataSize;
-   int    numItems;
-   size_t bufSize;
-   int    curLevel;
-   int    numLevels;
-   int    numBuffers;
-   char*  recvBuffers;
+   int levelIndex(int level) { return ((level + curLevel) % numLevels); }
 
-   unsigned int*   activeIndices;
-   long *   numActive;
+private:
+   int   numItems;
+   int   curLevel;
+   int   numLevels;
+   int   numBuffers;
    bool  isSparse_flag;
-   double * lastUpdateTimes; // A ring buffer for the getLastUpdateTime() function.
+
+   std::vector<std::vector<pvdata_t> > mBuffer;
+   std::vector<std::vector<long> > mNumActive;
+   std::vector<std::vector<unsigned int> > mActiveIndices;
+   std::vector<std::vector<double> > mLastUpdateTimes;
 };
 
 } // NAMESPACE

--- a/src/columns/Publisher.cpp
+++ b/src/columns/Publisher.cpp
@@ -30,7 +30,6 @@ Publisher::Publisher(Communicator * comm, int numItems, PVLayerLoc loc, int numL
 
    store = new DataStore(numBuffers, numItems, dataSize, numLevels, isSparse);
 
-   //DONE: check for memory leak here, method flagged by valgrind
    this->neighborDatatypes = Communicator::newDatatypes(&loc);
 
    requests.clear();
@@ -106,8 +105,6 @@ int Publisher::publish(double currentTime, double lastUpdateTime,
 
    pvdata_t * sendBuf = cube->data;
    pvdata_t * recvBuf = recvBuffer(0); //Grab all of the buffer, allocated continuously
-
-   bool isSparse = store->isSparse();
 
    if (lastUpdateTime >= currentTime) {
       // copy entire layer and let neighbors overwrite

--- a/src/columns/Publisher.cpp
+++ b/src/columns/Publisher.cpp
@@ -13,15 +13,13 @@ namespace PV {
 
 Publisher::Publisher(Communicator * comm, PVLayerCube * cube, int numLevels, bool isSparse)
 {
-   size_t dataSize  = sizeof(float);
-
    this->mLayerCube = cube;
    this->mComm  = comm;
 
    int const numBuffers = cube->loc.nbatch;
    int const numItems = cube->numItems/numBuffers; // number of items in one batch element.
 
-   store = new DataStore(numBuffers, numItems, dataSize, numLevels, isSparse);
+   store = new DataStore(numBuffers, numItems, numLevels, isSparse);
 
    this->neighborDatatypes = Communicator::newDatatypes(&cube->loc);
 
@@ -49,7 +47,7 @@ int Publisher::calcAllActiveIndices() {
       for(int b = 0; b < store->numberOfBuffers(); b++){
          //Active indicies stored as local ext values
          int numActive = 0;
-         pvdata_t * activity = (pvdata_t*) store->buffer(b, l);;
+         pvdata_t * activity = store->buffer(b, l);;
          unsigned int * activeIndices = store->activeIndicesBuffer(b, l);
          long * numActiveBuf = store->numActiveBuffer(b, l);
 
@@ -70,7 +68,7 @@ int Publisher::calcActiveIndices() {
    for(int b = 0; b < store->numberOfBuffers(); b++){
       //Active indicies stored as local ext values
       int numActive = 0;
-      pvdata_t * activity = (pvdata_t*) store->buffer(b);;
+      pvdata_t * activity = store->buffer(b);;
       unsigned int * activeIndices = store->activeIndicesBuffer(b);
       long * numActiveBuf = store->numActiveBuffer(b);
       for (int kex = 0; kex < store->getNumItems(); kex++) {
@@ -93,7 +91,6 @@ int Publisher::publish(double currentTime, double lastUpdateTime)
    //
 
    size_t dataSize = mLayerCube->numItems * sizeof(pvdata_t);
-   pvAssert(dataSize == (store->size() * store->numberOfBuffers()));
 
    pvdata_t const * sendBuf = mLayerCube->data;
    pvdata_t * recvBuf = recvBuffer(0); //Grab all of the buffer, allocated continuously

--- a/src/columns/Publisher.cpp
+++ b/src/columns/Publisher.cpp
@@ -43,8 +43,8 @@ int Publisher::updateActiveIndices() {
 }
 
 int Publisher::calcAllActiveIndices() {
-   for(int l = 0; l < store->numberOfLevels(); l++){
-      for(int b = 0; b < store->numberOfBuffers(); b++){
+   for(int l = 0; l < store->getNumLevels(); l++){
+      for(int b = 0; b < store->getNumBuffers(); b++){
          //Active indicies stored as local ext values
          int numActive = 0;
          pvdata_t * activity = store->buffer(b, l);;
@@ -65,7 +65,7 @@ int Publisher::calcAllActiveIndices() {
 }
 
 int Publisher::calcActiveIndices() {
-   for(int b = 0; b < store->numberOfBuffers(); b++){
+   for(int b = 0; b < store->getNumBuffers(); b++){
       //Active indicies stored as local ext values
       int numActive = 0;
       pvdata_t * activity = store->buffer(b);;
@@ -105,7 +105,7 @@ int Publisher::publish(double currentTime, double lastUpdateTime)
       //Updating active indices is done after MPI wait in HyPerCol
       //to avoid race condition because exchangeBorders mpi is async
    }
-   else if (store->numberOfLevels()>1){
+   else if (store->getNumLevels()>1){
       // If there are delays, copy last level's data to this level.
       // TODO: we could use pointer indirection to cut down on the number of memcpy calls required, if this turns out to be an expensive step
       memcpy(recvBuf, recvBuffer(LOCAL/*bufferId*/,1), dataSize);

--- a/src/columns/Publisher.hpp
+++ b/src/columns/Publisher.hpp
@@ -20,9 +20,9 @@ namespace PV {
 class Publisher {
 
 public:
-   Publisher(Communicator * comm, int numItems, PVLayerLoc loc, int numLevels, bool isSparse);
+   Publisher(Communicator * comm, PVLayerCube * cube, int numLevels, bool isSparse);
    virtual ~Publisher();
-   int publish(double currentTime, double lastUpdateTime, PVLayerCube * data);
+   int publish(double currentTime, double lastUpdateTime);
    int exchangeBorders(const PVLayerLoc * loc, int delay=0);
    int wait();
 
@@ -59,7 +59,7 @@ private:
 
    DataStore * store;
 
-   PVLayerCube cube;
+   PVLayerCube * mLayerCube;
 
    Communicator * mComm;
 

--- a/src/columns/Publisher.hpp
+++ b/src/columns/Publisher.hpp
@@ -36,9 +36,9 @@ public:
 private:
 
    pvdata_t * recvBuffer(int bufferId)
-         {return (pvdata_t *) store->buffer(bufferId);}
+         {return store->buffer(bufferId);}
    pvdata_t * recvBuffer(int bufferId, int delay)
-         {return (pvdata_t *) store->buffer(bufferId, delay);}
+         {return store->buffer(bufferId, delay);}
 
    long * recvNumActiveBuffer(int bufferId){
       return store->numActiveBuffer(bufferId);

--- a/src/connections/HyPerConn.cpp
+++ b/src/connections/HyPerConn.cpp
@@ -2769,7 +2769,7 @@ int HyPerConn::deliver() {
 
    for (int arbor=0; arbor<numArbors; arbor++) {
       int delay = getDelay(arbor);
-      cube.data = (pvdata_t *) store->buffer(0, delay); //First element is batch, but since it's a continuous buffer, 0 here is alright
+      cube.data = store->buffer(0, delay); //First element is batch, but since it's a continuous buffer, 0 here is alright
       if(!getUpdateGSynFromPostPerspective()){
          cube.isSparse = store->isSparse();
          if(cube.isSparse){

--- a/src/connections/PoolingConn.hpp
+++ b/src/connections/PoolingConn.hpp
@@ -76,7 +76,7 @@ protected:
 private:
    int initialize_base();
    void unsetAccumulateType();
-   int ** thread_gateIdxBuffer;
+   pvdata_t ** thread_gateIdxBuffer;
    bool needPostIndexLayer;
    char* postIndexLayerName;
    PoolingIndexLayer* postIndexLayer;

--- a/src/connections/TransposePoolingConn.cpp
+++ b/src/connections/TransposePoolingConn.cpp
@@ -543,7 +543,7 @@ int TransposePoolingConn::deliverPresynapticPerspective(PVLayerCube const * acti
    const int numExtended = activity->numItems;
 
    //Grab postIdxLayer's data
-   int* postIdxData = NULL;
+   pvdata_t * postIdxData = nullptr;
    if(poolingType == PoolingConn::MAX){
       PoolingIndexLayer* postIndexLayer = originalConn->getPostIndexLayer();
       assert(postIndexLayer);
@@ -552,14 +552,13 @@ int TransposePoolingConn::deliverPresynapticPerspective(PVLayerCube const * acti
       DataStore * store = postIndexLayer->getPublisher()->dataStore();
       int delay = getDelay(arborID);
 
-      //TODO this is currently a hack, need to properly implement data types.
-      postIdxData = (int*) store->buffer(LOCAL, delay);
+      postIdxData = store->buffer(LOCAL, delay);
    }
 
    for(int b = 0; b < parent->getNBatch(); b++){
       pvdata_t * activityBatch = activity->data + b * (preLoc->nx + preLoc->halo.rt + preLoc->halo.lt) * (preLoc->ny + preLoc->halo.up + preLoc->halo.dn) * preLoc->nf;
       pvdata_t * gSynPatchHeadBatch = post->getChannel(getChannel()) + b * postLoc->nx * postLoc->ny * postLoc->nf;
-      int * postIdxDataBatch = NULL;
+      pvdata_t * postIdxDataBatch = nullptr;
       if(poolingType == PoolingConn::MAX){
          postIdxDataBatch = postIdxData + b * originalConn->getPostIndexLayer()->getNumExtended();
       }
@@ -635,7 +634,7 @@ int TransposePoolingConn::deliverPresynapticPerspective(PVLayerCube const * acti
             }
 
             //Convert stored global extended index into local extended index
-            int postGlobalExtIdx = postIdxDataBatch[kPreExt];
+            int postGlobalExtIdx = (int) postIdxDataBatch[kPreExt];
 
             // If all inputs are zero and input layer is sparse, postGlobalExtIdx will still be -1.
             if(postGlobalExtIdx == -1) { continue; }

--- a/src/io/fileio.cpp
+++ b/src/io/fileio.cpp
@@ -1276,7 +1276,7 @@ int writeActivity(PV_Stream * pvstream, Communicator * comm, double timed, DataS
    int rank = comm->commRank();
 
    for(int b = 0; b < loc->nbatch; b++){
-      pvadata_t * data = (pvadata_t*) store->buffer(b);
+      pvadata_t * data = store->buffer(b);
       if( rank == 0 ) {
          long fpos = getPV_StreamFilepos(pvstream);
          if (fpos == 0L) {
@@ -1316,7 +1316,7 @@ int writeActivitySparse(PV_Stream * pvstream, Communicator * comm, double timed,
 
       int localActive = *(store->numActiveBuffer(b));
       unsigned int * indices = store->activeIndicesBuffer(b);
-      pvadata_t * valueData = (pvadata_t*) store->buffer(b);
+      pvadata_t * valueData = store->buffer(b);
 
       indexvaluepair * indexvaluepairs = NULL;
       unsigned int * globalResIndices = NULL;

--- a/src/layers/HyPerLayer.cpp
+++ b/src/layers/HyPerLayer.cpp
@@ -528,7 +528,7 @@ int HyPerLayer::allocateGSyn() {
 
 void HyPerLayer::addPublisher() {
    Communicator * icComm = parent->getCommunicator();
-   publisher = new Publisher(icComm, getNumExtended(), clayer->loc, getNumDelayLevels(), getSparseFlag());
+   publisher = new Publisher(icComm, clayer->activity, getNumDelayLevels(), getSparseFlag());
 }
 
 int HyPerLayer::initializeState() {
@@ -1918,7 +1918,7 @@ int HyPerLayer::publish(Communicator* comm, double time)
       mirrorInteriorToBorder(clayer->activity, clayer->activity);
    }
    
-   int status = publisher->publish(time, lastUpdateTime, clayer->activity);
+   int status = publisher->publish(time, lastUpdateTime);
    publish_timer->stop();
    return status;
 }

--- a/src/layers/HyPerLayer.cpp
+++ b/src/layers/HyPerLayer.cpp
@@ -1508,7 +1508,7 @@ int HyPerLayer::requireChannel(int channelNeeded, int * numChannelsResult) {
 const pvdata_t * HyPerLayer::getLayerData(int delay)
 {
    DataStore * store = publisher->dataStore();
-   return (pvdata_t *) store->buffer(0, delay);
+   return store->buffer(0, delay);
 }
 
 #ifdef OBSOLETE // Marked obsolete June 28, 2016.  When mirroring is done, all borders are mirrored.
@@ -2196,7 +2196,7 @@ int HyPerLayer::readDataStoreFromFile(const char * filename, Communicator * comm
          double tlevel;
          pvp_read_time(readFile, comm, 0/*root process*/, &tlevel);
          datastore->setLastUpdateTime(b/*bufferId*/, l, tlevel);
-         pvdata_t * buffer = (pvdata_t *) datastore->buffer(b, l);
+         pvdata_t * buffer = datastore->buffer(b, l);
          int status1 = scatterActivity(readFile, comm, 0/*root process*/, buffer, getLayerLoc(), true, NULL, 0, 0, PVP_NONSPIKING_ACT_FILE_TYPE, 0);
          if (status1 != PV_SUCCESS) status = PV_FAILURE;
       }
@@ -2313,7 +2313,7 @@ int HyPerLayer::writeDataStoreToFile(const char * filename, Communicator * comm,
                pvError().printf("HyPerLayer::writeBufferFile error writing timestamp to \"%s\"\n", filename);
             }
          }
-         pvdata_t * buffer = (pvdata_t *) datastore->buffer(b, l);
+         pvdata_t * buffer = datastore->buffer(b, l);
          int status1 = gatherActivity(writeFile, comm, 0, buffer, getLayerLoc(), true/*extended*/);
          if (status1 != PV_SUCCESS) status = PV_FAILURE;
       }

--- a/src/layers/HyPerLayer.cpp
+++ b/src/layers/HyPerLayer.cpp
@@ -2186,8 +2186,8 @@ int HyPerLayer::readDataStoreFromFile(const char * filename, Communicator * comm
       abort();
    }
    DataStore * datastore = publisher->dataStore();
-   int numlevels = datastore->numberOfLevels();
-   int numbuffers = datastore->numberOfBuffers();
+   int numlevels = datastore->getNumLevels();
+   int numbuffers = datastore->getNumBuffers();
    if (params[INDEX_NBANDS] != numlevels*numbuffers) {
       pvError().printf("readDataStoreFromFile error reading \"%s\": number of delays + batches in file is %d, but number of delays + batches in layer is %d\n", filename, params[INDEX_NBANDS], numlevels*numbuffers);
    }
@@ -2293,8 +2293,8 @@ template int HyPerLayer::writeBufferFile<float>(const char * filename, Communica
 int HyPerLayer::writeDataStoreToFile(const char * filename, Communicator * comm, double timed) {
    PV_Stream * writeFile = pvp_open_write_file(filename, comm, /*append*/false);
    assert( (writeFile != NULL && comm->commRank() == 0) || (writeFile == NULL && comm->commRank() != 0) );
-   int numlevels = publisher->dataStore()->numberOfLevels();
-   int numbuffers = publisher->dataStore()->numberOfBuffers();
+   int numlevels = publisher->dataStore()->getNumLevels();
+   int numbuffers = publisher->dataStore()->getNumBuffers();
    assert(numlevels == getNumDelayLevels());
    int * params = pvp_set_nonspiking_act_params(comm, timed, getLayerLoc(), PV_FLOAT_TYPE, numlevels);
    assert(params && params[1]==NUM_BIN_PARAMS);

--- a/src/layers/PoolingIndexLayer.cpp
+++ b/src/layers/PoolingIndexLayer.cpp
@@ -48,7 +48,7 @@ void PoolingIndexLayer::ioParam_dataType(enum ParamsIOFlag ioFlag) {
 
 //This function should never be called, since this layer should never be a post layer and only accessed from PoolingConn.
 int PoolingIndexLayer::requireChannel(int channelNeeded, int * numChannelsResult) {
-   pvError() << "Error, PoolingIndexLayer cannot be a post layer\n";
+   pvError() << "PoolingIndexLayer cannot be a post layer\n";
    return PV_SUCCESS;
 }
 

--- a/src/layers/PoolingIndexLayer.hpp
+++ b/src/layers/PoolingIndexLayer.hpp
@@ -16,10 +16,6 @@ class PoolingIndexLayer : public HyPerLayer {
 public:
    PoolingIndexLayer(const char* name, HyPerCol * hc);
    virtual ~PoolingIndexLayer();
-   virtual int * getActivity(){return (int*)(clayer->activity->data);} // TODO: access to clayer->activity->data should not be public
-   virtual int* getChannel(ChannelType ch) {                         // name query
-       return (ch < this->numChannels && ch >= 0) ? (int*)GSyn[ch] : NULL;
-   }
    bool activityIsSpiking() { return false; }
    virtual int requireChannel(int channelNeeded, int * numChannelsResult);
 protected:

--- a/src/layers/accumulate_functions.c
+++ b/src/layers/accumulate_functions.c
@@ -98,16 +98,13 @@ int pvpatch_max_pooling(int kPreGlobalExt, int nk, float* RESTRICT v, float a, p
 {
   int k;
   int err = 0;
-  //float * gate = (float *)auxPtr;
-  int * gate = (int*)auxPtr;
+  float * gate = (float *)auxPtr;
   for (k = 0; k < nk; k+=sf) {
-    //     v[k] = v[k] > a*w[k] ? v[k] : a*w[k];
-    //v[k] = v[k] > a*w[0] ? v[k] : a*w[0];
     float checkVal = a*w[0];
     if(v[k] <= checkVal){
        v[k] = checkVal;
        if(gate){
-          gate[k] = kPreGlobalExt;
+          gate[k] = (float) kPreGlobalExt;
        }
     }
   }
@@ -118,14 +115,12 @@ int pvpatch_max_pooling_from_post(int kPreGlobalExt, int nk, float * RESTRICT v,
    int status = 0;
    int k;
    float vmax = *v;
-   int* gate = (int*)auxPtr;
+   float* gate = (float*)auxPtr;
    int gateMax;
    if(gate){
-      gateMax = *gate;
+      gateMax = (int) *gate;
    }
    for (k = 0; k < nk; k+=sf) {
-      //vmax = vmax > a[k]*w[k] ? vmax : a[k]*w[k];
-      //vmax = vmax > a[k]*w[0] ? vmax : a[k]*w[0];
       float checkVal = a[k]*w[0];
       if(vmax <= checkVal){
          vmax = checkVal;
@@ -136,7 +131,7 @@ int pvpatch_max_pooling_from_post(int kPreGlobalExt, int nk, float * RESTRICT v,
    }
    *v = vmax;
    if(gate){
-      *gate = gateMax;
+      *gate = (float) gateMax;
    }
    return status;
 }

--- a/src/layers/updateStateFunctions.h
+++ b/src/layers/updateStateFunctions.h
@@ -207,7 +207,7 @@ int setActivity_GapLayer(int nbatch, int numNeurons,
 KERNEL
 int resetGSynBuffers_HyPerLayer(int nbatch, int numNeurons, int num_channels, MEM_GLOBAL pvdata_t * GSynHead);
 KERNEL
-int resetGSynBuffers_PoolingIndexLayer(int nbatch, int numNeurons, int num_channels, MEM_GLOBAL float * GSynHead);
+int resetGSynBuffers_PoolingIndexLayer(int nbatch, int numNeurons, int num_channels, MEM_GLOBAL pvdata_t * GSynHead);
 KERNEL
 int resetGSynBuffers_SigmoidLayer();
 
@@ -1186,9 +1186,9 @@ int resetGSynBuffers_HyPerLayer(int nbatch, int numNeurons, int num_channels, ME
 
 //TODO merge this with resetGSynBuffers_HyPerLayer with a template
 KERNEL
-int resetGSynBuffers_PoolingIndexLayer(int nbatch, int numNeurons, int num_channels, MEM_GLOBAL int * GSynHead) {
+int resetGSynBuffers_PoolingIndexLayer(int nbatch, int numNeurons, int num_channels, MEM_GLOBAL pvdata_t * GSynHead) {
    for( int ch = 0; ch < num_channels; ch ++ ) {
-      MEM_GLOBAL int * channelStart = &GSynHead[ch*nbatch*numNeurons];
+      MEM_GLOBAL pvdata_t * channelStart = &GSynHead[ch*nbatch*numNeurons];
       int k;
 #ifndef PV_USE_CUDA
    #ifdef PV_USE_OPENMP_THREADS
@@ -1199,7 +1199,7 @@ int resetGSynBuffers_PoolingIndexLayer(int nbatch, int numNeurons, int num_chann
       k = getIndex();
 #endif // PV_USE_CUDA
       {
-         channelStart[k] = -1;
+         channelStart[k] = (pvdata_t) -1;
       }
    }
    return PV_SUCCESS;

--- a/tests/DatastoreDelayTest/src/DatastoreDelayTestLayer.cpp
+++ b/tests/DatastoreDelayTest/src/DatastoreDelayTestLayer.cpp
@@ -31,7 +31,7 @@ int DatastoreDelayTestLayer::updateState(double timed, double dt) {
 
 int DatastoreDelayTestLayer::updateState(double timef, double dt, int num_neurons, pvdata_t * V, pvdata_t * A, int nx, int ny, int nf, int lt, int rt, int dn, int up) {
    // updateV();
-   updateV_DatastoreDelayTestLayer(getLayerLoc(), &inited, getV(), publisher->dataStore()->numberOfLevels());
+   updateV_DatastoreDelayTestLayer(getLayerLoc(), &inited, getV(), publisher->dataStore()->getNumLevels());
    setActivity_HyPerLayer(parent->getNBatch(), num_neurons, A, V, nx, ny, nf, lt, rt, dn, up);
    // resetGSynBuffers(); // Since V doesn't use the GSyn buffers, no need to maintain them.
 

--- a/tests/MPITest/src/MPITestLayer.cpp
+++ b/tests/MPITest/src/MPITestLayer.cpp
@@ -77,21 +77,13 @@ int MPITestLayer::allocateDataStructures() {
 
 int MPITestLayer::updateState(double timed, double dt)
 {
-   //updateV();
-   //setActivity();
-   //resetGSynBuffers();
-   //updateActiveIndices();
-
    return PV_SUCCESS;
 }
 
 int MPITestLayer::publish(Communicator* comm, double timed)
 {
    setActivitytoGlobalPos();
-   int status = publisher->publish(timed, lastUpdateTime, clayer->activity);
-   return status;
-
-   //return HyPerLayer::publish(comm, time);
+   return HyPerLayer::publish(comm, timed);
 }
 
 } /* namespace PV */

--- a/tests/PlasticConnTest/src/PlasticConnTestLayer.cpp
+++ b/tests/PlasticConnTest/src/PlasticConnTestLayer.cpp
@@ -59,21 +59,13 @@ int PlasticConnTestLayer::allocateDataStructures() {
 
 int PlasticConnTestLayer::updateState(double timef, double dt)
 {
-   //updateV();
-   //setActivity();
-   //resetGSynBuffers();
-   //updateActiveIndices();
-
    return PV_SUCCESS;
 }
 
 int PlasticConnTestLayer::publish(Communicator* comm, double timef)
 {
    setActivitytoGlobalPos();
-   int status = publisher->publish(timef, lastUpdateTime, clayer->activity);
-   return status;
-
-   //return HyPerLayer::publish(comm, time);
+   return HyPerLayer::publish(comm, timef);
 }
 
 } /* namespace PV */

--- a/tests/ShrunkenPatchTest/src/ShrunkenPatchTestLayer.cpp
+++ b/tests/ShrunkenPatchTest/src/ShrunkenPatchTestLayer.cpp
@@ -73,21 +73,13 @@ int ShrunkenPatchTestLayer::allocateDataStructures() {
 
 int ShrunkenPatchTestLayer::updateState(double timed, double dt)
 {
-   //updateV();
-   //setActivity();
-   //resetGSynBuffers();
-   //updateActiveIndices();
-
    return PV_SUCCESS;
 }
 
 int ShrunkenPatchTestLayer::publish(Communicator* comm, double timed)
 {
    setActivitytoGlobalPos();
-   int status = publisher->publish(timed, lastUpdateTime, clayer->activity);
-   return status;
-
-   //return HyPerLayer::publish(comm, time);
+   return HyPerLayer::publish(comm, timed);
 }
 
 } /* namespace PV */


### PR DESCRIPTION
The ring buffer in DataStore has long been declared as a pointer to char, and the methods that retrieve a ring buffer element have returned a pointer to void.  In principle, this allowed flexibility of the data stored in a DataStore object.  However, Publisher, HyPerConn, and HyPerLayer all assume that the DataStore contains pvdata_t (i.e. float) values.

Rather than being able to make use of the flexibility that DataStore theoretically provided, PoolingIndexLayer and PoolingConn/PoolingTransposeConn instead rely on an int value using the same number of bytes as a pvdata_t.

This pull request makes the DataStore buffer into a vector of type float, and size numLevels (the number of delay levels).  Objects that call DataStore::buffer() no longer have to cast the result to pvdata_t themselves.

The maxpooling accumulate functions store the index of the max location as the float equivalent of the integer index.  TransposePoolingConn then casts that value back to an int after retrieving it from the buffer (as opposed to casting the buffer as int\* and reading directly from it).

One potential for a performance hit is the cast from int to float inside the innermost loop of the maxpooling accumulate functions.  However, it is expected that these routines will not be a bottleneck.
