### PR TITLE
HyPerConn allocate fix

### DIFF
--- a/src/connections/HyPerConn.cpp
+++ b/src/connections/HyPerConn.cpp
@@ -1435,14 +1435,6 @@ int HyPerConn::allocatePostConn(){
 
 
 int HyPerConn::allocateDataStructures() {
-#ifdef PV_USE_CUDA
-   if (!pre->getDataStructuresAllocatedFlag()) {
-      if (parent->columnId()==0) {
-         pvInfo().printf("%s must wait until pre-synaptic layer \"%s\" has finished its allocateDataStructures stage.\n", getDescription_c(), pre->getName());
-      }
-      return PV_POSTPONE;
-   }
-#endif // defined(PV_USE_CUDA)
    int status = BaseConnection::allocateDataStructures();
    pvAssert(status == PV_SUCCESS);
    initNumWeightPatches();
@@ -1479,20 +1471,7 @@ int HyPerConn::allocateDataStructures() {
 
 #ifdef PV_USE_CUDA
    status = allocateDeviceBuffers();
-   if(receiveGpu){
-      if(updateGSynFromPostPerspective){
-         status |= allocateReceivePostKernel();
-      }
-      else{
-         status |= allocateReceivePreKernel();
-      }
-   }
-   if(status == 0) {
-      status = PV_SUCCESS;
-   }
-   else{
-      pvError().printf("%s: unable to allocate device memory in rank %d process: %s\n", getDescription_c(), getParent()->columnId(), strerror(errno));
-   }
+   // allocateReceivePostKernel and allocateReceivePreKernel moved to setInitialValues stage
 #endif
 
    //Allocate temp buffers if needed, 1 for each thread
@@ -1686,7 +1665,7 @@ int HyPerConn::allocateDeviceBuffers()
    return status;
 }
 
-int HyPerConn::allocateReceivePreKernel()
+int HyPerConn::initializeReceivePreKernelArgs()
 {
    int status = 0;
    PVCuda::CudaDevice * device = parent->getDevice();
@@ -1769,7 +1748,7 @@ int HyPerConn::allocateReceivePreKernel()
    return status;
 }
 
-int HyPerConn::allocateReceivePostKernel()
+int HyPerConn::initializeReceivePostKernelArgs()
 {
    pvInfo() << name << " setting up post kernel\n";
    int status = 0;
@@ -2212,7 +2191,22 @@ int HyPerConn::insertProbe(BaseConnectionProbe * p)
 
 int HyPerConn::setInitialValues() {
    initializeWeights(wPatches, wDataStart);
-   return PV_SUCCESS;
+   int status = PV_SUCCESS;
+   if(receiveGpu){
+      if(updateGSynFromPostPerspective){
+         status = initializeReceivePostKernelArgs();
+      }
+      else{
+         status = initializeReceivePreKernelArgs();
+      }
+   }
+   if(status == 0) {
+      status = PV_SUCCESS;
+   }
+   else{
+      pvError().printf("%s: unable to allocate device memory in rank %d process: %s\n", getDescription_c(), getParent()->columnId(), strerror(errno));
+   }
+   return status;
 }
 
 int HyPerConn::outputProbeParams() {

--- a/src/connections/HyPerConn.cpp
+++ b/src/connections/HyPerConn.cpp
@@ -2192,6 +2192,7 @@ int HyPerConn::insertProbe(BaseConnectionProbe * p)
 int HyPerConn::setInitialValues() {
    initializeWeights(wPatches, wDataStart);
    int status = PV_SUCCESS;
+#ifdef PV_USE_CUDA
    if(receiveGpu){
       if(updateGSynFromPostPerspective){
          status = initializeReceivePostKernelArgs();
@@ -2206,6 +2207,7 @@ int HyPerConn::setInitialValues() {
    else{
       pvError().printf("%s: unable to allocate device memory in rank %d process: %s\n", getDescription_c(), getParent()->columnId(), strerror(errno));
    }
+#endif // PV_USE_CUDA
    return status;
 }
 

--- a/src/connections/HyPerConn.hpp
+++ b/src/connections/HyPerConn.hpp
@@ -1024,8 +1024,8 @@ protected:
    virtual int allocatePostDeviceWeights();
    virtual int allocateDeviceWeights();
    virtual int allocateDeviceBuffers();
-   virtual int allocateReceivePostKernel();
-   virtual int allocateReceivePreKernel();
+   virtual int initializeReceivePostKernelArgs();
+   virtual int initializeReceivePreKernelArgs();
    virtual void updateDeviceWeights();
 
    bool allocDeviceWeights;

--- a/src/connections/privateTransposeConn.cpp
+++ b/src/connections/privateTransposeConn.cpp
@@ -120,11 +120,11 @@ int privateTransposeConn::setPatchSize() {
 
 int privateTransposeConn::allocateDataStructures() {
    int status = HyPerConn::allocateDataStructures();
-   assert(status==PV_SUCCESS);
+   assert(status==PV_SUCCESS || status==PV_POSTPONE);
    normalizer = NULL;
    
    // normalize_flag = false; // replaced by testing whether normalizer!=NULL
-   return PV_SUCCESS;
+   return status;
 }
 
 int privateTransposeConn::constructWeights(){


### PR DESCRIPTION
This pull request fixes a bug that surfaces when using GPUs if a connection has a transpose whose presynaptic layer comes after it in the params file.

The HyPerConn deliver kernels now have their setArgs methods called during the setInitialValues stage instead of allocateDataStructures stage.  Hence, HyPerConn::allocateDataStructures does not have to postpone until its presynaptic layer has allocated.
