### PR TITLE
Enable double promotion warning and fix all occurences

### DIFF
--- a/cmake/PVConfigProject.cmake
+++ b/cmake/PVConfigProject.cmake
@@ -36,7 +36,7 @@ macro(pv_config_project)
   set(GCC_CPP_11X_FLAGS "-std=c++11")
   set(GCC_SANITIZE_ADDRESS_CXX_FLAGS -g;-fsanitize=address;-fno-omit-frame-pointer)
   set(GCC_SANITIZE_ADDRESS_LINKER_FLAGS -g;-fsanitize=address)
-#  set(GCC_COMPILE_FLAGS_DEBUG -Wdouble-promotion)
+  set(GCC_COMPILE_FLAGS_DEBUG -Wdouble-promotion)
   set(GCC_RELEASE_FLAGS "")
   set(GCC_LINK_LIBRARIES m)
   

--- a/src/arch/cuda/CudaDevice.cpp
+++ b/src/arch/cuda/CudaDevice.cpp
@@ -140,7 +140,7 @@ void CudaDevice::query_device(int id)
 
    pvInfo().printf("with %d units/cores", props.multiProcessorCount);
 
-   pvInfo().printf(" at %f MHz\n", (float)props.clockRate * .001);
+   pvInfo().printf(" at %f MHz\n", (double)props.clockRate * 0.001);
 
    pvInfo().printf("\tMaximum threads group size == %d\n", props.maxThreadsPerBlock);
    

--- a/src/columns/GaussianRandom.cpp
+++ b/src/columns/GaussianRandom.cpp
@@ -110,12 +110,12 @@ float GaussianRandom::gaussianDist(int localIndex) {
    else {
       float w;
       do {
-         x1 = 2.0 * uniformRandom(localIndex) - 1.0;
-         x2 = 2.0 * uniformRandom(localIndex) - 1.0;
+         x1 = 2.0f * uniformRandom(localIndex) - 1.0f;
+         x2 = 2.0f * uniformRandom(localIndex) - 1.0f;
          w = x1 * x1 + x2 * x2;
-      } while ( w >= 1.0 );
+      } while ( w >= 1.0f );
 
-      w = sqrt( (-2.0 * log( w ) ) / w );
+      w = sqrtf( (-2.0f * logf( w ) ) / w );
       y = x1 * w;
       bmdata.heldValue = x2 * w;
    }

--- a/src/columns/HyPerCol.cpp
+++ b/src/columns/HyPerCol.cpp
@@ -1146,10 +1146,10 @@ void HyPerCol::writeParam(const char * param_name, T value) {
       }
       else {
          if (std::numeric_limits<T>::has_infinity) {
-             if (value<=-FLT_MAX) {
+             if (value == std::numeric_limits<T>::min()) {
                  vstr << "-infinity";
              }
-             else if (value>=FLT_MAX) {
+             else if (value == std::numeric_limits<T>::max()) {
                  vstr << "infinity";
              }
              else {
@@ -1195,11 +1195,11 @@ void HyPerCol::writeParamArray(const char * param_name, const T * array, int arr
          fprintf(mPrintParamsStream->fp, "    %-35s = [", param_name);
          fprintf(mLuaPrintParamsStream->fp, "    %-35s = {", param_name);
          for (int k=0; k<arraysize-1; k++) {
-            fprintf(mPrintParamsStream->fp, "%f,", (float) array[k]);
-            fprintf(mLuaPrintParamsStream->fp, "%f,", (float) array[k]);
+            fprintf(mPrintParamsStream->fp, "%f,", (double) array[k]);
+            fprintf(mLuaPrintParamsStream->fp, "%f,", (double) array[k]);
          }
-         fprintf(mPrintParamsStream->fp, "%f];\n", (float) array[arraysize-1]);
-         fprintf(mLuaPrintParamsStream->fp, "%f};\n", (float) array[arraysize-1]);
+         fprintf(mPrintParamsStream->fp, "%f];\n", (double) array[arraysize-1]);
+         fprintf(mLuaPrintParamsStream->fp, "%f};\n", (double) array[arraysize-1]);
       }
    }
 }

--- a/src/columns/Publisher.cpp
+++ b/src/columns/Publisher.cpp
@@ -52,7 +52,7 @@ int Publisher::calcAllActiveIndices() {
          long * numActiveBuf = store->numActiveBuffer(b, l);
 
          for (int kex = 0; kex < store->getNumItems(); kex++) {
-            if (activity[kex] != 0.0) {
+            if (activity[kex] != 0.0f) {
                activeIndices[numActive] = kex;
                numActive++;
             }
@@ -72,7 +72,7 @@ int Publisher::calcActiveIndices() {
       unsigned int * activeIndices = store->activeIndicesBuffer(b);
       long * numActiveBuf = store->numActiveBuffer(b);
       for (int kex = 0; kex < store->getNumItems(); kex++) {
-         if (activity[kex] != 0.0) {
+         if (activity[kex] != 0.0f) {
             activeIndices[numActive] = kex;
             numActive++;
          }

--- a/src/connections/BaseConnection.cpp
+++ b/src/connections/BaseConnection.cpp
@@ -493,12 +493,12 @@ int BaseConnection::maxDelaySteps() {
 }
 
 //Input delay is in ms
-void BaseConnection::setDelay(int arborId, float delay) {
-   assert(arborId>=0 && arborId<this->numberOfAxonalArborLists());
-   int intDelay = round(delay/this->getParent()->getDeltaTime());
-   if (fmod(delay, this->getParent()->getDeltaTime()) != 0){
-      float actualDelay = intDelay * this->getParent()->getDeltaTime();
-      pvWarn() << this->getName() << ": A delay of " << delay << " will be rounded to " << actualDelay << "\n";
+void BaseConnection::setDelay(int arborId, double delay) {
+   assert(arborId>=0 && arborId<numberOfAxonalArborLists());
+   int intDelay = round(delay / getParent()->getDeltaTime());
+   if (fmod(delay, getParent()->getDeltaTime()) != 0){
+      double actualDelay = intDelay * getParent()->getDeltaTime();
+      pvWarn() << getName() << ": A delay of " << delay << " will be rounded to " << actualDelay << "\n";
    }
    delays[arborId] = (int)(intDelay);
 }

--- a/src/connections/BaseConnection.hpp
+++ b/src/connections/BaseConnection.hpp
@@ -265,7 +265,7 @@ protected:
     * that the parent HyPerCol's dt parameter is specified in.  Internally, the delay is set as
     * an integral number of timesteps, specifically round(delay/dt).
     */
-   void setDelay(int arborId, float delay);
+   void setDelay(int arborId, double delay);
 
    /**
     * Sets the number of arbors to the indicated argument.  It is an error to try to change numArbors

--- a/src/connections/CopyConn.cpp
+++ b/src/connections/CopyConn.cpp
@@ -216,14 +216,12 @@ int CopyConn::updateState(double time, double dt){
 
 int CopyConn::updateWeights(int axonID) {
    assert(originalConn->getLastUpdateTime() > lastUpdateTime);
-   int status;
-   float original_update_time = originalConn->getLastUpdateTime();
+   int status = PV_SUCCESS;
+   double original_update_time = originalConn->getLastUpdateTime();
    if(original_update_time > lastUpdateTime ) {
       status = copy(axonID);
       lastUpdateTime = parent->simulationTime();
    }
-   else
-      status = PV_SUCCESS;
    return status;
 }  // end of CopyConn::updateWeights(int);
 

--- a/src/connections/HyPerConn.hpp
+++ b/src/connections/HyPerConn.hpp
@@ -957,7 +957,7 @@ protected:
    virtual int deliverPostsynapticPerspectiveGPU(PVLayerCube const * activity, int arborID);
 #endif // PV_USE_CUDA
 
-   float getConvertToRateDeltaTimeFactor();
+   double getConvertToRateDeltaTimeFactor();
 
 //GPU variables
 #ifdef PV_USE_CUDA

--- a/src/connections/IdentConn.cpp
+++ b/src/connections/IdentConn.cpp
@@ -246,9 +246,7 @@ int IdentConn::deliverPresynapticPerspective(PVLayerCube const * activity, int a
       return PV_SUCCESS;
    }
    assert(post->getChannel(getChannel()));
-
-   float dt_factor = getConvertToRateDeltaTimeFactor();
-   assert(dt_factor==1.0);
+   assert(getConvertToRateDeltaTimeFactor() == 1.0);
 
    const PVLayerLoc * preLoc = preSynapticLayer()->getLayerLoc();
    const PVLayerLoc * postLoc = postSynapticLayer()->getLayerLoc();

--- a/src/connections/MomentumConn.cpp
+++ b/src/connections/MomentumConn.cpp
@@ -208,7 +208,7 @@ int MomentumConn::updateWeights(int arborId){
 int MomentumConn::applyMomentum(int arbor_ID){
    int nExt = preSynapticLayer()->getNumExtended();
    const PVLayerLoc * loc = preSynapticLayer()->getLayerLoc();
-   if(sharedWeights){
+   if (sharedWeights) {
       int numKernels = getNumDataPatches();
       //Shared weights done in parallel, parallel in numkernels
 #ifdef PV_USE_OPENMP_THREADS
@@ -226,7 +226,7 @@ int MomentumConn::applyMomentum(int arbor_ID){
          else if(!strcmp(momentumMethod, "viscosity")){
             for(int k = 0; k < nxp*nyp*nfp; k++){
                //dwdata_start[k] = momentumTau * (prev_dw_start[k] + dwdata_start[k]) * (1 - exp(-1.0/ momentumTau)) - momentumDecay*wdata_start[k];
-               dwdata_start[k] = (prev_dw_start[k] * exp(-1.0/ momentumTau)) + dwdata_start[k] - momentumDecay*wdata_start[k];
+               dwdata_start[k] = (prev_dw_start[k] * expf(-1.0f / momentumTau)) + dwdata_start[k] - momentumDecay*wdata_start[k];
             }
          }
          else if(!strcmp(momentumMethod, "alex")){

--- a/src/connections/PoolingConn.cpp
+++ b/src/connections/PoolingConn.cpp
@@ -590,14 +590,14 @@ int PoolingConn::deliverPresynapticPerspective(PVLayerCube const * activity, int
 
          int offset = kfPre;
          int sf = fPatchSize();
-         pvwdata_t w = 1.0;
+         pvwdata_t w = 1.0f;
          if(getPoolingType() == SUM){
-           w = 1.0;
+           w = 1.0f;
          }
          else if(getPoolingType() == AVG){
            float relative_XScale = pow(2, (post->getXScale() - pre->getXScale()));
            float relative_YScale = pow(2, (post->getYScale() - pre->getYScale()));
-           w = 1.0/(nxp*nyp*relative_XScale*relative_YScale);
+           w = 1.0f / (nxp*nyp*relative_XScale*relative_YScale);
          }
          void* auxPtr = nullptr;
          for (int y = 0; y < ny; y++) {
@@ -738,14 +738,14 @@ int PoolingConn::deliverPostsynapticPerspective(PVLayerCube const * activity, in
          const int kfPost = featureIndex(kTargetExt, postLoc->nx + postLoc->halo.lt + postLoc->halo.rt, postLoc->ny + postLoc->halo.dn + postLoc->halo.up, postLoc->nf);
          int offset = kfPost;
 
-         pvwdata_t w = 1.0;
+         pvwdata_t w = 1.0f;
          if(getPoolingType() == SUM){
-           w = 1.0;
+           w = 1.0f;
          }
          else if(getPoolingType() == AVG){
            float relative_XScale = pow(2, (post->getXScale() - pre->getXScale()));
            float relative_YScale = pow(2, (post->getYScale() - pre->getYScale()));
-           w = 1.0/(nxp*nyp*relative_XScale*relative_YScale);
+           w = 1.0f / (nxp*nyp*relative_XScale*relative_YScale);
          }
 
          for (int ky = 0; ky < yPatchSize; ky++){

--- a/src/connections/RescaleConn.cpp
+++ b/src/connections/RescaleConn.cpp
@@ -49,9 +49,7 @@ int RescaleConn::deliverPresynapticPerspective(PVLayerCube const * activity, int
       return PV_SUCCESS;
    }
    assert(post->getChannel(getChannel()));
-
-   float dt_factor = getConvertToRateDeltaTimeFactor();
-   assert(dt_factor==1.0);
+   assert(getConvertToRateDeltaTimeFactor() == 1.0);
 
    const PVLayerLoc * preLoc = preSynapticLayer()->getLayerLoc();
    const PVLayerLoc * postLoc = postSynapticLayer()->getLayerLoc();

--- a/src/connections/TransposePoolingConn.cpp
+++ b/src/connections/TransposePoolingConn.cpp
@@ -676,18 +676,15 @@ int TransposePoolingConn::deliverPresynapticPerspective(PVLayerCube const * acti
             int offset = kfPre;
             int sf = fPatchSize();
 
-            pvwdata_t w = 1.0;
+            pvwdata_t w = 1.0f;
             if(mPoolingType == PoolingConn::MAX){
-              //float relative_XScale = pow(2, (post->getXScale() - pre->getXScale()));
-              //float relative_YScale = pow(2, (post->getYScale() - pre->getYScale()));
-              //w = 1.0/(nxp*nyp*relative_XScale*relative_YScale);
-              w = 1.0;
+              w = 1.0f;
             }
             else if(mPoolingType == PoolingConn::MAX){
               float relative_XScale = pow(2, (post->getXScale() - pre->getXScale()));
               float relative_YScale = pow(2, (post->getYScale() - pre->getYScale()));
               float normVal = nxp*nyp;
-              w = 1.0/normVal;
+              w = 1.0f / normVal;
             }
             void* auxPtr = NULL;
             for (int y = 0; y < ny; y++) {
@@ -709,8 +706,8 @@ int TransposePoolingConn::deliverPresynapticPerspective(PVLayerCube const * acti
                float maxMag = -INFINITY;
                int maxMagIdx = -1;
                for(int ti = 0; ti < parent->getNumThreads(); ti++){
-                  if(maxMag < fabs(thread_gSyn[ti][ni])){
-                     maxMag = fabs(thread_gSyn[ti][ni]);
+                  if(maxMag < fabsf(thread_gSyn[ti][ni])){
+                     maxMag = fabsf(thread_gSyn[ti][ni]);
                      maxMagIdx = ti;
                   }
                }

--- a/src/connections/accumulate_functions.cpp
+++ b/src/connections/accumulate_functions.cpp
@@ -1,101 +1,73 @@
 #include <connections/accumulate_functions.hpp>
 
+// TODO athresher 9-12-16: Why do these have different return types?
+
 #ifdef COMPRESS_PHI
 void pvpatch_accumulate(int kPreExt, int nk, float* restrict v, float a, pvwdata_t* restrict w,
                         float* restrict m)
 {
-   const float scale = 33.3;
-   const float inv_scale = 1.0/scale;
-   const float shift = 2.0;
-   int k;
-
-   for (k = 0; k < nk; k++) {
-            v[k] = (((shift + scale*v[k]) + a*w[k]*m[k])
-                  - shift) * inv_scale;
-      // without mask
-      //      v[k] = (((shift + scale*v[k]) + a*w[k])
-      //                  - shift) * inv_scale;
+   const float scale = 33.3f;
+   const float inv_scale = 1.0f / scale;
+   const float shift = 2.0f;
+   for (int k = 0; k < nk; ++k) {
+      v[k] = (shift + scale*v[k] + a*w[k]*m[k] - shift) * inv_scale;
    }
 }
 #else
   int pvpatch_accumulate(int kPreExt, int nk, float* RESTRICT v, float a, pvwdata_t* RESTRICT w, void * auxPtr, int sf)
 {
-   int k;
-   int err = 0;
-   float accumval = 0;
-   for (k = 0; k < nk; k++) {
-      accumval = a*w[k];
-      v[k] += accumval;
+   for (int k = 0; k < nk; ++k) {
+      v[k] += a * w[k];
    }
-   return err;
+   return PV_SUCCESS;
 }
 #endif
 
 int pvpatch_accumulate_from_post(int kPreExt, int nk, float * RESTRICT v, float * RESTRICT a, pvwdata_t * RESTRICT w, float dt_factor, void * auxPtr, int sf) {
-   int status = 0;
-   int k;
-   float dv = 0.0;
-   for (k = 0; k < nk; k++) {
+   float dv = 0.0f;
+   for (int k = 0; k < nk; ++k) {
       dv += a[k] * w[k];
    }
    *v += dt_factor * dv;
-   return status;
+   return PV_SUCCESS;
 }
 
 int pvpatch_accumulate2(int nk, float* RESTRICT v, float a, pvwdata_t* RESTRICT w, float* RESTRICT m)
 {
-   int k;
-   int err = 0;
-   float accumval = 0;
-   for (k = 0; k < nk; k++) {
-      accumval = a*w[k]*m[k];
-//#ifdef PV_USE_OPENMP_THREADS
-//#pragma omp atomic
-//#endif
-      v[k] += accumval;
+   for (int k = 0; k < nk; ++k) {
+      v[k] += a * w[k] * m[k];
    }
-      //v[k] += accumval;
-   return err;
+   return PV_SUCCESS;
 }
 
+// TODO athresher 9-12-16: Can we change this void pointer to *taus_uint4?
 int pvpatch_accumulate_stochastic(int kPreExt, int nk, float* RESTRICT v, float a, pvwdata_t* RESTRICT w, void * auxPtr, int sf)
 {
    taus_uint4 * rng = (taus_uint4 *) auxPtr;
-   long along = (long) (a*cl_random_max());
-   int err = 0;
-   int k;
-   float accumval = 0;
-   for (k = 0; k < nk; k+=sf) {
+   long along = (long) ((double)a * cl_random_max());
+   for (int k = 0; k < nk; k += sf) {
       *rng = cl_random_get(*rng);
-      accumval = (rng->s0 < along)*w[k];
-//#ifdef PV_USE_OPENMP_THREADS
-//#pragma omp atomic
-//#endif
-      v[k] += accumval;
+      v[k] += (rng->s0 < along) * w[k];
    }
-   return err;
+   return PV_SUCCESS;
 }
 
 int pvpatch_accumulate_stochastic_from_post(int kPreExt, int nk, float * RESTRICT v, float * RESTRICT a, pvwdata_t * RESTRICT w, float dt_factor, void * auxPtr, int sf) {
-   int status = 0;
    taus_uint4 * rng = (taus_uint4 *) auxPtr;
-   int k;
    float dv = 0.0f;
-   for (k = 0; k < nk; k+=sf) {
+   for (int k = 0; k < nk; k+=sf) {
       *rng = cl_random_get(*rng);
       double p = (double) rng->s0/cl_random_max(); // 0.0 < p < 1.0
-      dv += (p<a[k]*dt_factor)*w[k];
+      dv += ((float)p < a[k] * dt_factor) * w[k];
    }
    *v = *v + dv;
-   return status;
+   return PV_SUCCESS;
 }
 
 int pvpatch_max_pooling(int kPreGlobalExt, int nk, float* RESTRICT v, float a, pvwdata_t* RESTRICT w, void * auxPtr, int sf)
 {
-  int k;
-  int err = 0;
   float * gate = (float *)auxPtr;
-  for (k = 0; k < nk; k+=sf) {
+  for (int k = 0; k < nk; k+=sf) {
     float checkVal = a*w[0];
     if(v[k] <= checkVal){
        v[k] = checkVal;
@@ -104,53 +76,43 @@ int pvpatch_max_pooling(int kPreGlobalExt, int nk, float* RESTRICT v, float a, p
        }
     }
   }
-  return err;
+  return PV_SUCCESS;
 }
 
 int pvpatch_max_pooling_from_post(int kPreGlobalExt, int nk, float * RESTRICT v, float * RESTRICT a, pvwdata_t * RESTRICT w, float dt_factor, void * auxPtr, int sf) {
-   int status = 0;
-   int k;
    float vmax = *v;
    float* gate = (float*)auxPtr;
-   int gateMax;
-   if(gate){
+   int gateMax = 0;
+   if (gate) {
       gateMax = (int) *gate;
    }
-   for (k = 0; k < nk; k+=sf) {
+   for (int k = 0; k < nk; k+=sf) {
       float checkVal = a[k];
-      if(vmax <= checkVal){
+      if(vmax <= checkVal) {
          vmax = checkVal;
-         if(gate){
-            gateMax = kPreGlobalExt+k;
-         }
+         gateMax = kPreGlobalExt + k;
       }
    }
    *v = vmax*w[0];
-   if(gate){
+   if (gate) {
       *gate = (float) gateMax;
    }
-   return status;
+   return PV_SUCCESS;
 }
 
 int pvpatch_sum_pooling(int kPreExt, int nk, float* RESTRICT v, float a, pvwdata_t* RESTRICT w, void * auxPtr, int sf)
 {
-   int k;
-   int err = 0;
-   float accumval = 0;
-   for (k = 0; k < nk; k+=sf) {
-      accumval = a*w[0];
-      v[k] += accumval;
+   for (int k = 0; k < nk; k+=sf) {
+      v[k] += a*w[0];
    }
-   return err;
+   return PV_SUCCESS;
 }
 
 int pvpatch_sumpooling_from_post(int kPreExt, int nk, float * RESTRICT v, float * RESTRICT a, pvwdata_t * RESTRICT w, float dt_factor, void * auxPtr, int sf) {
-   int status = 0;
-   int k;
    float dv = 0.0f;
-   for (k = 0; k < nk; k+=sf) {
+   for (int k = 0; k < nk; k+=sf) {
       dv += a[k];
    }
    *v += dt_factor*dv*w[0];
-   return status;
+   return PV_SUCCESS;
 }

--- a/src/connections/weight_conversions.hpp
+++ b/src/connections/weight_conversions.hpp
@@ -12,7 +12,7 @@ namespace PV {
 
 /** Compress a weight value to an unsigned char */
 static inline unsigned char compressWeight(pvdata_t w, pvdata_t minVal, pvdata_t maxVal) {
-   return (unsigned char) (255.0 * ((w - minVal) / (maxVal - minVal)) + 0.5);
+   return (unsigned char) (255.0f * ((w - minVal) / (maxVal - minVal)) + 0.5f);
 }
 
 /** Compress a weight value to an unsigned char (weight type pvwdata_t already a uchar) */
@@ -22,7 +22,7 @@ static inline unsigned char compressWeight(unsigned char w, pvdata_t minVal, pvd
 
 /** Uncompress a weight value to a pvdata_t data type */
 static inline pvdata_t uncompressWeight(unsigned char w, pvdata_t minVal, pvdata_t maxVal) {
-   return (pvdata_t) (minVal + (maxVal - minVal) * ((pvdata_t)w / 255.0));
+   return (pvdata_t) (minVal + (maxVal - minVal) * ((pvdata_t)w / 255.0f));
 }
 
 /** Uncompress a weight value to a pvdata_t data type (weight type pvwdata_t already a float) */

--- a/src/include/pv_common.h
+++ b/src/include/pv_common.h
@@ -20,7 +20,6 @@
 #define PV_SUCCESS 0
 #define PV_FAILURE 1
 #define PV_BREAK 2
-// #define PV_EXIT_NORMALLY 3 // Not currently used
 #define PV_POSTPONE 4
 #define PV_CONTINUE 5
 #define PV_MARGINWIDTH_FAILURE 65
@@ -33,20 +32,10 @@
 #define MAX_FILESYSTEMCALL_TRIES 5
 
 // Misc:
-#define PI              3.1415926535897932
+#define PI              3.1415926535897932f
 
 // number in communicating neighborhood
 #define NUM_NEIGHBORHOOD 9
-
-// directional indices
-//#define LOCAL     0 //#define NORTHWEST 1
-//#define NORTH     2
-//#define NORTHEAST 3
-//#define WEST      4
-//#define EAST      5
-//#define SOUTHWEST 6
-//#define SOUTH     7
-//#define SOUTHEAST 8
 
 // Limits:
 #define MAX_NEIGHBORS                   8
@@ -56,7 +45,5 @@
 #define INITIAL_SUBSCRIBER_ARRAY_SIZE INITIAL_LAYER_ARRAY_SIZE
 #define RESIZE_ARRAY_INCR               5
 #define MAX_F_DELAY                    1001//21 // can have 0:MAX_F_DELAY-1 buffers of delay
-
-#define DISPLAY_PERIOD 1.0
 
 #endif /* PV_COMMON_H */

--- a/src/io/FirmThresholdCostFnProbe.cpp
+++ b/src/io/FirmThresholdCostFnProbe.cpp
@@ -84,9 +84,9 @@ double FirmThresholdCostFnProbe::getValueInternal(double timevalue, int index) {
    int const dn = halo->dn;
    int const up = halo->up;
    double sum = 0.0;
-   pvpotentialdata_t VThreshPlusVWidth = VThresh+VWidth;
-   double amax=0.5f*VThreshPlusVWidth;
-   double a2 = 0.5f/VThreshPlusVWidth;
+   double VThreshPlusVWidth = VThresh + VWidth;
+   double amax= 0.5 * VThreshPlusVWidth;
+   double a2  = 0.5 / VThreshPlusVWidth;
    pvadata_t const * aBuffer = getTargetLayer()->getLayerData() + index * getTargetLayer()->getNumExtended();
    
    if (getMaskLayer()) {
@@ -105,16 +105,16 @@ double FirmThresholdCostFnProbe::getValueInternal(double timevalue, int index) {
 #endif // PV_USE_OPENMP_THREADS
          for (int kxy=0; kxy<nxy; kxy++) {
             int kexMask = kIndexExtended(kxy, nx, ny, 1, maskLt, maskRt, maskDn, maskUp);
-            if (maskLayerData[kexMask]==0) { continue; }
+            if (maskLayerData[kexMask] == 0) { continue; }
             int featureBase = kxy*nf;
             for (int f=0; f<nf; f++) {
                int kex = kIndexExtended(featureBase++, nx, ny, nf, lt, rt, dn, up);
-               pvadata_t a = fabsf(aBuffer[kex]);
-               if (a>=VThreshPlusVWidth) {
+               double a = (double)fabs(aBuffer[kex]);
+               if (a >= VThreshPlusVWidth) {
                   sum += amax;
                }
                else {
-                  sum += a*(1 - a2*a);
+                  sum += a * (1.0 - a2*a);
                }
             }
          }         
@@ -125,15 +125,15 @@ double FirmThresholdCostFnProbe::getValueInternal(double timevalue, int index) {
 #endif // PV_USE_OPENMP_THREADS
          for (int k=0; k<getTargetLayer()->getNumNeurons(); k++) {
             int kex = kIndexExtended(k, nx, ny, nf, lt, rt, dn, up);
-            pvadata_t a = fabsf(aBuffer[kex]);
+            double a = (double)fabs(aBuffer[kex]);
             if (a==0) { continue; }
             int kexMask = kIndexExtended(k, nx, ny, nf, maskLt, maskRt, maskDn, maskUp);
             if (maskLayerData[kexMask]==0) { continue; }
-            if (a>=VThreshPlusVWidth) {
+            if (a >= VThreshPlusVWidth) {
                sum += amax;
             }
             else {
-               sum += a*(1 - a2*a);
+               sum += a * (1.0 - a2*a);
             }
          }
       }
@@ -149,12 +149,12 @@ double FirmThresholdCostFnProbe::getValueInternal(double timevalue, int index) {
          for (int k=0; k<numActive; k++) {
             int extIndex = activeList[k];
             int inRestricted = !extendedIndexInBorderRegion(extIndex, nx, ny, nf, halo->lt, halo->rt, halo->dn, halo->up);
-            pvadata_t a = inRestricted * fabsf(aBuffer[extIndex]);
-            if (a>=VThreshPlusVWidth) {
+            double a = inRestricted * (double)fabs(aBuffer[extIndex]);
+            if (a >= VThreshPlusVWidth) {
                sum += amax;
             }
             else {
-               sum += a*(1 - a2*a);
+               sum += a * (1.0 - a2*a);
             }
          }
       }
@@ -164,13 +164,13 @@ double FirmThresholdCostFnProbe::getValueInternal(double timevalue, int index) {
 #endif // PV_USE_OPENMP_THREADS
          for (int k=0; k<getTargetLayer()->getNumNeurons(); k++) {
             int kex = kIndexExtended(k, nx, ny, nf, lt, rt, dn, up);
-            pvadata_t a = fabsf(aBuffer[kex]);
+            double a = (double)fabs(aBuffer[kex]);
             if (a==0) { continue; }
             if (a>=VThreshPlusVWidth) {
                sum += amax;
             }
             else {
-               sum += a*(1 - a2*a);
+               sum += a * (1.0 - a2*a);
             }
          }
       }

--- a/src/io/L1NormProbe.cpp
+++ b/src/io/L1NormProbe.cpp
@@ -91,8 +91,8 @@ double L1NormProbe::getValueInternal(double timevalue, int index) {
          for (int k=0; k<numActive; k++) {
             int extIndex = activeList[k];
             int inRestricted = !extendedIndexInBorderRegion(extIndex, nx, ny, nf, halo->lt, halo->rt, halo->dn, halo->up);
-            pvadata_t val = inRestricted * fabsf(aBuffer[extIndex]);
-            sum += fabsf(val);
+            double val = inRestricted * (double)fabs(aBuffer[extIndex]);
+            sum += fabs(val);
          }
       }
       else {
@@ -101,8 +101,7 @@ double L1NormProbe::getValueInternal(double timevalue, int index) {
 #endif // PV_USE_OPENMP_THREADS
          for (int k=0; k<getTargetLayer()->getNumNeurons(); k++) {
             int kex = kIndexExtended(k, nx, ny, nf, lt, rt, dn, up);
-            pvadata_t val = fabsf(aBuffer[kex]);
-            sum += fabsf(val);
+            sum += (double)fabs(aBuffer[kex]);
          }
       }
    }

--- a/src/io/L2NormProbe.cpp
+++ b/src/io/L2NormProbe.cpp
@@ -93,8 +93,7 @@ double L2NormProbe::getValueInternal(double timevalue, int index) {
                int featureBase = kxy*nf;
                for (int f=0; f<nf; f++) {
                   int kex = kIndexExtended(featureBase++, nx, ny, nf, lt, rt, dn, up);
-                  pvadata_t val = aBuffer[kex];
-                  l2normsq += val*val;
+                  l2normsq += pow((double)aBuffer[kex], 2.0);
                }
             }
          }         
@@ -106,10 +105,8 @@ double L2NormProbe::getValueInternal(double timevalue, int index) {
          for (int k=0; k<getTargetLayer()->getNumNeurons(); k++) {
             int kex = kIndexExtended(k, nx, ny, nf, lt, rt, dn, up);
             int kexMask = kIndexExtended(k, nx, ny, nf, maskLt, maskRt, maskDn, maskUp);
-            //            if (maskLayerData[kexMask]) {
-               pvadata_t val = aBuffer[kex];
-               l2normsq += maskLayerData[kexMask] * val*val;
-            //            }
+               double val = aBuffer[kex];
+               l2normsq += (double)maskLayerData[kexMask] * val * val;
          }
       }
    }
@@ -124,8 +121,8 @@ double L2NormProbe::getValueInternal(double timevalue, int index) {
          for (int k=0; k<numActive; k++) {
             int extIndex = activeList[k];
             int inRestricted = !extendedIndexInBorderRegion(extIndex, nx, ny, nf, halo->lt, halo->rt, halo->dn, halo->up);
-            pvadata_t val = inRestricted * fabsf(aBuffer[extIndex]);
-            l2normsq += val*val;
+            double val = inRestricted * fabs((double)aBuffer[extIndex]);
+            l2normsq += pow(val, 2.0);
          }
       }
       else {
@@ -134,8 +131,7 @@ double L2NormProbe::getValueInternal(double timevalue, int index) {
 #endif // PV_USE_OPENMP_THREADS
          for (int k=0; k<getTargetLayer()->getNumNeurons(); k++) {
             int kex = kIndexExtended(k, nx, ny, nf, lt, rt, dn, up);
-            pvadata_t val = aBuffer[kex];
-            l2normsq += val*val;
+            l2normsq += pow((double)aBuffer[kex], 2.0); 
          }
       }
    }

--- a/src/io/PVParams.cpp
+++ b/src/io/PVParams.cpp
@@ -79,12 +79,22 @@ Parameter::~Parameter()
 
 int Parameter::outputParam(FILE * fp, int indentation) {
    int status = PV_SUCCESS;
-   for( int i=indentation; i>0; i-- ) fputc(' ', fp);
+   for(int i = 0; i < indentation; ++i) {
+      fputc(' ', fp);
+   }
    fprintf(fp, "%s : %.17e", paramName, paramDblValue);
-   if( paramDblValue == 1.0f ) fprintf(fp, " (true)");
-   else if( paramDblValue == 1.0f ) fprintf(fp, " (false)");
-   else if( paramDblValue == FLT_MAX ) fprintf(fp, " (infinity)");
-   else if( paramDblValue == -FLT_MAX ) fprintf(fp, " (-infinity)");
+   if (paramDblValue == 1.0) {
+      fprintf(fp, " (true)");
+   }
+   else if (paramDblValue == -1.0) {
+      fprintf(fp, " (false)");
+   }
+   else if (paramDblValue == DBL_MAX) {
+      fprintf(fp, " (infinity)");
+   }
+   else if (paramDblValue == -DBL_MAX) {
+      fprintf(fp, " (-infinity)");
+   }
    fprintf(fp, "\n");
    return status;
 }

--- a/src/io/StatsProbe.hpp
+++ b/src/io/StatsProbe.hpp
@@ -53,7 +53,7 @@ protected:
    float* avg;
    float* sigma;
 
-   pvdata_t nnzThreshold;
+   float nnzThreshold;
    Timer * iotimer;   // A timer for the i/o part of outputState
    Timer * mpitimer;  // A timer for the MPI part of outputState
    Timer * comptimer; // A timer for the basic computation of outputState

--- a/src/io/fileio.cpp
+++ b/src/io/fileio.cpp
@@ -1991,18 +1991,13 @@ int pv_text_write_patch(OutStream * outStream, PVPatch * patch, pvwdata_t * data
 
    const int nx = (int) patch->nx;
    const int ny = (int) patch->ny;
-   //const int nf = (int) patch->nf;
-
-   //const int sx = (int) patch->sx;  assert(sx == nf);
-   //const int sy = (int) patch->sy;  //assert(sy == nf*nx);
-   //const int sf = (int) patch->sf;  assert(sf == 1);
 
    assert(outStream != NULL);
 
    for (f = 0; f < nf; f++) {
       for (j = 0; j < ny; j++) {
          for (i = 0; i < nx; i++) {
-            outStream->printf("%7.5f ", data[i*sx + j*sy + f*sf]);
+            outStream->printf("%7.5f ", (double)data[i*sx + j*sy + f*sf]);
          }
          outStream->printf("\n");
       }

--- a/src/layers/ANNErrorLayer.cpp
+++ b/src/layers/ANNErrorLayer.cpp
@@ -108,7 +108,7 @@ int ANNErrorLayer::checkVertices() const {
    if (VThresh < 0 && VThresh > -0.999*max_pvvdata_t) { // 0.999 is to allow for imprecision from params files using 3.40282e+38 instead of infinity
       if (parent->columnId()==0) {
          pvErrorNoExit().printf("%s: VThresh cannot be negative (value is %f).\n",
-               getDescription_c(), VThresh);
+               getDescription_c(), (double)VThresh);
       }
       status = PV_FAILURE;
    }

--- a/src/layers/ANNLayer.cpp
+++ b/src/layers/ANNLayer.cpp
@@ -203,7 +203,7 @@ int ANNLayer::setVertices() {
       VWidth = -VWidth;
       if (parent->columnId()==0) {
          pvWarn().printf("%s: interpreting negative VWidth as setting VThresh=%f and VWidth=%f\n",
-               getDescription_c(), VThresh, VWidth);
+               getDescription_c(), (double)VThresh, (double)VWidth);
       }
    }
 
@@ -214,11 +214,11 @@ int ANNLayer::setVertices() {
       if (parent->columnId()==0) {
          if (VWidth==0) {
             pvWarn().printf("%s: nonmonotonic transfer function, jumping from %f to %f at Vthresh=%f\n",
-                  getDescription_c(), AMin, limfromright, VThresh);
+                  getDescription_c(), (double)AMin, (double)limfromright, (double)VThresh);
          }
          else {
             pvWarn().printf("%s: nonmonotonic transfer function, changing from %f to %f as V goes from VThresh=%f to VThresh+VWidth=%f\n",
-                  getDescription_c(), AMin, limfromright, VThresh, VThresh+VWidth);
+                  getDescription_c(), (double)AMin, (double)limfromright, (double)VThresh, (double)(VThresh+VWidth));
          }
       }
    }
@@ -350,13 +350,13 @@ int ANNLayer::checkVertices() const {
          status = PV_FAILURE;
          if (this->getParent()->columnId()==0) {
             pvErrorNoExit().printf("%s: vertices %d and %d: V-coordinates decrease from %f to %f.\n",
-                  getDescription_c(), v, v+1, verticesV[v-1], verticesV[v]);
+                  getDescription_c(), v, v+1, (double)verticesV[v-1], (double)verticesV[v]);
          }
       }
       if (verticesA[v] < verticesA[v-1]) {
          if (this->getParent()->columnId()==0) {
             pvWarn().printf("%s: vertices %d and %d: A-coordinates decrease from %f to %f.\n",
-                  getDescription_c(), v, v+1, verticesA[v-1], verticesA[v]);
+                  getDescription_c(), v, v+1, (double)verticesA[v-1], (double)verticesA[v]);
          }
       }
    }

--- a/src/layers/BinningLayer.cpp
+++ b/src/layers/BinningLayer.cpp
@@ -62,7 +62,7 @@ void BinningLayer::ioParam_binMaxMin(enum ParamsIOFlag ioFlag) {
    if(ioFlag == PARAMS_IO_READ && binMax <= binMin){
       if (parent->columnId()==0) {
          pvErrorNoExit().printf("%s: binMax (%f) must be greater than binMin (%f).\n",
-               getDescription_c(), binMax, binMin);
+               getDescription_c(), (double)binMax, (double)binMin);
       }
       MPI_Barrier(parent->getCommunicator()->communicator());
       exit(EXIT_FAILURE);
@@ -280,10 +280,10 @@ int BinningLayer::doUpdateState(double timed, double dt, const PVLayerLoc * orig
 
 float BinningLayer::calcNormDist(float xVal, float mean, float sigma){
    if(normalDist){
-      return (float(1)/(sigma*(sqrt(2*PI))))*exp(-(pow(xVal-mean, 2)/(2*pow(sigma, 2))));
+      return 1.0f / (sigma * (sqrtf(2.0f * (float)PI))) * expf(-(powf(xVal-mean, 2.0f) / (2.0f * powf(sigma, 2.0f))));
    }
    else{
-      return exp(-(pow(xVal-mean, 2)/(2*pow((sigma/2), 2))));
+      return expf(-(powf(xVal-mean, 2.0f) / (2.0f * powf((sigma/2.0f), 2.0f))));
    }
 }
 

--- a/src/layers/HyPerLCALayer.cpp
+++ b/src/layers/HyPerLCALayer.cpp
@@ -147,7 +147,7 @@ int HyPerLCALayer::allocateUpdateKernel(){
    const float AShift = this->AShift;
    const float VWidth = this->VWidth;
    const bool selfInteract = this->selfInteract;
-   const float tau = timeConstantTau/parent->getDeltaTime(); // TODO: eliminate need to call parent method
+   const float tau = timeConstantTau / (float)parent->getDeltaTime(); // TODO: eliminate need to call parent method
    PVCuda::CudaBuffer* d_GSyn = getDeviceGSyn();
    PVCuda::CudaBuffer* d_activity = getDeviceActivity();
 
@@ -222,7 +222,7 @@ int HyPerLCALayer::updateState(double time, double dt) {
       
       HyPerLCALayer_update_state(nbatch, num_neurons, nx, ny, nf, loc->halo.lt, loc->halo.rt, loc->halo.dn, loc->halo.up, numChannels,
             V, numVertices, verticesV, verticesA, slopes,
-            selfInteract, deltaTimes(), timeConstantTau/dt, gSynHead, A);
+            selfInteract, deltaTimes(), timeConstantTau / (float)dt, gSynHead, A);
    }
 
    return PV_SUCCESS;

--- a/src/layers/HyPerLayer.cpp
+++ b/src/layers/HyPerLayer.cpp
@@ -170,7 +170,7 @@ int HyPerLayer::initialize(const char * name, HyPerCol * hc) {
 #endif
 #endif
 
-   PVParams * params = parent->parameters();
+   PVParams * params = hc->parameters();
 
    status = ioParams(PARAMS_IO_READ);
    assert(status == PV_SUCCESS);
@@ -179,17 +179,17 @@ int HyPerLayer::initialize(const char * name, HyPerCol * hc) {
    writeActivityCalls = 0;
    writeActivitySparseCalls = 0;
    numDelayLevels = 1; // If a connection has positive delay so that more delay levels are needed, numDelayLevels is increased when BaseConnection::communicateInitInfo calls increaseDelayLevels
-   maxRate = 1000.0f/parent->getDeltaTime();
+   maxRate = 1000.0f / (float)hc->getDeltaTime();
 
    initClayer();
 
    // must set ioAppend before addLayer is called (addLayer causes activity file to be opened using layerid)
-   ioAppend = parent->getCheckpointReadFlag() ? 1 : 0;
+   ioAppend = hc->getCheckpointReadFlag() ? 1 : 0;
 
-   parent->addLayer(this);
+   hc->addLayer(this);
 
-   mLastUpdateTime  = parent->getDeltaTime();
-   mLastTriggerTime = parent->getDeltaTime();
+   mLastUpdateTime  = hc->getDeltaTime();
+   mLastTriggerTime = hc->getDeltaTime();
    return PV_SUCCESS;
 }
 
@@ -405,7 +405,8 @@ int HyPerLayer::setLayerLoc(PVLayerLoc * layerLoc, float nxScale, float nyScale,
       if (parent->columnId()==0) {
          pvErrorNoExit(errorMessage);
          errorMessage.printf("nxScale of layer \"%s\" is incompatible with size of column.\n", getName());
-         errorMessage.printf("Column nx %d multiplied by nxScale %f must be an integer.\n", parent->getNxGlobal(), nxScale);
+         errorMessage.printf("Column nx %d multiplied by nxScale %f must be an integer.\n",
+               (double)parent->getNxGlobal(), (double)nxScale);
       }
       status = PV_FAILURE;
    }
@@ -416,7 +417,8 @@ int HyPerLayer::setLayerLoc(PVLayerLoc * layerLoc, float nxScale, float nyScale,
       if (parent->columnId()==0) {
          pvErrorNoExit(errorMessage);
          errorMessage.printf("nyScale of layer \"%s\" is incompatible with size of column.\n", getName());
-         errorMessage.printf("Column ny %d multiplied by nyScale %f must be an integer.\n", parent->getNyGlobal(), nyScale);
+         errorMessage.printf("Column ny %d multiplied by nyScale %f must be an integer.\n",
+               (double)parent->getNyGlobal(), (double)nyScale);
       }
       status = PV_FAILURE;
    }
@@ -1756,8 +1758,8 @@ int HyPerLayer::recvAllSynapticInput() {
 
 
 #ifdef PV_USE_CUDA
-float HyPerLayer::addGpuTimers(){
-   float simTime = 0;
+double HyPerLayer::addGpuTimers(){
+   double simTime = 0;
    bool updateNeeded = needUpdate(parent->simulationTime(), parent->getDeltaTime());
    if(recvGpu && updateNeeded){
       simTime += gpu_recvsyn_timer->accumulateTime();
@@ -2148,7 +2150,7 @@ int HyPerLayer::checkpointWrite(const char * cpDir) {
       }
    }
 
-   if (writeStep>=0.0f) {
+   if (writeStep >= 0.0) {
       if (sparseLayer) {
          parent->writeScalarToFile(cpDir, getName(), "numframes_sparse", writeActivitySparseCalls);
       }

--- a/src/layers/HyPerLayer.hpp
+++ b/src/layers/HyPerLayer.hpp
@@ -539,7 +539,7 @@ protected:
 public:
 
    virtual void syncGpu();
-   virtual float addGpuTimers();
+   virtual double addGpuTimers();
 
    void copyAllGSynToDevice();
    void copyAllGSynFromDevice();

--- a/src/layers/ISTALayer.cpp
+++ b/src/layers/ISTALayer.cpp
@@ -55,7 +55,7 @@ ISTALayer::~ISTALayer()
 int ISTALayer::initialize_base()
 {
    numChannels = 1; // If a connection connects to this layer on inhibitory channel, HyPerLayer::requireChannel will add necessary channel
-   timeConstantTau = 1.0;
+   timeConstantTau = 1.0f;
    //Locality in conn
    //numWindowX = 1;
    //numWindowY = 1;
@@ -135,7 +135,7 @@ int ISTALayer::allocateUpdateKernel(){
    const float AShift = this->AShift;
    const float VWidth = this->VWidth;
    const bool selfInteract = this->selfInteract;
-   const float tau = timeConstantTau/parent->getDeltaTime(); // TODO: eliminate need to call parent method
+   const float tau = timeConstantTau/(float)parent->getDeltaTime(); // TODO: eliminate need to call parent method
    PVCuda::CudaBuffer* d_GSyn = getDeviceGSyn();
    PVCuda::CudaBuffer* d_activity = getDeviceActivity();
 
@@ -197,7 +197,7 @@ int ISTALayer::updateState(double time, double dt)
    }
    
    ISTALayer_update_state(nbatch, num_neurons, nx, ny, nf, loc->halo.lt, loc->halo.rt, loc->halo.dn, loc->halo.up, numChannels,
-         V, VThresh, deltaTimes(), timeConstantTau/dt, gSynHead, A);
+         V, VThresh, deltaTimes(), timeConstantTau/(float)dt, gSynHead, A);
    return PV_SUCCESS;
 }
 

--- a/src/layers/InputLayer.cpp
+++ b/src/layers/InputLayer.cpp
@@ -261,17 +261,17 @@ namespace PV {
          float* buf = getActivity() + b * numExtended;
          if (mNormalizeLuminanceFlag){
             if (mNormalizeStdDev){
-               double image_sum = 0.0f;
-               double image_sum2 = 0.0f;
+               float image_sum = 0.0;
+               float image_sum2 = 0.0;
                for (int k=0; k<numExtended; k++) {
                   image_sum += buf[k];
                   image_sum2 += buf[k]*buf[k];
                }
-               double image_ave = image_sum / numExtended;
-               double image_ave2 = image_sum2 / numExtended;
-               MPI_Allreduce(MPI_IN_PLACE, &image_ave, 1, MPI_DOUBLE, MPI_SUM, parent->getCommunicator()->communicator());
+               float image_ave = image_sum / numExtended;
+               float image_ave2 = image_sum2 / numExtended;
+               MPI_Allreduce(MPI_IN_PLACE, &image_ave, 1, MPI_FLOAT, MPI_SUM, parent->getCommunicator()->communicator());
                image_ave /= parent->getCommunicator()->commSize();
-               MPI_Allreduce(MPI_IN_PLACE, &image_ave2, 1, MPI_DOUBLE, MPI_SUM, parent->getCommunicator()->communicator());
+               MPI_Allreduce(MPI_IN_PLACE, &image_ave2, 1, MPI_FLOAT, MPI_SUM, parent->getCommunicator()->communicator());
                image_ave2 /= parent->getCommunicator()->commSize();
 
                // set mean to zero
@@ -280,10 +280,10 @@ namespace PV {
                }
                
                // set std dev to 1
-               double image_std = sqrt(image_ave2 - image_ave*image_ave); 
+               float image_std = sqrtf(image_ave2 - image_ave*image_ave); 
                if (image_std == 0){
                   for (int k=0; k<numExtended; k++) {
-                     buf[k] = 0.0;
+                     buf[k] = 0.0f;
                   }
                }
                else {
@@ -318,7 +318,7 @@ namespace PV {
          if (mInverseFlag) {
             for (int k=0; k<numExtended; k++) {
                // If normalizeLuminanceFlag is true, should the effect of inverseFlag be buf[k] = -buf[k]?
-               buf[k] = 1 - buf[k]; 
+               buf[k] = 1.0f - buf[k]; 
             }
          }
       }

--- a/src/layers/LCALIFLayer.hpp
+++ b/src/layers/LCALIFLayer.hpp
@@ -11,7 +11,7 @@
 #include "HyPerLayer.hpp"
 #include "LIFGap.hpp"
 
-#define DEFAULT_DYNVTHSCALE 1.0
+#define DEFAULT_DYNVTHSCALE 1.0f
 
 namespace PV {
 class LCALIFLayer : public PV::LIFGap {

--- a/src/layers/LIF.cpp
+++ b/src/layers/LIF.cpp
@@ -195,24 +195,30 @@ void LIF::ioParam_noiseAmpIB(enum ParamsIOFlag ioFlag) { parent->ioParamValue(io
 void LIF::ioParam_noiseFreqE(enum ParamsIOFlag ioFlag) {
    parent->ioParamValue(ioFlag, name, "noiseFreqE", &lParams.noiseFreqE, 250.0f);
    if (ioFlag==PARAMS_IO_READ) {
-      float dt_sec = .001 * parent->getDeltaTime();// seconds
-      if (dt_sec * lParams.noiseFreqE  > 1.0) lParams.noiseFreqE  = 1.0/dt_sec;
+      float dt_sec = 0.001f * (float)parent->getDeltaTime();// seconds
+      if (dt_sec * lParams.noiseFreqE  > 1.0f) {
+         lParams.noiseFreqE  = 1.0f / dt_sec;
+      }
    }
 }
 
 void LIF::ioParam_noiseFreqI(enum ParamsIOFlag ioFlag) {
    parent->ioParamValue(ioFlag, name, "noiseFreqI", &lParams.noiseFreqI, 250.0f);
    if (ioFlag==PARAMS_IO_READ) {
-      float dt_sec = .001 * parent->getDeltaTime();// seconds
-      if (dt_sec * lParams.noiseFreqI  > 1.0) lParams.noiseFreqI  = 1.0/dt_sec;
+      float dt_sec = 0.001f * (float)parent->getDeltaTime();// seconds
+      if (dt_sec * lParams.noiseFreqI  > 1.0f) {
+         lParams.noiseFreqI  = 1.0f / dt_sec;
+      }
    }
 }
 
 void LIF::ioParam_noiseFreqIB(enum ParamsIOFlag ioFlag) {
    parent->ioParamValue(ioFlag, name, "noiseFreqIB", &lParams.noiseFreqIB, 250.0f);
    if (ioFlag==PARAMS_IO_READ) {
-      float dt_sec = .001 * parent->getDeltaTime();// seconds
-      if (dt_sec * lParams.noiseFreqIB > 1.0) lParams.noiseFreqIB = 1.0/dt_sec;
+      float dt_sec = 0.001f * (float)parent->getDeltaTime();// seconds
+      if (dt_sec * lParams.noiseFreqIB > 1.0f) {
+         lParams.noiseFreqIB = 1.0f / dt_sec;
+      }
    }
 }
 
@@ -220,7 +226,9 @@ void LIF::ioParam_method(enum ParamsIOFlag ioFlag) {
    // Read the integration method: one of 'arma' (preferred), 'beginning' (deprecated), or 'original' (deprecated).
    const char * default_method = "arma";
    parent->ioParamString(ioFlag, name, "method", &methodString, default_method, true/*warnIfAbsent*/);
-   if (ioFlag != PARAMS_IO_READ) return;
+   if (ioFlag != PARAMS_IO_READ) {
+      return;
+   }
 
    assert(methodString);
    if (methodString[0] == '\0') {
@@ -470,7 +478,7 @@ float LIF_Vmem_derivative(
       const float V_IB,
       const float Vrest,
       const float tau) {
-   float totalconductance = 1.0 + G_E + G_I + G_IB;
+   float totalconductance = 1.0f + G_E + G_I + G_IB;
    float Vmeminf = (Vrest + V_E*G_E + V_I*G_I + V_IB*G_IB)/totalconductance;
    return totalconductance*(Vmeminf-Vmem)/tau;
 }
@@ -514,7 +522,7 @@ void LIF_update_state_original(
    const float exp_tauIB   = expf(-dt/params->tauIB);
    const float exp_tauVth  = expf(-dt/params->tauVth);
 
-   const float dt_sec = .001 * dt;   // convert to seconds
+   const float dt_sec = 0.001f * dt;   // convert to seconds
 
 
    for (k = 0; k < nx*ny*nf*nbatch; k++) {
@@ -527,7 +535,7 @@ void LIF_update_state_original(
       // local param variables
       float tau, Vrest, VthRest, Vexc, Vinh, VinhB, deltaVth, deltaGIB;
 
-      const float GMAX = 10.0;
+      const float GMAX = 10.0f;
 
       // local variables
       float l_activ;
@@ -596,9 +604,9 @@ void LIF_update_state_original(
       l_G_I  = (l_G_I  > GMAX) ? GMAX : l_G_I;
       l_G_IB = (l_G_IB > GMAX) ? GMAX : l_G_IB;
 
-      tauInf  = (dt/tau) * (1.0 + l_G_E + l_G_I + l_G_IB);
+      tauInf  = (dt/tau) * (1.0f + l_G_E + l_G_I + l_G_IB);
       VmemInf = (Vrest + l_G_E*Vexc + l_G_I*Vinh + l_G_IB*VinhB)
-              / (1.0 + l_G_E + l_G_I + l_G_IB);
+              / (1.0f + l_G_E + l_G_I + l_G_IB);
 
       l_V = VmemInf + (l_V - VmemInf)*expf(-tauInf);
 
@@ -679,7 +687,7 @@ void LIF_update_state_beginning(
    const float exp_tauIB   = expf(-dt/params->tauIB);
    const float exp_tauVth  = expf(-dt/params->tauVth);
 
-   const float dt_sec = .001 * dt;   // convert to seconds
+   const float dt_sec = 0.001f * dt;   // convert to seconds
 
 
    for (k = 0; k < nx*ny*nf*nbatch; k++) {
@@ -693,7 +701,7 @@ void LIF_update_state_beginning(
       // local param variables
       float tau, Vrest, VthRest, Vexc, Vinh, VinhB, deltaVth, deltaGIB;
 
-      const float GMAX = 10.0;
+      const float GMAX = 10.0f;
 
       // local variables
       float l_activ;
@@ -771,7 +779,7 @@ void LIF_update_state_beginning(
 
       dV1 = LIF_Vmem_derivative(l_V, G_E_initial, G_I_initial, G_IB_initial, Vexc, Vinh, VinhB, Vrest, tau);
       dV2 = LIF_Vmem_derivative(l_V+dt*dV1, G_E_final, G_I_final, G_IB_final, Vexc, Vinh, VinhB, Vrest, tau);
-      dV = (dV1+dV2)*0.5;
+      dV = (dV1+dV2)*0.5f;
       l_V = l_V + dt*dV;
 
       l_G_E = G_E_final;
@@ -845,7 +853,7 @@ void LIF_update_state_arma(
    const float exp_tauIB   = expf(-dt/params->tauIB);
    const float exp_tauVth  = expf(-dt/params->tauVth);
 
-   const float dt_sec = .001 * dt;   // convert to seconds
+   const float dt_sec = 0.001f * dt;   // convert to seconds
 
 
    for (k = 0; k < nx*ny*nf*nbatch; k++) {

--- a/src/layers/LIFGap.cpp
+++ b/src/layers/LIFGap.cpp
@@ -275,7 +275,7 @@ float LIFGap_Vmem_derivative(
       const pvgsyndata_t sum_gap,
       const float Vrest,
       const float tau) {
-   float totalconductance = 1.0 + G_E + G_I + G_IB + sum_gap;
+   float totalconductance = 1.0f + G_E + G_I + G_IB + sum_gap;
    float Vmeminf = (Vrest + V_E*G_E + V_I*G_I + V_IB*G_IB + G_Gap)/totalconductance;
    return totalconductance*(Vmeminf-Vmem)/tau;
 }
@@ -323,7 +323,7 @@ void LIFGap_update_state_original(
    const float exp_tauIB   = expf(-dt/params->tauIB);
    const float exp_tauVth  = expf(-dt/params->tauVth);
 
-   const float dt_sec = .001 * dt;   // convert to seconds
+   const float dt_sec = 0.001f * dt;   // convert to seconds
 
 
 for (k = 0; k < nx*ny*nf*nbatch; k++) {
@@ -391,7 +391,7 @@ for (k = 0; k < nx*ny*nf*nbatch; k++) {
       l_GSynInhB = l_GSynInhB + params->noiseAmpIB*cl_random_prob(l_rnd);
    }
 
-   const float GMAX = 10.0;
+   const float GMAX = 10.0f;
    float tauInf, VmemInf;
 
 
@@ -406,9 +406,9 @@ for (k = 0; k < nx*ny*nf*nbatch; k++) {
 
    // l_G_Gap = l_GSynGap;
 
-   tauInf  = (dt/tau) * (1.0 + l_G_E + l_G_I + l_G_IB + l_gapStrength);
+   tauInf  = (dt/tau) * (1.0f + l_G_E + l_G_I + l_G_IB + l_gapStrength);
    VmemInf = (Vrest + l_G_E*Vexc + l_G_I*Vinh + l_G_IB*VinhB + l_GSynGap)
-           / (1.0 + l_G_E + l_G_I + l_G_IB + l_gapStrength);
+           / (1.0f + l_G_E + l_G_I + l_G_IB + l_gapStrength);
 
    l_V = VmemInf + (l_V - VmemInf)*expf(-tauInf);
 
@@ -485,7 +485,7 @@ void LIFGap_update_state_beginning(
    const float exp_tauIB   = expf(-dt/params->tauIB);
    const float exp_tauVth  = expf(-dt/params->tauVth);
 
-   const float dt_sec = .001 * dt;   // convert to seconds
+   const float dt_sec = 0.001f * dt;   // convert to seconds
 
 for (k = 0; k < nx*ny*nf*nbatch; k++) {
    int kex = kIndexExtendedBatch(k, nbatch, nx, ny, nf, lt, rt, dn, up);
@@ -556,7 +556,7 @@ for (k = 0; k < nx*ny*nf*nbatch; k++) {
       l_GSynInhB = l_GSynInhB + params->noiseAmpIB*cl_random_prob(l_rnd);
    }
 
-   const float GMAX = 10.0;
+   const float GMAX = 10.0f;
 
    // The portion of code below uses the newer method of calculating l_V.
    float G_E_initial, G_I_initial, G_IB_initial, G_E_final, G_I_final, G_IB_final;
@@ -578,7 +578,7 @@ for (k = 0; k < nx*ny*nf*nbatch; k++) {
 
    dV1 = LIFGap_Vmem_derivative(l_V, G_E_initial, G_I_initial, G_IB_initial, l_GSynGap, Vexc, Vinh, VinhB, l_gapStrength, Vrest, tau);
    dV2 = LIFGap_Vmem_derivative(l_V+dt*dV1, G_E_final, G_I_final, G_IB_final, l_GSynGap, Vexc, Vinh, VinhB, l_gapStrength, Vrest, tau);
-   dV = (dV1+dV2)*0.5;
+   dV = (dV1+dV2)*0.5f;
    l_V = l_V + dt*dV;
    
    l_G_E = G_E_final;
@@ -654,7 +654,7 @@ void LIFGap_update_state_arma(
    const float exp_tauIB   = expf(-dt/params->tauIB);
    const float exp_tauVth  = expf(-dt/params->tauVth);
 
-   const float dt_sec = .001 * dt;   // convert to seconds
+   const float dt_sec = 0.001f * dt;   // convert to seconds
 
 
    for (k = 0; k < nx*ny*nf*nbatch; k++) {
@@ -667,7 +667,7 @@ void LIFGap_update_state_arma(
       // local param variables
       float tau, Vrest, VthRest, Vexc, Vinh, VinhB, deltaVth, deltaGIB;
 
-      const float GMAX = 10.0;
+      const float GMAX = 10.0f;
 
       // local variables
       float l_activ;
@@ -738,8 +738,8 @@ void LIFGap_update_state_arma(
       G_I_initial = l_G_I + l_GSynInh;
       G_IB_initial = l_G_IB + l_GSynInhB;
       // l_G_Gap = l_GSynGap;
-      tau_inf_initial = tau/(1+G_E_initial+G_I_initial+G_IB_initial+l_gapStrength);
-      V_inf_initial = (Vrest+Vexc*G_E_initial+Vinh*G_I_initial+VinhB*G_IB_initial+l_GSynGap)/(1+G_E_initial+G_I_initial+G_IB_initial+l_gapStrength);
+      tau_inf_initial = tau/(1.0f+G_E_initial+G_I_initial+G_IB_initial+l_gapStrength);
+      V_inf_initial = (Vrest+Vexc*G_E_initial+Vinh*G_I_initial+VinhB*G_IB_initial+l_GSynGap)/(1.0f+G_E_initial+G_I_initial+G_IB_initial+l_gapStrength);
 
       G_E_initial  = (G_E_initial  > GMAX) ? GMAX : G_E_initial;
       G_I_initial  = (G_I_initial  > GMAX) ? GMAX : G_I_initial;
@@ -748,8 +748,8 @@ void LIFGap_update_state_arma(
       G_E_final = G_E_initial*exp_tauE;
       G_I_final = G_I_initial*exp_tauI;
       G_IB_final = G_IB_initial*exp_tauIB;
-      tau_inf_final = tau/(1+G_E_final+G_I_final+G_IB_final+l_gapStrength);
-      V_inf_final = (Vrest+Vexc*G_E_final+Vinh*G_I_final+VinhB*G_IB_final+l_GSynGap)/(1+G_E_final+G_I_final+G_IB_final+l_gapStrength);
+      tau_inf_final = tau/(1.0f+G_E_final+G_I_final+G_IB_final+l_gapStrength);
+      V_inf_final = (Vrest+Vexc*G_E_final+Vinh*G_I_final+VinhB*G_IB_final+l_GSynGap)/(1.0f+G_E_final+G_I_final+G_IB_final+l_gapStrength);
 
       float tau_slope = (tau_inf_final-tau_inf_initial)/dt;
       float f1 = tau_slope==0.0f ? expf(-dt/tau_inf_initial) : powf(tau_inf_final/tau_inf_initial, -1/tau_slope);

--- a/src/layers/LeakyIntegrator.cpp
+++ b/src/layers/LeakyIntegrator.cpp
@@ -44,7 +44,7 @@ void LeakyIntegrator::ioParam_integrationTime(enum ParamsIOFlag ioFlag) {
 int LeakyIntegrator::updateState(double timed, double dt) {
    pvdata_t * V = getV();
    pvdata_t * gSyn = GSyn[0];
-   pvdata_t decayfactor = (pvdata_t) exp(-dt/integrationTime);
+   pvdata_t decayfactor = expf((float)-dt/integrationTime);
    for (int k=0; k<getNumNeuronsAllBatches(); k++) {
       V[k] *= decayfactor;
       V[k] += gSyn[k];

--- a/src/layers/MomentumLCALayer.cpp
+++ b/src/layers/MomentumLCALayer.cpp
@@ -135,7 +135,7 @@ int MomentumLCALayer::allocateUpdateKernel(){
    const float AShift = this->AShift;
    const float VWidth = this->VWidth;
    const bool selfInteract = this->selfInteract;
-   const float tau = timeConstantTau/parent->getDeltaTime(); // TODO: eliminate need to call parent method
+   const float tau = timeConstantTau/(float)parent->getDeltaTime(); // TODO: eliminate need to call parent method
    PVCuda::CudaBuffer* d_GSyn = getDeviceGSyn();
    PVCuda::CudaBuffer* d_activity = getDeviceActivity();
 
@@ -215,7 +215,7 @@ int MomentumLCALayer::updateState(double time, double dt)
    
    MomentumLCALayer_update_state(nbatch, num_neurons, nx, ny, nf, loc->halo.lt, loc->halo.rt, loc->halo.dn, loc->halo.up, numChannels,
          V, numVertices, verticesV, verticesA, slopes,
-         selfInteract, deltaTimes(), timeConstantTau/dt, LCAMomentumRate, gSynHead, A, prevDrive);
+         selfInteract, deltaTimes(), timeConstantTau/(float)dt, LCAMomentumRate, gSynHead, A, prevDrive);
    return PV_SUCCESS;
 }
 

--- a/src/layers/PtwiseLinearTransferLayer.cpp
+++ b/src/layers/PtwiseLinearTransferLayer.cpp
@@ -159,7 +159,7 @@ int PtwiseLinearTransferLayer::checkVertices() {
          status = PV_FAILURE;
          if (this->getParent()->columnId()==0) {
             pvErrorNoExit().printf("%s: vertices %d and %d: V-coordinates decrease from %f to %f.\n",
-                  getDescription_c(), v, v+1, verticesV[v-1], verticesV[v]);
+                  getDescription_c(), v, v+1, (double)verticesV[v-1], (double)verticesV[v]);
          }
       }
    }

--- a/src/layers/RescaleLayer.cpp
+++ b/src/layers/RescaleLayer.cpp
@@ -226,10 +226,10 @@ int RescaleLayer::updateState(double timef, double dt) {
           }
 
           MPI_Allreduce(MPI_IN_PLACE, &sumsq, 1, MPI_FLOAT, MPI_SUM, parent->getCommunicator()->communicator());
-          float std = sqrt(sumsq / originalLayer->getNumGlobalNeurons());
+          float std = sqrtf(sumsq / originalLayer->getNumGlobalNeurons());
           // The difference between the if and the else clauses is only in the computation of A[kext], but this
           // way the std != 0.0 conditional is only evaluated once, not every time through the for-loop.
-          if (std != 0.0) {
+          if (std != 0.0f) {
 #ifdef PV_USE_OPENMP_THREADS
 #pragma omp parallel for
 #endif
@@ -280,10 +280,10 @@ int RescaleLayer::updateState(double timef, double dt) {
           }
 
           MPI_Allreduce(MPI_IN_PLACE, &sumsq, 1, MPI_FLOAT, MPI_SUM, parent->getCommunicator()->communicator());
-          float std = sqrt(sumsq / originalLayer->getNumGlobalNeurons());
+          float std = sqrtf(sumsq / originalLayer->getNumGlobalNeurons());
           // The difference between the if and the else clauses is only in the computation of A[kext], but this
           // way the std != 0.0 conditional is only evaluated once, not every time through the for-loop.
-          if (std != 0.0) {
+          if (std != 0.0f) {
 #ifdef PV_USE_OPENMP_THREADS
 #pragma omp parallel for
 #endif
@@ -291,7 +291,7 @@ int RescaleLayer::updateState(double timef, double dt) {
                 int kext = kIndexExtended(k, loc->nx, loc->ny, loc->nf, loc->halo.lt, loc->halo.rt, loc->halo.up, loc->halo.dn);
                 int kextOriginal = kIndexExtended(k, locOriginal->nx, locOriginal->ny, locOriginal->nf,
                       locOriginal->halo.lt, locOriginal->halo.rt, locOriginal->halo.dn, locOriginal->halo.up);
-                ABatch[kext] = ((originalABatch[kextOriginal] - mean) * (1/(std * sqrt((float)patchSize))));
+                ABatch[kext] = ((originalABatch[kextOriginal] - mean) * (1.0f/(std * sqrtf((float)patchSize))));
              }
           }
           else {
@@ -325,7 +325,7 @@ int RescaleLayer::updateState(double timef, double dt) {
           float std = sqrt(sumsq / originalLayer->getNumGlobalNeurons());
           // The difference between the if and the else clauses is only in the computation of A[kext], but this
           // way the std != 0.0 conditional is only evaluated once, not every time through the for-loop.
-          if (std != 0.0) {
+          if (std != 0.0f) {
 #ifdef PV_USE_OPENMP_THREADS
 #pragma omp parallel for
 #endif
@@ -333,7 +333,7 @@ int RescaleLayer::updateState(double timef, double dt) {
                 int kext = kIndexExtended(k, loc->nx, loc->ny, loc->nf, loc->halo.lt, loc->halo.rt, loc->halo.up, loc->halo.dn);
                 int kextOriginal = kIndexExtended(k, locOriginal->nx, locOriginal->ny, locOriginal->nf,
                       locOriginal->halo.lt, locOriginal->halo.rt, locOriginal->halo.dn, locOriginal->halo.up);
-                ABatch[kext] = ((originalABatch[kextOriginal]) * (1/(std * sqrt((float)patchSize))));
+                ABatch[kext] = ((originalABatch[kextOriginal]) * (1.0f/(std * sqrtf((float)patchSize))));
              }
           }
           else {
@@ -368,7 +368,7 @@ int RescaleLayer::updateState(double timef, double dt) {
                    int kext = kIndex(iX, iY, iF, nx+haloOrig->lt+haloOrig->rt, ny+haloOrig->dn+haloOrig->up, nf);
                    sumsq += (originalABatch[kext]) * (originalABatch[kext]);
                 }
-                float divisor = sqrt(sumsq);
+                float divisor = sqrtf(sumsq);
                 // Difference in the if-part and else-part is only in the value assigned to A[kext], but this way the std != 0
                 // conditional does not have to be reevaluated every time through the for loop.
                 // can't pragma omp parallel the for loops because it was already parallelized in the outermost for-loop
@@ -414,7 +414,7 @@ int RescaleLayer::updateState(double timef, double dt) {
                    int kext = kIndex(iX, iY, iF, nx+haloOrig->lt+haloOrig->rt, ny+haloOrig->dn+haloOrig->up, nf);
                    sumsq += (originalABatch[kext] - mean) * (originalABatch[kext] - mean);
                 }
-                float std = sqrt(sumsq/nf);
+                float std = sqrtf(sumsq/nf);
                 // Difference in the if-part and else-part is only in the value assigned to A[kext], but this way the std != 0
                 // conditional does not have to be reevaluated every time through the for loop.
                 // can't pragma omp parallel the for loops because it was already parallelized in the outermost for-loop
@@ -451,7 +451,7 @@ int RescaleLayer::updateState(double timef, double dt) {
                 float sumexpx = 0;
                 for(int iF = 0; iF < nf; iF++){
                    int kextOrig = kIndex(iX, iY, iF, nx+haloOrig->lt+haloOrig->rt, ny+haloOrig->dn+haloOrig->up, nf);
-                   sumexpx += exp(originalABatch[kextOrig]);
+                   sumexpx += expf(originalABatch[kextOrig]);
                 }
                 //Error checking for sumexpx = 0
                 assert(sumexpx != 0);
@@ -459,7 +459,7 @@ int RescaleLayer::updateState(double timef, double dt) {
                 for(int iF = 0; iF < nf; iF++){
                    int kextOrig = kIndex(iX, iY, iF, nx+haloOrig->lt+haloOrig->rt, ny+haloOrig->dn+haloOrig->up, nf);
                    int kext = kIndex(iX, iY, iF, nx+halo->lt+halo->rt, ny+halo->dn+halo->up, nf);
-                   ABatch[kext] = exp(originalABatch[kextOrig])/sumexpx;
+                   ABatch[kext] = expf(originalABatch[kextOrig])/sumexpx;
                    //if(ABatch[kext] < 0 || ABatch[kext] > 1){
                    //   pvInfo() << "ABatch[" << kext << "] = " << ABatch[kext] << " : " << originalABatch[kextOrig] << " - " << mean << " / " << sumexpx << "\n";
                    //   pvInfo() << std::flush;
@@ -482,7 +482,7 @@ int RescaleLayer::updateState(double timef, double dt) {
              int kext = kIndexExtended(k, loc->nx, loc->ny, loc->nf, loc->halo.lt, loc->halo.rt, loc->halo.up, loc->halo.dn);
              int kextOriginal = kIndexExtended(k, locOriginal->nx, locOriginal->ny, locOriginal->nf,
                    locOriginal->halo.lt, locOriginal->halo.rt, locOriginal->halo.dn, locOriginal->halo.up);
-             ABatch[kext] = (float)1/(1+exp(originalABatch[kextOriginal]));
+             ABatch[kext] = 1.0f/(1.0f+expf(originalABatch[kextOriginal]));
           }
        }
        else if(strcmp(rescaleMethod, "zerotonegative") == 0){

--- a/src/layers/Retina.cpp
+++ b/src/layers/Retina.cpp
@@ -258,12 +258,15 @@ int Retina::setRetinaParams(PVParams * p)
 {
    clayer->params = &rParams;
 
-   double dt_sec = parent->getDeltaTime() * .001;  // seconds
+   float dt_sec = (float)parent->getDeltaTime() * 0.001f;  // seconds
    float probStim = probStimParam * dt_sec;
-   if (probStim > 1.0) probStim = 1.0f;
+   if (probStim > 1.0f) {
+      probStim = 1.0f;
+   }
    float probBase = probBaseParam * dt_sec;
-   if (probBase > 1.0) probBase = 1.0f;
-
+   if (probBase > 1.0f) {
+      probBase = 1.0f;
+   }
    maxRate = probStim/dt_sec;
 
    // default parameters
@@ -417,10 +420,10 @@ static inline
 float calcBurstStatus(double timed, Retina_params * params) {
    float burstStatus;
    if (params->burstDuration <= 0 || params->burstFreq == 0) {
-      burstStatus = cosf( 2*PI*timed * params->burstFreq / 1000. );
+      burstStatus = cosf(2.0f * (float)(PI * timed) * params->burstFreq / 1000.0f );
    }
    else {
-      burstStatus = fmod(timed, 1000. / params->burstFreq);
+      burstStatus = fmodf((float)timed, 1000.0f / params->burstFreq);
       burstStatus = burstStatus < params->burstDuration;
    }
    burstStatus *= (int) ( (timed >= params->beginStim) && (timed < params->endStim) );
@@ -509,8 +512,8 @@ void Retina_spiking_update_state (
          float l_phiInh = phiInhBatch[k];
          float l_prev   = prevTimeBatch[kex];
          float l_activ;
-         l_activ = (float) spike(timed, dt, l_prev, (l_phiExc - l_phiInh), &l_rnd, burst_status, params);
-         l_prev  = (l_activ > 0.0f) ? timed : l_prev;
+         l_activ = (float) spike((float)timed, (float)dt, l_prev, (l_phiExc - l_phiInh), &l_rnd, burst_status, params);
+         l_prev  = (l_activ > 0.0f) ? (float)timed : l_prev;
          //l_phiExc = 0.0f;
          //l_phiInh = 0.0f;
          // store local variables back to global memory

--- a/src/layers/Retina.cpp
+++ b/src/layers/Retina.cpp
@@ -420,7 +420,7 @@ static inline
 float calcBurstStatus(double timed, Retina_params * params) {
    float burstStatus;
    if (params->burstDuration <= 0 || params->burstFreq == 0) {
-      burstStatus = cosf(2.0f * (float)(PI * timed) * params->burstFreq / 1000.0f );
+      burstStatus = cosf(2.0f * PI * (float)timed * params->burstFreq / 1000.0f );
    }
    else {
       burstStatus = fmodf((float)timed, 1000.0f / params->burstFreq);

--- a/src/layers/RunningAverageLayer.cpp
+++ b/src/layers/RunningAverageLayer.cpp
@@ -80,7 +80,6 @@ int RunningAverageLayer::setActivity() {
 int RunningAverageLayer::updateState(double timef, double dt) {
    numUpdateTimes++;
    int status = PV_SUCCESS;
-   double deltaT = parent->getDeltaTime();
    //Check if an update is needed
    //Done in cloneVLayer
     int numNeurons = originalLayer->getNumNeurons();
@@ -98,7 +97,7 @@ int RunningAverageLayer::updateState(double timef, double dt) {
     for(int b = 0; b < nbatch; b++){
        const pvdata_t * originalABatch = originalA + b * originalLayer->getNumExtended();
        pvdata_t * ABatch = A + b * getNumExtended();
-       if (numUpdateTimes < numImagesToAverage*deltaT){
+       if (numUpdateTimes < numImagesToAverage * dt){
 #ifdef PV_USE_OPENMP_THREADS
 #pragma omp parallel for
 #endif // PV_USE_OPENMP_THREADS
@@ -106,7 +105,7 @@ int RunningAverageLayer::updateState(double timef, double dt) {
                 int kExt = kIndexExtended(k, loc->nx, loc->ny, loc->nf, loc->halo.lt, loc->halo.rt, loc->halo.dn, loc->halo.up);
                 int kExtOriginal = kIndexExtended(k, locOriginal->nx, locOriginal->ny, locOriginal->nf,
                       locOriginal->halo.lt, loc->halo.rt, loc->halo.dn, loc->halo.up);
-                ABatch[kExt] = ((numUpdateTimes/deltaT-1) * ABatch[kExt] + originalABatch[kExtOriginal]) * deltaT / numUpdateTimes;
+                ABatch[kExt] = ((numUpdateTimes / (float)dt - 1) * ABatch[kExt] + originalABatch[kExtOriginal]) * (float)dt / numUpdateTimes;
              }
        }
        else{

--- a/src/layers/WTALayer.cpp
+++ b/src/layers/WTALayer.cpp
@@ -106,7 +106,7 @@ void WTALayer::ioParam_binMaxMin(enum ParamsIOFlag ioFlag) {
    if(ioFlag == PARAMS_IO_READ && binMax <= binMin){
       if (parent->columnId()==0) {
          pvErrorNoExit().printf("%s: binMax (%f) must be greater than binMin (%f).\n",
-            getDescription_c(), binMax, binMin);
+            getDescription_c(), (double)binMax, (double)binMin);
       }
       MPI_Barrier(parent->getCommunicator()->communicator());
       exit(EXIT_FAILURE);

--- a/src/layers/updateStateFunctions.h
+++ b/src/layers/updateStateFunctions.h
@@ -360,13 +360,13 @@ int applyGSyn_HyPerLCALayer(int nbatch, int numNeurons,
    {
       int b = kbatch / numNeurons;
       int k = kbatch % numNeurons;
-      float exp_tau = expf((float)-dtAdapt[b]/tau);
+      float exp_tau = (float)exp(-dtAdapt[b]/(double)tau);
       MEM_GLOBAL pvdata_t* VBatch = V + b*numNeurons;
       MEM_GLOBAL pvdata_t* GSynErrorBatch = GSynError + b*numNeurons;
       //Activity extended
       MEM_GLOBAL pvdata_t* activityBatch = activity + b*(nx+rt+lt)*(ny+up+dn)*nf;
       int kex = kIndexExtended(k, nx, ny, nf, lt, rt, dn, up);
-         VBatch[k] = exp_tau * VBatch[k] + (1.0f - exp_tau) * (GSynErrorBatch[k] + selfInteract * activityBatch[kex]);
+      VBatch[k] = exp_tau * VBatch[k] + (1.0f - exp_tau) * (GSynErrorBatch[k] + selfInteract * activityBatch[kex]);
    }
    return PV_SUCCESS;
 }
@@ -377,8 +377,8 @@ int applyGSyn_HyPerLCALayer2(int nbatch, int numNeurons,
       MEM_GLOBAL pvdata_t * activity, double* dtAdapt, pvdata_t tau, pvdata_t selfInteract, 
       int nx, int ny, int nf, int lt, int rt, int dn, int up) {
    int kbatch;
-   MEM_GLOBAL pvdata_t * GSynError = &GSynHead[CHANNEL_EXC * nbatch * numNeurons]; // weighted input
-   MEM_GLOBAL pvdata_t * GSynError2 = &GSynHead[CHANNEL_INH * nbatch * numNeurons]; // weighted input
+   MEM_GLOBAL pvdata_t * GSynError = &GSynHead[0 * nbatch * numNeurons]; // weighted input
+   MEM_GLOBAL pvdata_t * GSynError2 = &GSynHead[1 * nbatch * numNeurons]; // weighted input
 
 #ifndef PV_USE_CUDA
    #ifdef PV_USE_OPENMP_THREADS
@@ -392,7 +392,7 @@ int applyGSyn_HyPerLCALayer2(int nbatch, int numNeurons,
       int b = kbatch / numNeurons;
       int k = kbatch % numNeurons;
 
-      float exp_tau = expf((float)-dtAdapt[b]/tau);
+      float exp_tau = (float)exp(-dtAdapt[b]/(double)tau);
       MEM_GLOBAL pvdata_t* VBatch = V + b*numNeurons;
       MEM_GLOBAL pvdata_t* GSynErrorBatch = GSynError + b*numNeurons;
       MEM_GLOBAL pvdata_t* GSynError2Batch = GSynError2 + b*numNeurons;
@@ -400,7 +400,7 @@ int applyGSyn_HyPerLCALayer2(int nbatch, int numNeurons,
       MEM_GLOBAL pvdata_t* activityBatch = activity + b*(nx+rt+lt)*(ny+up+dn)*nf;
 
       int kex = kIndexExtended(k, nx, ny, nf, lt, rt, dn, up);
-         VBatch[k] = exp_tau * VBatch[k] + (1.0f - exp_tau) * (GSynErrorBatch[k] - GSynError2Batch[k] + selfInteract * activityBatch[kex]);
+      VBatch[k] = exp_tau * VBatch[k] + (1.0f - exp_tau) * (GSynErrorBatch[k] - GSynError2Batch[k] + selfInteract * activityBatch[kex]);
    }
    return PV_SUCCESS;
 }

--- a/src/normalizers/NormalizeBase.cpp
+++ b/src/normalizers/NormalizeBase.cpp
@@ -113,7 +113,7 @@ int NormalizeBase::normalizeWeights() {
    return status;
 }
 
-int NormalizeBase::accumulateSum(pvwdata_t * dataPatchStart, int weights_in_patch, double * sum) {
+int NormalizeBase::accumulateSum(pvwdata_t * dataPatchStart, int weights_in_patch, float * sum) {
    // Do not call with sum uninitialized.
    // sum, sumsq, max are not cleared inside this routine so that you can accumulate the stats over several patches with multiple calls
    for (int k=0; k<weights_in_patch; k++) {
@@ -124,7 +124,7 @@ int NormalizeBase::accumulateSum(pvwdata_t * dataPatchStart, int weights_in_patc
    return PV_SUCCESS;
 }
 
-int NormalizeBase::accumulateSumShrunken(pvwdata_t * dataPatchStart, double * sum,
+int NormalizeBase::accumulateSumShrunken(pvwdata_t * dataPatchStart, float * sum,
 		int nxpShrunken, int nypShrunken, int offsetShrunken, int xPatchStride, int yPatchStride) {
    // Do not call with sumsq uninitialized.
    // sum, sumsq, max are not cleared inside this routine so that you can accumulate the stats over several patches with multiple calls
@@ -140,7 +140,7 @@ int NormalizeBase::accumulateSumShrunken(pvwdata_t * dataPatchStart, double * su
    return PV_SUCCESS;
 }
 
-int NormalizeBase::accumulateSumSquared(pvwdata_t * dataPatchStart, int weights_in_patch, double * sumsq) {
+int NormalizeBase::accumulateSumSquared(pvwdata_t * dataPatchStart, int weights_in_patch, float * sumsq) {
    // Do not call with sumsq uninitialized.
    // sum, sumsq, max are not cleared inside this routine so that you can accumulate the stats over several patches with multiple calls
    for (int k=0; k<weights_in_patch; k++) {
@@ -150,7 +150,7 @@ int NormalizeBase::accumulateSumSquared(pvwdata_t * dataPatchStart, int weights_
    return PV_SUCCESS;
 }
 
-int NormalizeBase::accumulateSumSquaredShrunken(pvwdata_t * dataPatchStart, double * sumsq,
+int NormalizeBase::accumulateSumSquaredShrunken(pvwdata_t * dataPatchStart, float * sumsq,
 		int nxpShrunken, int nypShrunken, int offsetShrunken, int xPatchStride, int yPatchStride) {
    // Do not call with sumsq uninitialized.
    // sum, sumsq, max are not cleared inside this routine so that you can accumulate the stats over several patches with multiple calls

--- a/src/normalizers/NormalizeBase.hpp
+++ b/src/normalizers/NormalizeBase.hpp
@@ -60,11 +60,11 @@ protected:
    virtual void ioParam_normalizeOnWeightUpdate(enum ParamsIOFlag ioFlag);
 
    virtual int normalizeWeights();
-   int accumulateSum(pvwdata_t * dataPatchStart, int weights_in_patch, double * sum);
-   int accumulateSumShrunken(pvwdata_t * dataPatchStart, double * sum,
+   int accumulateSum(pvwdata_t * dataPatchStart, int weights_in_patch, float * sum);
+   int accumulateSumShrunken(pvwdata_t * dataPatchStart, float * sum,
    		int nxpShrunken, int nypShrunken, int offsetShrunken, int xPatchStride, int yPatchStride);
-   int accumulateSumSquared(pvwdata_t * dataPatchStart, int weights_in_patch, double * sumsq);
-   int accumulateSumSquaredShrunken(pvwdata_t * dataPatchStart, double * sumsq,
+   int accumulateSumSquared(pvwdata_t * dataPatchStart, int weights_in_patch, float * sumsq);
+   int accumulateSumSquaredShrunken(pvwdata_t * dataPatchStart, float * sumsq,
    		int nxpShrunken, int nypShrunken, int offsetShrunken, int xPatchStride, int yPatchStride);
    int accumulateMaxAbs(pvwdata_t * dataPatchStart, int weights_in_patch, float * max);
    int accumulateMax(pvwdata_t * dataPatchStart, int weights_in_patch, float * max);

--- a/src/normalizers/NormalizeContrastZeroMean.hpp
+++ b/src/normalizers/NormalizeContrastZeroMean.hpp
@@ -29,7 +29,7 @@ protected:
    virtual void ioParam_normalizeFromPostPerspective(enum ParamsIOFlag ioFlag);
 
    static void subtractOffsetAndNormalize(pvwdata_t * dataStartPatch, int weights_per_patch, float offset, float normalizer);
-   int accumulateSumAndSumSquared(pvwdata_t * dataPatchStart, int weights_in_patch, double * sum, double * sumsq);
+   int accumulateSumAndSumSquared(pvwdata_t * dataPatchStart, int weights_in_patch, float * sum, float * sumsq);
 
 private:
    int initialize_base();

--- a/src/normalizers/NormalizeL2.cpp
+++ b/src/normalizers/NormalizeL2.cpp
@@ -70,7 +70,7 @@ int NormalizeL2::normalizeWeights() {
                pvwdata_t * dataStartPatch = conn->get_wDataHead(arborID, patchindex);
                accumulateSumSquared(dataStartPatch, weights_per_patch, &sumsq);
             }
-            double l2norm = sqrtf(sumsq);
+            float l2norm = sqrtf(sumsq);
             if (fabsf(l2norm) <= minL2NormTolerated) {
                pvWarn().printf("for NormalizeL2 \"%s\": sum of squares of weights in patch %d of arbor %d is within minL2NormTolerated=%f of zero.  Weights in this patch unchanged.\n",
                      getName(), patchindex, arborID, (double)minL2NormTolerated);

--- a/src/normalizers/NormalizeL2.cpp
+++ b/src/normalizers/NormalizeL2.cpp
@@ -60,7 +60,7 @@ int NormalizeL2::normalizeWeights() {
    if (normalizeArborsIndividually) {
       for (int arborID = 0; arborID<nArbors; arborID++) {
          for (int patchindex = 0; patchindex<numDataPatches; patchindex++) {
-            double sumsq = 0.0;
+            float sumsq = 0.0f;
             for (int c=0; c<numConnections; c++) {
                HyPerConn * conn = connectionList[c];
                int nxp = conn->xPatchSize();
@@ -70,10 +70,11 @@ int NormalizeL2::normalizeWeights() {
                pvwdata_t * dataStartPatch = conn->get_wDataHead(arborID, patchindex);
                accumulateSumSquared(dataStartPatch, weights_per_patch, &sumsq);
             }
-            double l2norm = sqrt(sumsq);
-            if (fabs(l2norm) <= minL2NormTolerated) {
-               pvWarn().printf("for NormalizeL2 \"%s\": sum of squares of weights in patch %d of arbor %d is within minL2NormTolerated=%f of zero.  Weights in this patch unchanged.\n", getName(), patchindex, arborID, minL2NormTolerated);
-               break;
+            double l2norm = sqrtf(sumsq);
+            if (fabsf(l2norm) <= minL2NormTolerated) {
+               pvWarn().printf("for NormalizeL2 \"%s\": sum of squares of weights in patch %d of arbor %d is within minL2NormTolerated=%f of zero.  Weights in this patch unchanged.\n",
+                     getName(), patchindex, arborID, (double)minL2NormTolerated);
+               continue;
             }
             for (int c=0; c<numConnections; c++) {
                HyPerConn * conn = connectionList[c];
@@ -89,7 +90,7 @@ int NormalizeL2::normalizeWeights() {
    }
    else {
       for (int patchindex = 0; patchindex<numDataPatches; patchindex++) {
-         double sumsq = 0.0;
+         float sumsq = 0.0f;
          for (int arborID = 0; arborID<nArbors; arborID++) {
             for (int c=0; c<numConnections; c++) {
                HyPerConn * conn = connectionList[c];
@@ -103,9 +104,10 @@ int NormalizeL2::normalizeWeights() {
                accumulateSumSquared(dataStartPatch, weights_per_patch, &sumsq);
             }
          }
-         double l2norm = sqrt(sumsq);
-         if (fabs(sumsq) <= minL2NormTolerated) {
-            pvWarn().printf("for NormalizeL2 \"%s\": sum of squares of weights in patch %d is within minL2NormTolerated=%f of zero.  Weights in this patch unchanged.\n", getName(), patchindex, minL2NormTolerated);
+         float l2norm = sqrtf(sumsq);
+         if (fabsf(sumsq) <= minL2NormTolerated) {
+            pvWarn().printf("for NormalizeL2 \"%s\": sum of squares of weights in patch %d is within minL2NormTolerated=%f of zero.  Weights in this patch unchanged.\n",
+                  getName(), patchindex, (double)minL2NormTolerated);
             break;
          }
          for (int arborID = 0; arborID<nArbors; arborID++) {

--- a/src/normalizers/NormalizeMax.cpp
+++ b/src/normalizers/NormalizeMax.cpp
@@ -72,8 +72,9 @@ int NormalizeMax::normalizeWeights() {
                accumulateMax(dataStartPatch, weights_per_patch, &max);
             }
             if (max <= minMaxTolerated) {
-               pvWarn().printf("for NormalizeMax \"%s\": max of weights in patch %d of arbor %d is within minMaxTolerated=%f of zero.  Weights in this patch unchanged.\n", getName(), patchindex, arborID, minMaxTolerated);
-               break; // TODO: continue?
+               pvWarn().printf("for NormalizeMax \"%s\": max of weights in patch %d of arbor %d is within minMaxTolerated=%f of zero.  Weights in this patch unchanged.\n",
+                     getName(), patchindex, arborID, (double)minMaxTolerated);
+               continue;
             }
             for (int c=0; c<numConnections; c++) {
                HyPerConn * conn = connectionList[c];
@@ -102,8 +103,9 @@ int NormalizeMax::normalizeWeights() {
             }
          }
          if (max <= minMaxTolerated) {
-            pvWarn().printf("for NormalizeMax \"%s\": max of weights in patch %d is within minMaxTolerated=%f of zero. Weights in this patch unchanged.\n", getName(), patchindex, minMaxTolerated);
-            break; // TODO: continue?
+            pvWarn().printf("for NormalizeMax \"%s\": max of weights in patch %d is within minMaxTolerated=%f of zero. Weights in this patch unchanged.\n",
+                  getName(), patchindex, (double)minMaxTolerated);
+            continue;
          }
          for (int arborID = 0; arborID<nArbors; arborID++) {
             for (int c=0; c<numConnections; c++) {

--- a/src/normalizers/NormalizeSum.cpp
+++ b/src/normalizers/NormalizeSum.cpp
@@ -62,7 +62,7 @@ int NormalizeSum::normalizeWeights() {
    if (normalizeArborsIndividually) {
 	  for (int arborID = 0; arborID<nArbors; arborID++) {
 		 for (int patchindex = 0; patchindex<numDataPatches; patchindex++) {
-			double sum = 0.0;
+			float sum = 0.0;
 			for (int c=0; c<numConnections; c++) {
 			   HyPerConn * conn = connectionList[c];
                int nxp = conn->xPatchSize();
@@ -72,9 +72,10 @@ int NormalizeSum::normalizeWeights() {
 			   pvwdata_t * dataStartPatch = conn->get_wDataHead(arborID,patchindex);
                accumulateSum(dataStartPatch, weights_per_patch, &sum);
 			}
-			if (fabs(sum) <= minSumTolerated) {
-			   pvWarn().printf("NormalizeSum for %s: sum of weights in patch %d of arbor %d is within minSumTolerated=%f of zero. Weights in this patch unchanged.\n", getDescription_c(), patchindex, arborID, minSumTolerated);
-			   break;
+			if (fabsf(sum) <= minSumTolerated) {
+			   pvWarn().printf("NormalizeSum for %s: sum of weights in patch %d of arbor %d is within minSumTolerated=%f of zero. Weights in this patch unchanged.\n",
+                                 getDescription_c(), patchindex, arborID, (double)minSumTolerated);
+			   continue;
 			}
             for (int c=0; c<numConnections; c++) {
                HyPerConn * conn = connectionList[c];
@@ -90,7 +91,7 @@ int NormalizeSum::normalizeWeights() {
    }
    else {
       for (int patchindex = 0; patchindex<numDataPatches; patchindex++) {
-         double sum = 0.0;
+         float sum = 0.0;
          for (int arborID = 0; arborID<nArbors; arborID++) {
             for (int c=0; c<numConnections; c++) {
                HyPerConn * conn = connectionList[c];
@@ -102,9 +103,10 @@ int NormalizeSum::normalizeWeights() {
                accumulateSum(dataStartPatch, weights_per_patch, &sum);
             }
          }
-         if (fabs(sum) <= minSumTolerated) {
-            pvWarn().printf("NormalizeSum for %s: sum of weights in patch %d is within minSumTolerated=%f of zero.  Weights in this patch unchanged.\n", getDescription_c(), patchindex, minSumTolerated);
-            break;
+         if (fabsf(sum) <= minSumTolerated) {
+            pvWarn().printf("NormalizeSum for %s: sum of weights in patch %d is within minSumTolerated=%f of zero.  Weights in this patch unchanged.\n",
+                  getDescription_c(), patchindex, (double)minSumTolerated);
+            continue;
 
          }
          for (int arborID = 0; arborID<nArbors; arborID++) {

--- a/src/utils/stb_image.h
+++ b/src/utils/stb_image.h
@@ -1392,7 +1392,7 @@ static float   *stbi__ldr_to_hdr(stbi_uc *data, int x, int y, int comp)
    if (comp & 1) n = comp; else n = comp-1;
    for (i=0; i < x*y; ++i) {
       for (k=0; k < n; ++k) {
-         output[i*comp + k] = (float) (pow(data[i*comp+k]/255.0f, stbi__l2h_gamma) * stbi__l2h_scale);
+         output[i*comp + k] = (float) (powf(data[i*comp+k]/255.0f, stbi__l2h_gamma) * stbi__l2h_scale);
       }
       if (k < comp) output[i*comp + k] = data[i*comp+k]/255.0f;
    }

--- a/src/utils/stb_image.h
+++ b/src/utils/stb_image.h
@@ -1925,7 +1925,7 @@ stbi_inline static stbi_uc stbi__clamp(int x)
    return (stbi_uc) x;
 }
 
-#define stbi__f2f(x)  ((int) (((x) * 4096 + 0.5)))
+#define stbi__f2f(x)  ((int) (((x) * 4096 + 0.5f)))
 #define stbi__fsh(x)  ((x) << 12)
 
 // derived from jidctint -- DCT_ISLOW

--- a/src/weightinit/InitCocircWeights.cpp
+++ b/src/weightinit/InitCocircWeights.cpp
@@ -77,7 +77,9 @@ int InitCocircWeights::cocircCalcWeights(pvdata_t * w_tmp, InitCocircWeightsPara
 
       weightParamPtr->calcKurvePostAndSigmaKurvePost(kfPost);
 
-     if(weightParamPtr->checkThetaDiff(thPost)) continue;
+     if(weightParamPtr->checkThetaDiff(thPost)) { 
+        continue;
+     }
 
      for (int jPost = 0; jPost < nyPatch_tmp; jPost++) {
         float yDelta = weightParamPtr->calcYDelta(jPost);
@@ -87,17 +89,17 @@ int InitCocircWeights::cocircCalcWeights(pvdata_t * w_tmp, InitCocircWeightsPara
            weightParamPtr->initializeDistChordCocircKurvePreAndKurvePost();
 
 
-            if(calcDistChordCocircKurvePreNKurvePost(xDelta, yDelta, kfPost, weightParamPtr, thPost))
+            if(calcDistChordCocircKurvePreNKurvePost(xDelta, yDelta, kfPost, weightParamPtr, thPost)) {
               continue;
+            }
 
 
             //update weights based on calculated values:
             float weight_tmp = weightParamPtr->calculateWeight();
-            if (weight_tmp < min_weight) continue;
+            if (weight_tmp < min_weight) { 
+               continue;
+            }
             w_tmp[iPost * sx_tmp + jPost * sy_tmp + kfPost * sf_tmp] = weight_tmp;
-
-
-
         }
      }
    }
@@ -112,7 +114,7 @@ bool InitCocircWeights::calcDistChordCocircKurvePreNKurvePost(
    const float shift = weightParamPtr->getShift();
    const float sigma = weightParamPtr->getSigma();
    const float sigma2 = 2 * sigma * sigma;
-   const double r2Max = weightParamPtr->getr2Max();
+   const float r2Max = weightParamPtr->getr2Max();
    const int numFlanks = weightParamPtr->getNumFlanks();
    float thetaPre = weightParamPtr->getthPre();
 
@@ -137,13 +139,15 @@ bool InitCocircWeights::calcDistChordCocircKurvePreNKurvePost(
    }
 
 
-   if (weightParamPtr->getGDist() == 0.0) return true;
+   if (weightParamPtr->getGDist() == 0.0f) {
+      return true;
+   }
    if (d2 == 0) {
-     if(weightParamPtr->checkSameLoc(kfPost)) return true;
-
+     if(weightParamPtr->checkSameLoc(kfPost)) {
+        return true;
+     }
    }
    else { // d2 > 0
-
 
      // compute curvature of cocircular contour
      float cocircKurve_shift = d2_shift > 0 ? fabsf(2 * dyP_shift) / d2_shift
@@ -152,8 +156,9 @@ bool InitCocircWeights::calcDistChordCocircKurvePreNKurvePost(
       weightParamPtr->updateCocircNChord(
            thPost, dyP_shift, dxP,cocircKurve_shift, d2_shift);
 
-     if(weightParamPtr->checkFlags(dyP_shift, dxP))
+     if(weightParamPtr->checkFlags(dyP_shift, dxP)) {
         return true;
+     }
 
 
       //calculate values for gKurvePre and gKurvePost:
@@ -167,13 +172,12 @@ bool InitCocircWeights::calcDistChordCocircKurvePreNKurvePost(
         weightParamPtr->updateCocircNChord(
              thPost, dyP_shift2, dxP,cocircKurve_shift2, d2_shift);
 
-        if(weightParamPtr->checkFlags(dyP_shift2, dxP))
+        if(weightParamPtr->checkFlags(dyP_shift2, dxP)) {
            return true;
-
+        }
 
         //calculate values for gKurvePre and gKurvePost:
         weightParamPtr->updategKurvePreNgKurvePost(cocircKurve_shift2);
-
      }
    }
 

--- a/src/weightinit/InitCocircWeightsParams.cpp
+++ b/src/weightinit/InitCocircWeightsParams.cpp
@@ -25,10 +25,10 @@ InitCocircWeightsParams::~InitCocircWeightsParams()
 
 int InitCocircWeightsParams::initialize_base() {
 
-   aspect = 1.0; // circular (not line oriented)
-   sigma = 0.8;
-   rMax = 1.4;
-   strength = 1.0;
+   aspect = 1.0f; // circular (not line oriented)
+   sigma = 0.8f;
+   rMax = 1.4f;
+   strength = 1.0f;
    r2Max = rMax * rMax;
 
    numFlanks = 1;
@@ -37,20 +37,20 @@ int InitCocircWeightsParams::initialize_base() {
    //setDeltaThetaMax(2.0f * PI);  // max orientation in units of PI
    setThetaMax(1.0f); // max orientation in units of PI
 
-   sigma_cocirc = PI / 2.0;
+   sigma_cocirc = PI / 2.0f;
 
-   sigma_kurve = 1.0; // fraction of delta_radius_curvature
+   sigma_kurve = 1.0f; // fraction of delta_radius_curvature
 
    // sigma_chord = % of PI * R, where R == radius of curvature (1/curvature)
    // sigma_chord = 0.5;
 
-   setDeltaThetaMax(PI / 2.0);
+   setDeltaThetaMax(PI / 2.0f);
 
    cocirc_self = (pre != post);
 
    // from pv_common.h
    // // DK (1.0/(6*(NK-1)))   /*1/(sqrt(DX*DX+DY*DY)*(NK-1))*/         //  change in curvature
-   delta_radius_curvature = 1.0; // 1 = minimum radius of curvature
+   delta_radius_curvature = 1.0f; // 1 = minimum radius of curvature
 
    //why are these hard coded in!!!:
    min_weight = 0.0f; // read in as param
@@ -201,14 +201,14 @@ bool InitCocircWeightsParams::checkSameLoc(int kfPost) {
    if ((!sameLoc) || (cocirc_self)) {
       gCocirc = sigma_cocirc > 0 ? expf(-getDeltaTheta() * getDeltaTheta()
             / sigma_cocirc2) : expf(-getDeltaTheta() * getDeltaTheta() / sigma_cocirc2)
-            - 1.0;
+            - 1.0f;
       if ((nKurvePre > 1) && (nKurvePost > 1)) {
          gKurvePre = expf(-(kurvePre - kurvePost) * (kurvePre - kurvePost)
                / (sigma_kurve_pre2 + sigma_kurve_post2));
       }
    }
    else { // sameLoc && !cocircSelf
-      gCocirc = 0.0;
+      gCocirc = 0.0f;
       return true;
    }
    return false;
@@ -256,18 +256,18 @@ void InitCocircWeightsParams::updateCocircNChord(
    // const float sigma_chord2 = 2.0 * getSigma_chord() * getSigma_chord();
    const int nKurvePre = (int)getnKurvePre();
 
-   float atanx2_shift = thetaPre + 2. * atan2f(dyP_shift, dxP); // preferred angle (rad)
-   atanx2_shift += 2. * PI;
+   float atanx2_shift = thetaPre + 2.0f * atan2f(dyP_shift, dxP); // preferred angle (rad)
+   atanx2_shift += 2.0f * PI;
    atanx2_shift = fmodf(atanx2_shift, PI);
    atanx2_shift = fabsf(atanx2_shift - thPost);
    float chi_shift = atanx2_shift; //fabsf(atanx2_shift - thetaPost); // radians
-   if (chi_shift >= PI / 2.0) {
+   if (chi_shift >= PI / 2.0f) {
       chi_shift = PI - chi_shift;
    }
    if (noPre > 1 && noPost > 1) {
       gCocirc = sigma_cocirc2 > 0 ? expf(-chi_shift * chi_shift
             / sigma_cocirc2) : expf(-chi_shift * chi_shift / sigma_cocirc2)
-            - 1.0;
+            - 1.0f;
    }
    // compute distance along contour. // Broken because of sigma_chord bug. Commented out because gChord ultimately is not used.  -pete 2014-03-14
    // float d_chord_shift = (cocircKurve_shift != 0.0f) ? atanx2_shift
@@ -284,20 +284,20 @@ void InitCocircWeightsParams::updategKurvePreNgKurvePost(float cocircKurve_shift
    const float sigma_kurve_post2 = getSigma_kurve_post2();
 
    gKurvePre = (nKurvePre > 1) ? expf(-powf((cocircKurve_shift - fabsf(
-         kurvePre)), 2) / sigma_kurve_pre2) : 1.0;
+         kurvePre)), 2) / sigma_kurve_pre2) : 1.0f;
    gKurvePost
          = ((nKurvePre > 1) && (nKurvePost > 1) && (sigma_cocirc2 > 0)) ? expf(
                -powf((cocircKurve_shift - fabsf(kurvePost)), 2)
                      / sigma_kurve_post2)
-               : 1.0;
+               : 1.0f;
 }
 
 void InitCocircWeightsParams::initializeDistChordCocircKurvePreAndKurvePost() {
-   gDist = 0.0;
+   gDist = 0.0f;
    // gChord = 1.0; //not used!
-   gCocirc = 1.0;
-   gKurvePre = 1.0;
-   gKurvePost = 1.0;
+   gCocirc = 1.0f;
+   gKurvePre = 1.0f;
+   gKurvePost = 1.0f;
 }
 
 float InitCocircWeightsParams::calculateWeight() {

--- a/src/weightinit/InitGauss2DWeights.cpp
+++ b/src/weightinit/InitGauss2DWeights.cpp
@@ -70,8 +70,8 @@ int InitGauss2DWeights::gauss2DCalcWeights(pvdata_t * dataStart, InitGauss2DWeig
    int sx_tmp=weightParamPtr->getsx();
    int sy_tmp=weightParamPtr->getsy();
    int sf_tmp=weightParamPtr->getsf();
-   double r2Max=weightParamPtr->getr2Max();
-   double r2Min=weightParamPtr->getr2Min();
+   float r2Max=weightParamPtr->getr2Max();
+   float r2Min=weightParamPtr->getr2Min();
 
    pvdata_t * w_tmp = dataStart;
 
@@ -81,20 +81,28 @@ int InitGauss2DWeights::gauss2DCalcWeights(pvdata_t * dataStart, InitGauss2DWeig
    for (int fPost = 0; fPost < nfPatch_tmp; fPost++) {
       float thPost = weightParamPtr->calcThPost(fPost);
       //TODO: add additional weight factor for difference between thPre and thPost
-      if(weightParamPtr->checkThetaDiff(thPost)) continue;
-      if(weightParamPtr->checkColorDiff(fPost)) continue;
+      if(weightParamPtr->checkThetaDiff(thPost)) {
+         continue;
+      }
+      if(weightParamPtr->checkColorDiff(fPost)) {
+         continue;
+      }
       for (int jPost = 0; jPost < nyPatch_tmp; jPost++) {
          float yDelta = weightParamPtr->calcYDelta(jPost);
          for (int iPost = 0; iPost < nxPatch_tmp; iPost++) {
             float xDelta = weightParamPtr->calcXDelta(iPost);
 
-            if(weightParamPtr->isSameLocOrSelf(xDelta, yDelta, fPost)) continue;
+            if(weightParamPtr->isSameLocOrSelf(xDelta, yDelta, fPost)) {
+               continue;
+            }
 
             // rotate the reference frame by th (change sign of thPost?)
-            float xp = +xDelta * cos(thPost) + yDelta * sin(thPost);
-            float yp = -xDelta * sin(thPost) + yDelta * cos(thPost);
+            float xp = +xDelta * cosf(thPost) + yDelta * sinf(thPost);
+            float yp = -xDelta * sinf(thPost) + yDelta * cosf(thPost);
 
-            if(weightParamPtr->checkBowtieAngle(yp, xp)) continue;
+            if(weightParamPtr->checkBowtieAngle(yp, xp)) {
+               continue;
+            }
 
 
             // include shift to flanks
@@ -102,13 +110,13 @@ int InitGauss2DWeights::gauss2DCalcWeights(pvdata_t * dataStart, InitGauss2DWeig
             int index = iPost * sx_tmp + jPost * sy_tmp + fPost * sf_tmp;
             w_tmp[index] = 0;
             if ((d2 <= r2Max) && (d2 >= r2Min)) {
-               w_tmp[index] += strength*exp(-d2 / (2.0f * sigma * sigma));
+               w_tmp[index] += strength*expf(-d2 / (2.0f * sigma * sigma));
             }
             if (numFlanks > 1) {
                // shift in opposite direction
                d2 = xp * xp + (aspect * (yp + shift) * aspect * (yp + shift));
                if ((d2 <= r2Max) && (d2 >= r2Min)) {
-                  w_tmp[index] += strength*exp(-d2 / (2.0f * sigma * sigma));
+                  w_tmp[index] += strength*expf(-d2 / (2.0f * sigma * sigma));
                }
             }
          }

--- a/src/weightinit/InitGauss2DWeightsParams.cpp
+++ b/src/weightinit/InitGauss2DWeightsParams.cpp
@@ -238,12 +238,12 @@ float InitGauss2DWeightsParams::calcThPost(int fPost) {
 }
 
 bool InitGauss2DWeightsParams::checkThetaDiff(float thPost) {
-  if ((deltaTheta = fabs(thPre - thPost)) > deltaThetaMax) {
+  if ((deltaTheta = fabsf(thPre - thPost)) > deltaThetaMax) {
      //the following is obviously not ideal. But cocirc needs this deltaTheta:
-     deltaTheta = (deltaTheta <= PI / 2.0) ? deltaTheta : PI - deltaTheta;
+     deltaTheta = (deltaTheta <= PI / 2.0f) ? deltaTheta : PI - deltaTheta;
       return true;
    }
-  deltaTheta = (deltaTheta <= PI / 2.0) ? deltaTheta : PI - deltaTheta;
+  deltaTheta = (deltaTheta <= PI / 2.0f) ? deltaTheta : PI - deltaTheta;
    return false;
 }
 

--- a/src/weightinit/InitSpreadOverArborsWeights.cpp
+++ b/src/weightinit/InitSpreadOverArborsWeights.cpp
@@ -91,7 +91,7 @@ int InitSpreadOverArborsWeights::spreadOverArborsWeights(/* PVPatch * patch */ p
 
 
             float weight = 0;
-            if (xp*xp+yp*yp<1e-4) {
+            if (xp*xp+yp*yp<1e-4f) {
                weight = iWeight/nArbors;
             }
             else {
@@ -102,8 +102,12 @@ int InitSpreadOverArborsWeights::spreadOverArborsWeights(/* PVPatch * patch */ p
                f2u.f = xp; xpraw = f2u.i;
                f2u.f = yp; ypraw = f2u.i;
                f2u.f = theta2pi; atanraw = f2u.i;
-               if(theta2pi<0) theta2pi+=1;
-               if(theta2pi>=1) theta2pi-=1; // theta2pi should be in the range [0,1) but roundoff could make it exactly 1
+               if(theta2pi<0) {
+                  theta2pi+=1;
+               }
+               if(theta2pi>=1) {
+                  theta2pi-=1; // theta2pi should be in the range [0,1) but roundoff could make it exactly 1
+               }
                float zone = theta2pi*nArbors;
 
                float intpart;

--- a/src/weightinit/InitUniformRandomWeights.cpp
+++ b/src/weightinit/InitUniformRandomWeights.cpp
@@ -47,22 +47,23 @@ int InitUniformRandomWeights::randomWeights(pvdata_t * patchDataStart, InitWeigh
       pvError().printf("Failed to recast pointer to weightsParam!  Exiting...");
    }
 
-   float minwgt = weightParamPtr->getWMin();
-   float maxwgt = weightParamPtr->getWMax();
+   double minwgt = weightParamPtr->getWMin();
+   double maxwgt = weightParamPtr->getWMax();
    float sparseFraction = weightParamPtr->getSparseFraction();
 
    double p;
    if( maxwgt <= minwgt ) {
       if( maxwgt < minwgt ) {
-         pvWarn().printf("uniformWeights maximum less than minimum.  Changing max = %f to min value of %f\n", maxwgt, minwgt);
+         pvWarn().printf("uniformWeights maximum less than minimum.  Changing max = %f to min value of %f\n",
+               maxwgt, minwgt);
          maxwgt = minwgt;
       }
       p = 0;
    }
    else {
-       p = (maxwgt - minwgt) / (1.0+(double) CL_RANDOM_MAX);
+       p = (maxwgt - minwgt) / (1.0 + (double) CL_RANDOM_MAX);
    }
-   sparseFraction *= (1.0+(double) CL_RANDOM_MAX);
+   sparseFraction *= (float)(1.0 + (double) CL_RANDOM_MAX);
 
    // loop over all post-synaptic cells in patch
 
@@ -71,8 +72,10 @@ int InitUniformRandomWeights::randomWeights(pvdata_t * patchDataStart, InitWeigh
    const int nfp = weightParamPtr->getnfPatch();
    const int patchSize = nxp*nyp*nfp;
    for (int n=0; n<patchSize; n++) {
-      pvdata_t data = minwgt + (pvdata_t) (p * (double) randState->randomUInt(patchIndex));
-      if ((double) randState->randomUInt(patchIndex) < sparseFraction) data = 0.0;
+      float data = (float)(minwgt + (p * (double) randState->randomUInt(patchIndex)));
+      if ((double)randState->randomUInt(patchIndex) < (double)sparseFraction) {
+         data = 0.0f;
+      }
       patchDataStart[n] = data;
    }
 

--- a/styleguide
+++ b/styleguide
@@ -7,6 +7,8 @@
 // Primitive type names are lowercase
 // Enum values are ALL_CAPS
 
+// TODO comments must always include the date entered
+
 // Descriptive variable names are preferred to shorthand.
 // Avoid using one letter abbreviations anywhere other than for loop indices.
 

--- a/tests/ANNLayerVerticesTest/src/main.cpp
+++ b/tests/ANNLayerVerticesTest/src/main.cpp
@@ -29,11 +29,11 @@ int customexit(HyPerCol * hc, int argc, char * argv[]) {
       // Based on params file having verticesV = [0.5, 0.5]; verticesA = [0.0, 1.0]; slopeNegInf = 0.0; slopePosInf = 0.0;
       // i.e. indicator function of V>=0.5.
       // TODO: Currently, jumps in verticesV/verticesA are continuous from the right.  Need to generalize.
-      if (v < 0.5) {
-         pvErrorIf(!(a==0.0), "Test failed.\n");
+      if (v < 0.5f) {
+         pvErrorIf(!(a==0.0f), "Test failed.\n");
       }
       else {
-         pvErrorIf(!(a==1.0), "Test failed.\n");
+         pvErrorIf(!(a==1.0f), "Test failed.\n");
       }
    }
    return PV_SUCCESS;

--- a/tests/AdjustAxonalArborsTest/src/main.cpp
+++ b/tests/AdjustAxonalArborsTest/src/main.cpp
@@ -47,11 +47,11 @@ int checkoutput(HyPerCol * hc, int argc, char ** argv) {
             
             if (x>=0 && x<inLoc->nxGlobal && y>=0 && y<inLoc->nyGlobal) {
                int kRestricted = kIndex(x,y,f,inLoc->nxGlobal,inLoc->nyGlobal,inLoc->nf);
-               pvInfo().printf("Rank %d, kLocal(extended)=%d, kGlobal(restricted)=%2d, x=%2d, y=%2d, f=%2d, a=%f\n", r, k, kRestricted, x, y, f, a);
+               pvInfo().printf("Rank %d, kLocal(extended)=%d, kGlobal(restricted)=%2d, x=%2d, y=%2d, f=%2d, a=%f\n", r, k, kRestricted, x, y, f, (double)a);
                pvdata_t correctValue = (pvdata_t) kRestricted+1.0f;
                if (a!=correctValue) {
                   status = PV_FAILURE;
-                  pvErrorNoExit().printf("        Failure! Correct value is %f\n", correctValue);
+                  pvErrorNoExit().printf("        Failure! Correct value is %f\n", (double)correctValue);
                }
             }
          }
@@ -71,10 +71,10 @@ int checkoutput(HyPerCol * hc, int argc, char ** argv) {
       if (r==hc->columnId()) {
          pvInfo().printf("Rank %d, Weight values\n", r);
          for (int k=0; k<patchSize; k++) {
-            pvInfo().printf("Rank %d, k=%2d, w=%f\n", r, k, w[k]);
+            pvInfo().printf("Rank %d, k=%2d, w=%f\n", r, k, (double)w[k]);
             if (w[k]!=(pvdata_t) k) {
                status = PV_FAILURE;
-               pvErrorNoExit().printf("        Failure! Correct value is %f\n", (pvdata_t) k);
+               pvErrorNoExit().printf("        Failure! Correct value is %f\n", (double)k);
             }
          }
       }
@@ -106,10 +106,10 @@ int checkoutput(HyPerCol * hc, int argc, char ** argv) {
             
             if (x>=0 && x<outLoc->nxGlobal && y>=0 && y<outLoc->nyGlobal) {
                int kRestricted = kIndex(x,y,f,outLoc->nxGlobal,outLoc->nyGlobal,outLoc->nf);
-               pvInfo().printf("Rank %d, kLocal=%d, kGlobal=%2d, x=%2d, y=%2d, f=%2d, V=%f\n", r, k, kRestricted, x, y, f, V);
+               pvInfo().printf("Rank %d, kLocal=%d, kGlobal=%2d, x=%2d, y=%2d, f=%2d, V=%f\n", r, k, kRestricted, x, y, f, (double)V);
                if (V!=correct[kRestricted]) {
                   status = PV_FAILURE;
-                  pvErrorNoExit().printf("        Failure! Correct value is %f\n", correct[kRestricted]);
+                  pvErrorNoExit().printf("        Failure! Correct value is %f\n", (double)correct[kRestricted]);
                }
             }
          }

--- a/tests/ArborSystemTest/src/ArborTestForOnesProbe.cpp
+++ b/tests/ArborSystemTest/src/ArborTestForOnesProbe.cpp
@@ -36,11 +36,11 @@ int ArborTestForOnesProbe::outputState(double timed)
    if( icComm->commRank() != rcvProc ) {
       return 0;
    }
-   if(timed>1.0f){
+   if(timed>1.0){
       for(int b = 0; b < getParent()->getNBatch(); b++){
-         pvErrorIf(!((fMin[b]>0.99)&&(fMin[b]<1.01)), "Test failed.\n");
-         pvErrorIf(!((fMax[b]>0.99)&&(fMax[b]<1.01)), "Test failed.\n");
-         pvErrorIf(!((avg[b]>0.99)&&(avg[b]<1.01)), "Test failed.\n");
+         pvErrorIf(!((fMin[b]>0.99f)&&(fMin[b]<1.01f)), "Test failed.\n");
+         pvErrorIf(!((fMax[b]>0.99f)&&(fMax[b]<1.01f)), "Test failed.\n");
+         pvErrorIf(!((avg[b]>0.99f)&&(avg[b]<1.01f)), "Test failed.\n");
       }
    }
 

--- a/tests/ArborSystemTest/src/ArborTestProbe.cpp
+++ b/tests/ArborSystemTest/src/ArborTestProbe.cpp
@@ -60,19 +60,19 @@ int ArborTestProbe::outputState(double timed)
       return 0;
    }
    for(int b = 0; b < getParent()->getNBatch(); b++){
-      if(timed==1.0f){
-         pvErrorIf(!((avg[b]>0.2499)&&(avg[b]<0.2501)), "Test failed.\n");
+      if(timed==1.0){
+         pvErrorIf(!((avg[b]>0.2499f)&&(avg[b]<0.2501f)), "Test failed.\n");
       }
-      else if(timed==2.0f){
-         pvErrorIf(!((avg[b]>0.4999)&&(avg[b]<0.5001)), "Test failed.\n");
+      else if(timed==2.0){
+         pvErrorIf(!((avg[b]>0.4999f)&&(avg[b]<0.5001f)), "Test failed.\n");
       }
-      else if(timed==3.0f){
-         pvErrorIf(!((avg[b]>0.7499)&&(avg[b]<0.7501)), "Test failed.\n");
+      else if(timed==3.0){
+         pvErrorIf(!((avg[b]>0.7499f)&&(avg[b]<0.7501f)), "Test failed.\n");
       }
-      else if(timed>3.0f){
-         pvErrorIf(!((fMin[b]>0.9999)&&(fMin[b]<1.001)), "Test failed.\n");
-         pvErrorIf(!((fMax[b]>0.9999)&&(fMax[b]<1.001)), "Test failed.\n");
-         pvErrorIf(!((avg[b]>0.9999)&&(avg[b]<1.001)), "Test failed.\n");
+      else if(timed>3.0){
+         pvErrorIf(!((fMin[b]>0.9999f)&&(fMin[b]<1.001f)), "Test failed.\n");
+         pvErrorIf(!((fMax[b]>0.9999f)&&(fMax[b]<1.001f)), "Test failed.\n");
+         pvErrorIf(!((avg[b]>0.9999f)&&(avg[b]<1.001f)), "Test failed.\n");
       }
    }
 

--- a/tests/AvgPoolTest/src/AvgPoolTestLayer.cpp
+++ b/tests/AvgPoolTest/src/AvgPoolTestLayer.cpp
@@ -38,15 +38,15 @@ int AvgPoolTestLayer::updateState(double timef, double dt){
               pvErrorIf(!(yval >= 0 && yval < loc->nxGlobal), "Test failed.\n");
 
               float expectedvalue;
-              if(nxScale == .5){
-                 expectedvalue = iFeature * 64 + yval * 16 + xval * 2 + 4.5;
+              if(nxScale == 0.5f){
+                 expectedvalue = iFeature * 64 + yval * 16 + xval * 2 + 4.5f;
               }
               else{
                  int res_idx = kIndex(xval, yval, 0, nxGlobal, nyGlobal, 1);
                  //TODO different features define different offsets into this index
                  expectedvalue = iFeature * nxGlobal * nyGlobal + res_idx;
               }
-              if(fabs(actualvalue - expectedvalue) >= 1e-4){
+              if(fabsf(actualvalue - expectedvalue) >= 1e-4f){
                    pvErrorNoExit() << "Connection " << name << " Mismatch at (" << iX << "," << iY << ") : actual value: " << actualvalue << " Expected value: " << expectedvalue << ".  Discrepancy is a whopping " << actualvalue - expectedvalue << "!  Horrors!" << "\n";
                    isCorrect = false;
               }

--- a/tests/BinningLayerTest/src/BinningTestLayer.cpp
+++ b/tests/BinningLayerTest/src/BinningTestLayer.cpp
@@ -41,26 +41,26 @@ int BinningTestLayer::updateState(double timef, double dt){
             else if (getSigma() == 2){
                float temp;
                if(iX+kx0 == iF-2 || iX+kx0 == iF+2){
-                  temp = A[idx] - .121;
-                  if(temp > .00001){
+                  temp = A[idx] - 0.121f;
+                  if(temp > .00001f){
                      pvError() << iY << "," << iX << "," << iF << ": " << A[idx] << "\n";
                   }
-                  pvErrorIf(!(temp <= .00001), "Test failed.\n");
+                  pvErrorIf(!(temp <= 0.00001f), "Test failed.\n");
                }
                if(iX+kx0 == iF-1 || iX+kx0 == iF+1){
-                  temp = A[idx] - .176;
-                  if(temp > .00001){
+                  temp = A[idx] - 0.176f;
+                  if(temp > 0.00001f){
                      pvError() << iY << "," << iX << "," << iF << ": " << A[idx] << "\n";
                   }
-                  pvErrorIf(!(temp <= .00001), "Test failed.\n");
+                  pvErrorIf(!(temp <= 0.00001f), "Test failed.\n");
 
                }
                if(iX+kx0 == iF){
-                  temp = A[idx] - .199;
-                  if(temp > .00001){
+                  temp = A[idx] - 0.199f;
+                  if(temp > 0.00001f){
                      pvError() << iY << "," << iX << "," << iF << ": " << A[idx] << "\n";
                   }
-                  pvErrorIf(!(temp <= .00001), "Test failed.\n");
+                  pvErrorIf(!(temp <= 0.00001f), "Test failed.\n");
                }
             }
          }

--- a/tests/BufferTest/src/main.cpp
+++ b/tests/BufferTest/src/main.cpp
@@ -39,7 +39,7 @@ void testSetVector() {
       for(int x = 0; x < 2; ++x) {
          for(int f = 0; f < 2; ++f) {
             pvErrorIf(testBuffer.at(x, y, f) != v++,
-                  "Failed. Expected %d, found %d instead.\n", v-1, testBuffer.at(x, y, f));
+                  "Failed. Expected %f, found %f instead.\n", (double)v-1, (double)testBuffer.at(x, y, f));
          }
       }
    }
@@ -67,8 +67,8 @@ void testAsVector() {
 
    for(int i = 0; i < testVector.size(); ++i) {
       pvErrorIf(testVector.at(i) != comparison.at(i),
-            "Failed: Expected %d, found %d at index %d.\n",
-            testVector.at(i), comparison.at(i), i);
+            "Failed: Expected %f, found %f at index %d.\n",
+            (double)testVector.at(i), (double)comparison.at(i), i);
    }
 }
 
@@ -284,7 +284,7 @@ void testRescale() {
    for(int i = 0; i < nearest.size(); ++i) {
       pvErrorIf(nearest.at(i) != answerNearest.at(i),
          "Failed (Nearest). Expected %f at index %d, found %f.\n",
-         answerNearest.at(i), i, nearest.at(i));
+         (double)answerNearest.at(i), i, (double)nearest.at(i));
    }
  
    // Test Buffer::CROP resizeMethod
@@ -297,7 +297,7 @@ void testRescale() {
    for(int i = 0; i < cropped.size(); ++i) {
       pvErrorIf(cropped.at(i) != answerCrop.at(i),
          "Failed (Crop). Expected %f at index %d, found %f.\n",
-         answerCrop.at(i), i, cropped.at(i));
+         (double)answerCrop.at(i), i, (double)cropped.at(i));
    }
    
    // Test Buffer::PAD resizeMethod
@@ -310,7 +310,7 @@ void testRescale() {
   for(int i = 0; i < padded.size(); ++i) {
       pvErrorIf(padded.at(i) != answerPad.at(i),
          "Failed (Pad). Expected %f at index %d, found %f.\n",
-         answerPad.at(i), i, padded.at(i));
+         (double)answerPad.at(i), i, (double)padded.at(i));
    }
 }
 

--- a/tests/CloneHyPerConnTest/src/CloneHyPerConnTestProbe.cpp
+++ b/tests/CloneHyPerConnTest/src/CloneHyPerConnTestProbe.cpp
@@ -35,10 +35,10 @@ int CloneHyPerConnTestProbe::outputState(double timed)
       return 0;
    }
    for(int b = 0; b < getParent()->getNBatch(); b++){
-      if(timed>2.0f){
-         pvErrorIf(!(fabs(fMin[b]) < 1e-6), "Test failed.\n");
-         pvErrorIf(!(fabs(fMax[b]) < 1e-6), "Test failed.\n");
-         pvErrorIf(!(fabs(avg[b]) < 1e-6), "Test failed.\n");
+      if(timed>2.0){
+         pvErrorIf(!(fabsf(fMin[b]) < 1e-6f), "Test failed.\n");
+         pvErrorIf(!(fabsf(fMax[b]) < 1e-6f), "Test failed.\n");
+         pvErrorIf(!(fabsf(avg[b]) < 1e-6f), "Test failed.\n");
       }
    }
 

--- a/tests/CloneKernelConnTest/src/CloneKernelConnTestProbe.cpp
+++ b/tests/CloneKernelConnTest/src/CloneKernelConnTestProbe.cpp
@@ -36,10 +36,10 @@ int CloneKernelConnTestProbe::outputState(double timed)
    }
 
    for(int b = 0; b < getParent()->getNBatch(); b++){
-      if(timed>2.0f){
-         pvErrorIf(!(fabs(fMin[b]) < 1e-6), "Test failed.\n");
-         pvErrorIf(!(fabs(fMax[b]) < 1e-6), "Test failed.\n");
-         pvErrorIf(!(fabs(avg[b]) < 1e-6), "Test failed.\n");
+      if(timed>2.0){
+         pvErrorIf(!(fabsf(fMin[b]) < 1e-6f), "Test failed.\n");
+         pvErrorIf(!(fabsf(fMax[b]) < 1e-6f), "Test failed.\n");
+         pvErrorIf(!(fabsf(avg[b]) < 1e-6f), "Test failed.\n");
       }
    }
 

--- a/tests/CloneVLayerTest/src/CloneVLayerTest.cpp
+++ b/tests/CloneVLayerTest/src/CloneVLayerTest.cpp
@@ -41,7 +41,7 @@ int customexit(HyPerCol * hc, int argc, char * argv[]) {
    N = check_clone_layer->getNumExtended();
 
    for (int k=0; k<N; k++) {
-      pvErrorIf(!(fabsf(check_clone_layer_data[k])<1e-6), "Test failed.\n");
+      pvErrorIf(!(fabsf(check_clone_layer_data[k])<1e-6f), "Test failed.\n");
    }
 
    HyPerLayer * check_sigmoid_layer = hc->getLayer(check_sigmoid_id);
@@ -50,7 +50,7 @@ int customexit(HyPerCol * hc, int argc, char * argv[]) {
    N = check_sigmoid_layer->getNumExtended();
 
    for (int k=0; k<N; k++) {
-      pvErrorIf(!(fabsf(check_sigmoid_layer_data[k])<1e-6), "Test failed.\n");
+      pvErrorIf(!(fabsf(check_sigmoid_layer_data[k])<1e-6f), "Test failed.\n");
    }
 
    if (hc->columnId()==0) {

--- a/tests/ConvertToGrayscaleTest/src/main.cpp
+++ b/tests/ConvertToGrayscaleTest/src/main.cpp
@@ -19,7 +19,7 @@ int customexit(HyPerCol * hc, int argc, char ** argv) {
    pvadata_t tolerance = 1.0e-3f;
 
    if (hc->columnId()==0) {
-      pvInfo().printf("Checking whether input layer has all values equal to %f ...\n", correctvalue);
+      pvInfo().printf("Checking whether input layer has all values equal to %f ...\n", (double)correctvalue);
    }
    HyPerLayer * inputlayer = hc->getLayerFromName("input");
    pvErrorIf(!(inputlayer), "Test failed.\n");
@@ -47,9 +47,9 @@ int customexit(HyPerCol * hc, int argc, char ** argv) {
          for (int k=0; k<numNeurons; k++) {
             int kExt = kIndexExtended(k,loc->nx,loc->ny,loc->nf,loc->halo.lt,loc->halo.rt,loc->halo.dn,loc->halo.up);
             pvadata_t value = databuffer[kExt];
-            if (fabs(value-correctvalue)>=tolerance) {
+            if (fabsf(value-correctvalue)>=tolerance) {
                pvErrorNoExit().printf("Rank %d, restricted index %d, extended index %d, value is %f instead of %f\n",
-                     proc, k, kExt, value, correctvalue);
+                     proc, k, kExt, (double)value, (double)correctvalue);
                status = PV_FAILURE;
             }
          }

--- a/tests/CopyConnTest/src/main.cpp
+++ b/tests/CopyConnTest/src/main.cpp
@@ -119,9 +119,9 @@ int runparamsfile(PV_Init* initObj, char const * paramsfile) {
                   pvwdata_t origWeight = origConn->get_wDataHead(arbor, patchindex)[indexinpatch];
                   pvwdata_t copyWeight = copyConn->get_wDataHead(arbor, patchindex)[indexinpatch];
                   float discrep = fabsf(origWeight*copyStrength - copyWeight*origStrength);
-                  if (discrep > 1e-6) {
+                  if (discrep > 1e-6f) {
                      pvErrorNoExit().printf("Rank %d: arbor %d, patchindex %d, x=%d, y=%d, f=%d: discrepancy of %g\n",
-                           hc->columnId(), arbor, patchindex, x, y, f, discrep);
+                           hc->columnId(), arbor, patchindex, x, y, f, (double)discrep);
                      status = PV_FAILURE;
                   }
                }

--- a/tests/DatastoreDelayTest/src/DatastoreDelayTestProbe.cpp
+++ b/tests/DatastoreDelayTest/src/DatastoreDelayTestProbe.cpp
@@ -51,7 +51,7 @@ int DatastoreDelayTestProbe::outputState(double timed) {
       pvdata_t * V = l->getV();
       for( int k=0; k<l->getNumNeuronsAllBatches(); k++ ) {
          if( V[k] != correctValue ) {
-            outputStream->printf("%s: timef = %f, neuron %d: value is %f instead of %d\n", l->getDescription_c(), timed, k, V[k], (int) correctValue);
+            outputStream->printf("%s: timef = %f, neuron %d: value is %f instead of %d\n", l->getDescription_c(), timed, k, (double)V[k], (int) correctValue);
             status = PV_FAILURE;
          }
       }

--- a/tests/DelaysToFeaturesTest/src/DelayTestProbe.cpp
+++ b/tests/DelaysToFeaturesTest/src/DelayTestProbe.cpp
@@ -46,12 +46,12 @@ int DelayTestProbe::outputState(double timed)
 
    for(int b = 0; b < loc->nbatch; b++){
       if (timed==0) {
-         assert(avg[b] == static_cast<float>(timed / nf));
-         assert(avg[b] == static_cast<float>(nnz[b] / (nx*rows*ny*cols*nf)));
+         assert(avg[b] == (float)(timed / nf));
+         assert(avg[b] == (float)nnz[b] / (nx*rows*ny*cols*nf));
       }
       else {
-         assert(avg[b] == static_cast<float>((timed-1) / nf));
-         assert(avg[b] == static_cast<float>(nnz[b] / (nx*rows*ny*cols*nf)));
+         assert(avg[b] == (float)((timed-1) / nf));
+         assert(avg[b] == (float)nnz[b] / (nx*rows*ny*cols*nf));
       }
    }
    return status;

--- a/tests/DelaysToFeaturesTest/src/DelayTestProbe.cpp
+++ b/tests/DelaysToFeaturesTest/src/DelayTestProbe.cpp
@@ -46,13 +46,12 @@ int DelayTestProbe::outputState(double timed)
 
    for(int b = 0; b < loc->nbatch; b++){
       if (timed==0) {
-         //TODO: Is this a candidate for floating point error? Also, what is this even doing? Why not just compare these to each other?
-         assert(avg[b] == timed / nf);
-         assert(avg[b] == static_cast<double>(nnz[b]) / (nx*rows*ny*cols*nf));
+         assert(avg[b] == static_cast<float>(timed / nf));
+         assert(avg[b] == static_cast<float>(nnz[b] / (nx*rows*ny*cols*nf)));
       }
       else {
-         assert(avg[b] == (timed-1) / nf);
-         assert(avg[b] == static_cast<double>(nnz[b]) / (nx*rows*ny*cols*nf));
+         assert(avg[b] == static_cast<float>((timed-1) / nf));
+         assert(avg[b] == static_cast<float>(nnz[b] / (nx*rows*ny*cols*nf)));
       }
    }
    return status;

--- a/tests/GPUSystemTest/src/GPUSystemTestProbe.cpp
+++ b/tests/GPUSystemTest/src/GPUSystemTestProbe.cpp
@@ -35,11 +35,11 @@ int GPUSystemTestProbe::outputState(double timed){
    const pvdata_t * A = getTargetLayer()->getLayerData();
    float sumsq = 0;
    for (int i = 0; i < numExtNeurons; i++){
-      pvErrorIf(!(fabs(A[i]) < 5e-4), "Test failed.\n");
+      pvErrorIf(!(fabsf(A[i]) < 5e-4f), "Test failed.\n");
    }
    for(int b = 0; b < loc->nbatch; b++){
       //For max std of 5e-5
-      pvErrorIf(!(sigma[b] <= 5e-5), "Test failed.\n");
+      pvErrorIf(!(sigma[b] <= 5e-5f), "Test failed.\n");
    }
 
    return status;

--- a/tests/GPUSystemTest/src/identicalBatchProbe.cpp
+++ b/tests/GPUSystemTest/src/identicalBatchProbe.cpp
@@ -37,11 +37,11 @@ int identicalBatchProbe::outputState(double timed){
       pvdata_t checkVal = A[i];
       for(int b = 0; b < loc->nbatch; b++){
          const pvdata_t * ABatch = A + b * getTargetLayer()->getNumExtended();
-         float diff = fabs(checkVal - ABatch[i]);
-         if(diff > 1e-4){
+         float diff = fabsf(checkVal - ABatch[i]);
+         if(diff > 1e-4f){
             pvError() << "Difference at neuron " << i << ", batch 0: " << checkVal << " batch " << b << ": " << ABatch[i] << "\n";
          }
-         pvErrorIf(!(diff <= 1e-4), "Test failed.\n");
+         pvErrorIf(!(diff <= 1e-4f), "Test failed.\n");
       }
    }
    return status;

--- a/tests/GroupNormalizationTest/src/AllConstantValueProbe.cpp
+++ b/tests/GroupNormalizationTest/src/AllConstantValueProbe.cpp
@@ -40,8 +40,8 @@ int AllConstantValueProbe::outputState(double timed) {
    if (this->parent->columnId()==0) {
       for(int b = 0; b < this->parent->getNBatch(); b++){
          if (timed>0 && (fMin[b]<correctValue-nnzThreshold || fMax[b] > correctValue+nnzThreshold)) {
-            outputStream->printf("     Values outside of tolerance nnzThreshold=%f\n", nnzThreshold);
-            pvErrorNoExit().printf("t=%f: fMin=%f, fMax=%f; values more than nnzThreshold=%g away from correct value %f\n", timed, fMin[b], fMax[b], nnzThreshold, correctValue);
+            outputStream->printf("     Values outside of tolerance nnzThreshold=%f\n", (double)nnzThreshold);
+            pvErrorNoExit().printf("t=%f: fMin=%f, fMax=%f; values more than nnzThreshold=%g away from correct value %f\n", timed, (double)fMin[b], (double)fMax[b], (double)nnzThreshold, (double)correctValue);
          }
       }
    }

--- a/tests/ImageOffsetTest/src/ImageOffsetTestLayer.cpp
+++ b/tests/ImageOffsetTest/src/ImageOffsetTestLayer.cpp
@@ -117,7 +117,7 @@ namespace PV {
                      pvError() << "Layer name " << name << " not recoginzed\n";
                   }
                   float diff = fabs(actualvalue - expectedvalue);
-                  if(diff >= 1e-4){
+                  if(diff >= 1e-4f){
                      pvErrorNoExit() << "Connection " << name << " Mismatch at (" << ixGlobal << "," << iyGlobal << "," << iF << ") : actual value: " << actualvalue << " Expected value: " << expectedvalue << "\n";
                      isCorrect = false;
                   }

--- a/tests/ImageOffsetTest/src/ImagePvpOffsetTestLayer.cpp
+++ b/tests/ImageOffsetTest/src/ImagePvpOffsetTestLayer.cpp
@@ -116,7 +116,7 @@ int ImagePvpOffsetTestLayer::updateState(double timef, double dt){
                   pvError() << "Layer name " << name << " not recoginzed\n";
                }
                float diff = fabs(actualvalue - expectedvalue);
-               if(diff >= 1e-4){
+               if(diff >= 1e-4f){
                   pvErrorNoExit() << "Connection " << name << " Mismatch at (" << ixGlobal << "," << iyGlobal << "," << iF << ") : actual value: " << actualvalue << " Expected value: " << expectedvalue << "\n";
                   isCorrect = false;
                }

--- a/tests/ImageTest/src/main.cpp
+++ b/tests/ImageTest/src/main.cpp
@@ -196,11 +196,11 @@ void testConvertToGray() {
 
       pvErrorIf(img.getPixelR(1, 0) != Image::mGToGray,
             "Failed (Top Right). Expected %f, found %f.\n",
-            Image::mGToGray, (double)img.getPixelR(1, 0));
+            (double)Image::mGToGray, (double)img.getPixelR(1, 0));
 
        pvErrorIf(img.getPixelR(0, 1) != Image::mBToGray,
             "Failed (Bottom Left). Expected %f, found %f.\n",
-            (double)Image::mBToGray, img.getPixelR(0, 1));
+            (double)Image::mBToGray, (double)img.getPixelR(0, 1));
 
        pvErrorIf(img.getPixelG(1, 1) != 0.0f,
             "Failed (Bottom Right). Expected 0.0, found %f.\n",

--- a/tests/ImageTest/src/main.cpp
+++ b/tests/ImageTest/src/main.cpp
@@ -30,13 +30,13 @@ void testPng24Load() {
             && png24.getPixelB(1, 1) == 1.0f;
 
    pvErrorIf(!tl, "Failed (Top Left). Expected (1.0, 0.0, 0.0), found (%f, %f, %f) instead.\n",
-         png24.getPixelR(0, 0), png24.getPixelG(0, 0), png24.getPixelB(0, 0));
+         (double)png24.getPixelR(0, 0), (double)png24.getPixelG(0, 0), (double)png24.getPixelB(0, 0));
    pvErrorIf(!tr, "Failed (Top Right). Expected (0.0, 1.0, 0.0), found (%f, %f, %f) instead.\n",
-         png24.getPixelR(1, 0), png24.getPixelG(1, 0), png24.getPixelB(1, 0));
+         (double)png24.getPixelR(1, 0), (double)png24.getPixelG(1, 0), (double)png24.getPixelB(1, 0));
    pvErrorIf(!bl, "Failed (Bottom Left). Expected (0.0, 0.0, 1.0), found (%f, %f, %f) instead.\n",
-         png24.getPixelR(0, 1), png24.getPixelG(0, 1), png24.getPixelB(0, 1));
+         (double)png24.getPixelR(0, 1), (double)png24.getPixelG(0, 1), (double)png24.getPixelB(0, 1));
    pvErrorIf(!br, "Failed (Bottom Right). Expected (1.0, 1.0, 1.0), found (%f, %f, %f) instead.\n",
-         png24.getPixelR(1, 1), png24.getPixelG(1, 1), png24.getPixelB(1, 1));
+         (double)png24.getPixelR(1, 1), (double)png24.getPixelG(1, 1), (double)png24.getPixelB(1, 1));
 }
 
 // Image;:Image(filename.png32)
@@ -69,12 +69,12 @@ void testPng32Load() {
    bool br =   png32.getPixelA(1, 1) == 0.0f;
 
    pvErrorIf(!tl, "Failed (Top Left). Expected (1.0, 0.0, 0.0, 1.0), found (%f, %f, %f, %f) instead.\n",
-         png32.getPixelR(0, 0), png32.getPixelG(0, 0), png32.getPixelB(0, 0), png32.getPixelA(0, 0));
+         (double)png32.getPixelR(0, 0), (double)png32.getPixelG(0, 0), (double)png32.getPixelB(0, 0), (double)png32.getPixelA(0, 0));
    pvErrorIf(!tr, "Failed (Top Right). Expected (0.0, 1.0, 0.0, 1.0), found (%f, %f, %f, %f) instead.\n",
-         png32.getPixelR(1, 0), png32.getPixelG(1, 0), png32.getPixelB(1, 0), png32.getPixelA(1, 0));
+         (double)png32.getPixelR(1, 0), (double)png32.getPixelG(1, 0), (double)png32.getPixelB(1, 0), (double)png32.getPixelA(1, 0));
    pvErrorIf(!bl, "Failed (Bottom Left). Expected (0.0, 0.0, 1.0, 1.0), found (%f, %f, %f, %f) instead.\n",
-         png32.getPixelR(0, 1), png32.getPixelG(0, 1), png32.getPixelB(0, 1), png32.getPixelA(0, 1));
-   pvErrorIf(!br, "Failed (Bottom Right). Expected A = 0.0, found %f instead.\n", png32.getPixelA(1, 1));
+         (double)png32.getPixelR(0, 1), (double)png32.getPixelG(0, 1), (double)png32.getPixelB(0, 1), (double)png32.getPixelA(0, 1));
+   pvErrorIf(!br, "Failed (Bottom Right). Expected A = 0.0, found %f instead.\n", (double)png32.getPixelA(1, 1));
 }
 
 // Image::Image(filename.jpg)
@@ -108,13 +108,13 @@ void testJpgLoad() {
             && jpg.getPixelB(1, 1) >= 0.9f;
 
    pvErrorIf(!tl, "Failed (Top Left). Expected values within 0.1 of (1.0, 0.0, 0.0), found (%f, %f, %f) instead.\n",
-         jpg.getPixelR(0, 0), jpg.getPixelG(0, 0), jpg.getPixelB(0, 0));
+         (double)jpg.getPixelR(0, 0), (double)jpg.getPixelG(0, 0), (double)jpg.getPixelB(0, 0));
    pvErrorIf(!tr, "Failed (Top Right). Expected values within 0.1 of (0.0, 1.0, 0.0), found (%f, %f, %f) instead.\n",
-         jpg.getPixelR(1, 0), jpg.getPixelG(1, 0), jpg.getPixelB(1, 0));
+         (double)jpg.getPixelR(1, 0), (double)jpg.getPixelG(1, 0), (double)jpg.getPixelB(1, 0));
    pvErrorIf(!bl, "Failed (Bottom Left). Expected values within 0.1 of (0.0, 0.0, 1.0), found (%f, %f, %f) instead.\n",
-         jpg.getPixelR(0, 1), jpg.getPixelG(0, 1), jpg.getPixelB(0, 1));
+         (double)jpg.getPixelR(0, 1), (double)jpg.getPixelG(0, 1), (double)jpg.getPixelB(0, 1));
    pvErrorIf(!br, "Failed (Bottom Right). Expected values within 0.1 of (1.0, 1.0, 1.0), found (%f, %f, %f) instead.\n",
-         jpg.getPixelR(1, 1), jpg.getPixelG(1, 1), jpg.getPixelB(1, 1));
+         (double)jpg.getPixelR(1, 1), (double)jpg.getPixelG(1, 1), (double)jpg.getPixelB(1, 1));
 }
 
 // Image::Image(filename.bmp)
@@ -143,13 +143,13 @@ void testBmpLoad() {
             && bmp.getPixelB(1, 1) == 1.0f;
 
    pvErrorIf(!tl, "Failed (Top Left). Expected (1.0, 0.0, 0.0), found (%f, %f, %f) instead.\n",
-         bmp.getPixelR(0, 0), bmp.getPixelG(0, 0), bmp.getPixelB(0, 0));
+         (double)bmp.getPixelR(0, 0), (double)bmp.getPixelG(0, 0), (double)bmp.getPixelB(0, 0));
    pvErrorIf(!tr, "Failed (Top Right). Expected (0.0, 1.0, 0.0), found (%f, %f, %f) instead.\n",
-         bmp.getPixelR(1, 0), bmp.getPixelG(1, 0), bmp.getPixelB(1, 0));
+         (double)bmp.getPixelR(1, 0), (double)bmp.getPixelG(1, 0), (double)bmp.getPixelB(1, 0));
    pvErrorIf(!bl, "Failed (Bottom Left). Expected (0.0, 0.0, 1.0), found (%f, %f, %f) instead.\n",
-         bmp.getPixelR(0, 1), bmp.getPixelG(0, 1), bmp.getPixelB(0, 1));
+         (double)bmp.getPixelR(0, 1), (double)bmp.getPixelG(0, 1), (double)bmp.getPixelB(0, 1));
    pvErrorIf(!br, "Failed (Bottom Right). Expected (1.0, 1.0, 1.0), found (%f, %f, %f) instead.\n",
-         bmp.getPixelR(1, 1), bmp.getPixelG(1, 1), bmp.getPixelB(1, 1));
+         (double)bmp.getPixelR(1, 1), (double)bmp.getPixelG(1, 1), (double)bmp.getPixelB(1, 1));
 }
 
 // Image::convertToColor(bool alphaChannel)
@@ -169,19 +169,19 @@ void testConvertToGray() {
 
       pvErrorIf(img.getPixelR(0, 0) != Image::mRToGray,
             "Failed (Top Left). Expected %f, found %f.\n",
-            Image::mRToGray, img.getPixelR(0, 0));
+            (double)Image::mRToGray, (double)img.getPixelR(0, 0));
 
       pvErrorIf(img.getPixelR(1, 0) != Image::mGToGray,
             "Failed (Top Right). Expected %f, found %f.\n",
-            Image::mGToGray, img.getPixelR(1, 0));
+            (double)Image::mGToGray, (double)img.getPixelR(1, 0));
 
        pvErrorIf(img.getPixelR(0, 1) != Image::mBToGray,
             "Failed (Bottom Left). Expected %f, found %f.\n",
-            Image::mBToGray, img.getPixelR(0, 1));
+            (double)Image::mBToGray, (double)img.getPixelR(0, 1));
 
        pvErrorIf(img.getPixelR(1, 1) != 1.0f,
             "Failed (Bottom Right). Expected 1.0, found %f.\n",
-            img.getPixelR(1, 1));
+            (double)img.getPixelR(1, 1));
    }
 
    {
@@ -192,19 +192,19 @@ void testConvertToGray() {
 
       pvErrorIf(img.getPixelR(0, 0) != Image::mRToGray,
             "Failed (Top Left). Expected %f, found %f.\n",
-            Image::mRToGray, img.getPixelR(0, 0));
+            (double)Image::mRToGray, (double)img.getPixelR(0, 0));
 
       pvErrorIf(img.getPixelR(1, 0) != Image::mGToGray,
             "Failed (Top Right). Expected %f, found %f.\n",
-            Image::mGToGray, img.getPixelR(1, 0));
+            Image::mGToGray, (double)img.getPixelR(1, 0));
 
        pvErrorIf(img.getPixelR(0, 1) != Image::mBToGray,
             "Failed (Bottom Left). Expected %f, found %f.\n",
-            Image::mBToGray, img.getPixelR(0, 1));
+            (double)Image::mBToGray, img.getPixelR(0, 1));
 
        pvErrorIf(img.getPixelG(1, 1) != 0.0f,
             "Failed (Bottom Right). Expected 0.0, found %f.\n",
-            img.getPixelG(1, 1));
+            (double)img.getPixelG(1, 1));
    }
 }
 
@@ -219,19 +219,19 @@ void testConvertToColor() {
 
       pvErrorIf(img.getPixelR(0, 0) != Image::mRToGray,
             "Failed (Top Left). Expected R = %f, found %f.\n",
-            Image::mRToGray, img.getPixelR(0, 0));
+            (double)Image::mRToGray, (double)img.getPixelR(0, 0));
 
       pvErrorIf(img.getPixelG(1, 0) != Image::mGToGray,
             "Failed (Top Right). Expected G = %f, found %f.\n",
-            Image::mGToGray, img.getPixelG(1, 0));
+            (double)Image::mGToGray, (double)img.getPixelG(1, 0));
 
        pvErrorIf(img.getPixelB(0, 1) != Image::mBToGray,
             "Failed (Bottom Left). Expected B = %f, found %f.\n",
-            Image::mBToGray, img.getPixelB(0, 1));
+            (double)Image::mBToGray, (double)img.getPixelB(0, 1));
 
        pvErrorIf(img.getPixelR(1, 1) != 1.0f || img.getPixelG(1, 1) != 1.0f || img.getPixelB(1, 1) != 1.0f,
             "Failed (Bottom Right). Expected (1.0, 1.0, 1.0), found (%f, %f, %f).\n",
-            img.getPixelR(1, 1), img.getPixelG(1, 1), img.getPixelB(1, 1));
+            (double)img.getPixelR(1, 1), (double)img.getPixelG(1, 1), (double)img.getPixelB(1, 1));
    }
 
    {
@@ -242,19 +242,19 @@ void testConvertToColor() {
 
       pvErrorIf(img.getPixelR(0, 0) != Image::mRToGray,
             "Failed (Top Left). Expected %f, found %f.\n",
-            Image::mRToGray, img.getPixelR(0, 0));
+            (double)Image::mRToGray, (double)img.getPixelR(0, 0));
 
       pvErrorIf(img.getPixelG(1, 0) != Image::mGToGray,
             "Failed (Top Right). Expected %f, found %f.\n",
-            Image::mGToGray, img.getPixelG(1, 0));
+            (double)Image::mGToGray, (double)img.getPixelG(1, 0));
 
        pvErrorIf(img.getPixelB(0, 1) != Image::mBToGray,
             "Failed (Bottom Left). Expected %f, found %f.\n",
-            Image::mBToGray, img.getPixelB(0, 1));
+            (double)Image::mBToGray, (double)img.getPixelB(0, 1));
 
        pvErrorIf(img.getPixelA(1, 1) != 0.0f,
             "Failed (Bottom Right). Expected 0.0, found %f.\n",
-            img.getPixelA(1, 1));
+            (double)img.getPixelA(1, 1));
    }
 }
 

--- a/tests/InitWeightsTest/src/HyPerConnDebugInitWeights.cpp
+++ b/tests/InitWeightsTest/src/HyPerConnDebugInitWeights.cpp
@@ -142,10 +142,10 @@ int HyPerConnDebugInitWeights::smartWeights(PVPatch * wp, pvdata_t * dataStart, 
 PVPatch ** HyPerConnDebugInitWeights::initializeCocircWeights(PVPatch ** patches, pvdata_t * dataStart, int numDataPatches)
 {
    PVParams * params = parent->parameters();
-   float aspect = 1.0; // circular (not line oriented)
-   float sigma = 0.8;
-   float rMax = 1.4;
-   float strength = 1.0;
+   float aspect = 1.0f; // circular (not line oriented)
+   float sigma = 0.8f;
+   float rMax = 1.4f;
+   float strength = 1.0f;
 
    aspect = params->value(name, "aspect", aspect);
    sigma = params->value(name, "sigma", sigma);
@@ -172,17 +172,17 @@ PVPatch ** HyPerConnDebugInitWeights::initializeCocircWeights(PVPatch ** patches
    pvErrorIf(!(noPost > 0), "Test failed.\n");
    pvErrorIf(!(noPost <= post->getLayerLoc()->nf), "Test failed.\n");
 
-   float sigma_cocirc = PI / 2.0;
+   float sigma_cocirc = PI / 2.0f;
    sigma_cocirc = params->value(name, "sigmaCocirc", sigma_cocirc);
 
-   float sigma_kurve = 1.0; // fraction of delta_radius_curvature
+   float sigma_kurve = 1.0f; // fraction of delta_radius_curvature
    sigma_kurve = params->value(name, "sigmaKurve", sigma_kurve);
 
    // sigma_chord = % of PI * R, where R == radius of curvature (1/curvature)
-   float sigma_chord = 0.5;
+   float sigma_chord = 0.5f;
    sigma_chord = params->value(name, "sigmaChord", sigma_chord);
 
-   float delta_theta_max = PI / 2.0;
+   float delta_theta_max = PI / 2.0f;
    delta_theta_max = params->value(name, "deltaThetaMax", delta_theta_max);
 
    float cocirc_self = (pre != post);
@@ -190,7 +190,7 @@ PVPatch ** HyPerConnDebugInitWeights::initializeCocircWeights(PVPatch ** patches
 
    // from pv_common.h
    // // DK (1.0/(6*(NK-1)))   /*1/(sqrt(DX*DX+DY*DY)*(NK-1))*/         //  change in curvature
-   float delta_radius_curvature = 1.0; // 1 = minimum radius of curvature
+   float delta_radius_curvature = 1.0f; // 1 = minimum radius of curvature
    delta_radius_curvature = params->value(name, "deltaRadiusCurvature",
          delta_radius_curvature);
 
@@ -304,8 +304,8 @@ int HyPerConnDebugInitWeights::cocircCalcWeights(PVPatch * wp, pvdata_t * dataSt
    const int nKurvePost = post->getLayerLoc()->nf / noPost;
    const float dThPre = PI / noPre;
    const float dThPost = PI / noPost;
-   const float th0Pre = rotate * dThPre / 2.0;
-   const float th0Post = rotate * dThPost / 2.0;
+   const float th0Pre = rotate * dThPre / 2.0f;
+   const float th0Post = rotate * dThPost / 2.0f;
    const int iThPre = dataPatchIndex % noPre;
    //const int iThPre = kfPre / nKurvePre;
    const float thetaPre = th0Pre + iThPre * dThPre;
@@ -331,7 +331,7 @@ int HyPerConnDebugInitWeights::cocircCalcWeights(PVPatch * wp, pvdata_t * dataSt
    float sigma_kurve_pre = sigma_kurve * radKurvPre;
    float sigma_kurve_pre2 = 2 * sigma_kurve_pre * sigma_kurve_pre;
    sigma_chord *= PI * radKurvPre;
-   float sigma_chord2 = 2.0 * sigma_chord * sigma_chord;
+   float sigma_chord2 = 2.0f * sigma_chord * sigma_chord;
 
 
 
@@ -366,7 +366,7 @@ int HyPerConnDebugInitWeights::cocircCalcWeights(PVPatch * wp, pvdata_t * dataSt
       float sigma_kurve_post2 = 2 * sigma_kurve_post * sigma_kurve_post;
 
       float deltaTheta = fabsf(thetaPre - thetaPost);
-      deltaTheta = (deltaTheta <= PI / 2.0) ? deltaTheta : PI - deltaTheta;
+      deltaTheta = (deltaTheta <= PI / 2.0f) ? deltaTheta : PI - deltaTheta;
       if (deltaTheta > delta_theta_max) {
          continue;
       }
@@ -376,11 +376,11 @@ int HyPerConnDebugInitWeights::cocircCalcWeights(PVPatch * wp, pvdata_t * dataSt
          for (int iPost = 0; iPost < nxPatch_tmp; iPost++) {
             float xDelta = (xDistHeadPreUnits + iPost * dxPost);
 
-            float gDist = 0.0;
-            float gChord = 1.0;
-            float gCocirc = 1.0;
-            float gKurvePre = 1.0;
-            float gKurvePost = 1.0;
+            float gDist = 0.0f;
+            float gChord = 1.0f;
+            float gCocirc = 1.0f;
+            float gKurvePre = 1.0f;
+            float gKurvePost = 1.0f;
 
             // rotate the reference frame by th
             float dxP = +xDelta * cosf(thetaPre) + yDelta * sinf(thetaPre);
@@ -401,13 +401,13 @@ int HyPerConnDebugInitWeights::cocircCalcWeights(PVPatch * wp, pvdata_t * dataSt
                   gDist += expf(-d2_shift2 / sigma2);
                }
             }
-            if (gDist == 0.0) continue;
+            if (gDist == 0.0f) continue;
             if (d2 == 0) {
                bool sameLoc = (kfPre == kfPost);
                if ((!sameLoc) || (cocirc_self)) {
                   gCocirc = sigma_cocirc > 0 ? expf(-deltaTheta * deltaTheta
                         / sigma_cocirc2) : expf(-deltaTheta * deltaTheta / sigma_cocirc2)
-                        - 1.0;
+                        - 1.0f;
                   if ((nKurvePre > 1) && (nKurvePost > 1)) {
                      gKurvePre = expf(-(kurvePre - kurvePost) * (kurvePre - kurvePost)
                            / 2 * (sigma_kurve_pre * sigma_kurve_pre + sigma_kurve_post
@@ -415,24 +415,24 @@ int HyPerConnDebugInitWeights::cocircCalcWeights(PVPatch * wp, pvdata_t * dataSt
                   }
                }
                else { // sameLoc && !cocircSelf
-                  gCocirc = 0.0;
+                  gCocirc = 0.0f;
                   continue;
                }
             }
             else { // d2 > 0
 
-               float atanx2_shift = thetaPre + 2. * atan2f(dyP_shift, dxP); // preferred angle (rad)
-               atanx2_shift += 2. * PI;
+               float atanx2_shift = thetaPre + 2.0f * atan2f(dyP_shift, dxP); // preferred angle (rad)
+               atanx2_shift += 2.0f * PI;
                atanx2_shift = fmodf(atanx2_shift, PI);
                atanx2_shift = fabsf(atanx2_shift - thetaPost);
                float chi_shift = atanx2_shift; //fabsf(atanx2_shift - thetaPost); // radians
-               if (chi_shift >= PI / 2.0) {
+               if (chi_shift >= PI / 2.0f) {
                   chi_shift = PI - chi_shift;
                }
                if (noPre > 1 && noPost > 1) {
                   gCocirc = sigma_cocirc2 > 0 ? expf(-chi_shift * chi_shift
                         / sigma_cocirc2) : expf(-chi_shift * chi_shift / sigma_cocirc2)
-                        - 1.0;
+                        - 1.0f;
                }
 
                // compute curvature of cocircular contour
@@ -466,32 +466,32 @@ int HyPerConnDebugInitWeights::cocircCalcWeights(PVPatch * wp, pvdata_t * dataSt
                   }
                } // POS_KURVE_FLAG
                gKurvePre = (nKurvePre > 1) ? expf(-powf((cocircKurve_shift - fabsf(
-                     kurvePre)), 2) / sigma_kurve_pre2) : 1.0;
+                     kurvePre)), 2) / sigma_kurve_pre2) : 1.0f;
                gKurvePost
                = ((nKurvePre > 1) && (nKurvePost > 1) && (sigma_cocirc2 > 0)) ? expf(
                      -powf((cocircKurve_shift - fabsf(kurvePost)), 2)
                      / sigma_kurve_post2)
-                     : 1.0;
+                     : 1.0f;
 
                // compute distance along contour
                float d_chord_shift = (cocircKurve_shift != 0.0f) ? atanx2_shift
-                     / cocircKurve_shift : sqrt(d2_shift);
+                     / cocircKurve_shift : sqrtf(d2_shift);
                gChord = (nKurvePre > 1) ? expf(-powf(d_chord_shift, 2) / sigma_chord2)
-                     : 1.0;
+                     : 1.0f;
 
                if (numFlanks > 1) {
-                  float atanx2_shift2 = thetaPre + 2. * atan2f(dyP_shift2, dxP); // preferred angle (rad)
-                  atanx2_shift2 += 2. * PI;
+                  float atanx2_shift2 = thetaPre + 2.0f * atan2f(dyP_shift2, dxP); // preferred angle (rad)
+                  atanx2_shift2 += 2.0f * PI;
                   atanx2_shift2 = fmodf(atanx2_shift2, PI);
                   atanx2_shift2 = fabsf(atanx2_shift2 - thetaPost);
                   float chi_shift2 = atanx2_shift2; //fabsf(atanx2_shift2 - thetaPost); // radians
-                  if (chi_shift2 >= PI / 2.0) {
+                  if (chi_shift2 >= PI / 2.0f) {
                      chi_shift2 = PI - chi_shift2;
                   }
                   if (noPre > 1 && noPost > 1) {
                      gCocirc += sigma_cocirc2 > 0 ? expf(-chi_shift2 * chi_shift2
                            / sigma_cocirc2) : expf(-chi_shift2 * chi_shift2
-                                 / sigma_cocirc2) - 1.0;
+                                 / sigma_cocirc2) - 1.0f;
                   }
 
                   float cocircKurve_shift2 = d2_shift2 > 0 ? fabsf(2 * dyP_shift2)
@@ -523,15 +523,15 @@ int HyPerConnDebugInitWeights::cocircCalcWeights(PVPatch * wp, pvdata_t * dataSt
                      } // SADDLE_FLAG
                   } // POS_KURVE_FLAG
                   gKurvePre += (nKurvePre > 1) ? expf(-powf((cocircKurve_shift2 - fabsf(
-                        kurvePre)), 2) / sigma_kurve_pre2) : 1.0;
+                        kurvePre)), 2) / sigma_kurve_pre2) : 1.0f;
                   gKurvePost += ((nKurvePre > 1) && (nKurvePost > 1) && (sigma_cocirc2
                         > 0)) ? expf(-powf((cocircKurve_shift2 - fabsf(kurvePost)), 2)
-                              / sigma_kurve_post2) : 1.0;
+                              / sigma_kurve_post2) : 1.0f;
 
                   float d_chord_shift2 = cocircKurve_shift2 != 0.0f ? atanx2_shift2
-                        / cocircKurve_shift2 : sqrt(d2_shift2);
+                        / cocircKurve_shift2 : sqrtf(d2_shift2);
                   gChord += (nKurvePre > 1) ? expf(-powf(d_chord_shift2, 2) / sigma_chord2)
-                        : 1.0;
+                        : 1.0f;
 
                }
             }
@@ -543,35 +543,6 @@ int HyPerConnDebugInitWeights::cocircCalcWeights(PVPatch * wp, pvdata_t * dataSt
       }
    }
 
-   // copy weights from full sized temporary patch to (possibly shrunken) patch
-   // copyToWeightPatch(wp_tmp, 0, kPre);
-/*
-   w = wp->data;
-   const int nxunshrunkPatch = wp_tmp->nx;
-   const int nyunshrunkPatch = wp_tmp->ny;
-   const int nfunshrunkPatch = fPatchSize();
-   const int unshrunkPatchSize = nxunshrunkPatch*nyunshrunkPatch*nfunshrunkPatch;
-   pvdata_t *wtop = this->getPatchDataStart(0);
-   //pvdata_t * data_head = &wtop[unshrunkPatchSize*kPre];
-   //pvdata_t * data_head = (pvdata_t *) ((char*) wp + sizeof(PVPatch));
-   //size_t data_offset = w - data_head;
-   pvdata_t * data_head1 = &wtop[unshrunkPatchSize*kPre]; // (pvdata_t *) ((char*) wp + sizeof(PVPatch));
-   pvdata_t * data_head2 = (pvdata_t *) ((char*) wp + sizeof(PVPatch));
-   size_t data_offset1 = w - data_head1;
-   size_t data_offset2 = w - data_head2;
-   size_t data_offset = fabs(data_offset1) < fabs(data_offset2) ? data_offset1 : data_offset2;
-   w_tmp = &wp_tmp->data[data_offset];
-   int nk = nxPatch * nfPatch;
-   for (int ky = 0; ky < nyPatch; ky++) {
-      for (int iWeight = 0; iWeight < nk; iWeight++) {
-         w[iWeight] = w_tmp[iWeight];
-      }
-      w += sy;
-      w_tmp += sy_tmp;
-   }
-*/
-
-   // free(wp_tmp);
    return 0;
 
 }
@@ -582,13 +553,13 @@ PVPatch ** HyPerConnDebugInitWeights::initializeGaussian2DWeights(PVPatch ** pat
 
    // default values (chosen for center on cell of one pixel)
    int noPost = nfp;
-   float aspect = 1.0; // circular (not line oriented)
-   float sigma = 0.8;
-   float rMax = 1.4;
-   float rMin = 1.4;
-   float strength = 1.0;
+   float aspect = 1.0f; // circular (not line oriented)
+   float sigma = 0.8f;
+   float rMax = 1.4f;
+   float rMin = 1.4f;
+   float strength = 1.0f;
    float deltaThetaMax = 2.0f * PI;  // max difference in orientation between pre and post
-   float thetaMax = 1.0;  // max orientation in units of PI
+   float thetaMax = 1.0f;  // max orientation in units of PI
    int numFlanks = 1;
    float shift = 0.0f;
    float rotate = 0.0f;   // rotate so that axis isn't aligned
@@ -737,7 +708,7 @@ int HyPerConnDebugInitWeights::gauss2DCalcWeights(PVPatch * wp, pvdata_t * dataS
          thPost = thPre;
       }
       //TODO: add additional weight factor for difference between thPre and thPost
-      if (fabs(thPre - thPost) > deltaThetaMax) {
+      if (fabsf(thPre - thPost) > deltaThetaMax) {
          continue;
       }
       for (int jPost = 0; jPost < nyPatch_tmp; jPost++) {
@@ -782,36 +753,6 @@ int HyPerConnDebugInitWeights::gauss2DCalcWeights(PVPatch * wp, pvdata_t * dataS
          }
       }
    }
-
-   // copy weights from full sized temporary patch to (possibly shrunken) patch
-   // copyToWeightPatch(wp_tmp, 0, kPre);
-/*
-   w = wp->data;
-   const int nxunshrunkPatch = wp_tmp->nx;
-   const int nyunshrunkPatch = wp_tmp->ny;
-   const int nfunshrunkPatch = fPatchSize();
-   const int unshrunkPatchSize = nxunshrunkPatch*nyunshrunkPatch*nfunshrunkPatch;
-   pvdata_t *wtop = this->getPatchDataStart(0);
-   //pvdata_t * data_head = &wtop[unshrunkPatchSize*kPre];
-   //pvdata_t * data_head =  (pvdata_t *) ((char*) wp + sizeof(PVPatch));
-   //size_t data_offset = w - data_head;
-   pvdata_t * data_head1 = &wtop[unshrunkPatchSize*kPre]; // (pvdata_t *) ((char*) wp + sizeof(PVPatch));
-   pvdata_t * data_head2 = (pvdata_t *) ((char*) wp + sizeof(PVPatch));
-   size_t data_offset1 = w - data_head1;
-   size_t data_offset2 = w - data_head2;
-   size_t data_offset = fabs(data_offset1) < fabs(data_offset2) ? data_offset1 : data_offset2;
-   w_tmp = &wp_tmp->data[data_offset];
-   int nk = nxPatch * nfPatch;
-   for (int ky = 0; ky < nyPatch; ky++) {
-      for (int iWeight = 0; iWeight < nk; iWeight++) {
-         w[iWeight] = w_tmp[iWeight];
-      }
-      w += sy;
-      w_tmp += sy_tmp;
-   }
-*/
-
-   // free(wp_tmp);
    return 0;
 }
 
@@ -823,11 +764,11 @@ PVPatch ** HyPerConnDebugInitWeights::initializeGaborWeights(PVPatch ** patches,
 
    PVParams * params = parent->parameters();
 
-   float aspect = 4.0;
-   float sigma  = 2.0;
-   float rMax   = 8.0;
-   float lambda = sigma/0.8;    // gabor wavelength
-   float strength = 1.0;
+   float aspect = 4.0f;
+   float sigma  = 2.0f;
+   float rMax   = 8.0f;
+   float lambda = sigma/0.8f;    // gabor wavelength
+   float strength = 1.0f;
    float phi = 0;
 
    aspect   = params->value(name, "aspect", aspect);
@@ -851,8 +792,8 @@ int HyPerConnDebugInitWeights::gaborWeights(PVPatch * wp, pvdata_t * dataStart, 
 {
    PVParams * params = parent->parameters();
 
-   float rotate = 1.0;
-   float invert = 0.0;
+   float rotate = 1.0f;
+   float invert = 0.0f;
    if (params->present(name, "rotate")) rotate = params->value(name, "rotate");
    if (params->present(name, "invert")) invert = params->value(name, "invert");
 
@@ -896,7 +837,7 @@ int HyPerConnDebugInitWeights::gaborWeights(PVPatch * wp, pvdata_t * dataStart, 
             float u2 = -xp * sinf(th) + yp * cosf(th);
 
             float factor = cos(2.0f*PI*u2/lambda + phi);
-            if (fabs(u2/lambda) > 3.0f/4.0f) factor = 0.0f;  // phase < 3*PI/2 (no second positive band)
+            if (fabsf(u2/lambda) > 3.0f/4.0f) factor = 0.0f;  // phase < 3*PI/2 (no second positive band)
             float d2 = u1 * u1 + (aspect*u2 * aspect*u2);
             float wt = factor * expf(-d2 / (2.0f*sigma*sigma));
 

--- a/tests/InitWeightsTest/src/InitGaborWeights.cpp
+++ b/tests/InitWeightsTest/src/InitGaborWeights.cpp
@@ -71,7 +71,7 @@ int InitGaborWeights::gaborWeights(pvwdata_t * dataStart, InitGaborWeightsParams
    int sx_tmp=weightParamPtr->getsx();
    int sy_tmp=weightParamPtr->getsy();
    int sf_tmp=weightParamPtr->getsf();
-   double r2Max=weightParamPtr->getr2Max();
+   float r2Max=weightParamPtr->getr2Max();
 
    float wMin = weightParamPtr->getWMin();
    float wMax = weightParamPtr->getWMax();
@@ -91,8 +91,8 @@ int InitGaborWeights::gaborWeights(pvwdata_t * dataStart, InitGaborWeightsParams
             float xp = +xDelta * cosf(thPost) + yDelta * sinf(thPost);
             float yp = -xDelta * sinf(thPost) + yDelta * cosf(thPost);
 
-            float factor = cos(2.0f*PI*yp/lambda + phi);
-            if (fabs(yp/lambda) > 3.0f/4.0f) factor = 0.0f;  // phase < 3*PI/2 (no second positive band)
+            float factor = cosf(2.0f*PI*yp/lambda + phi);
+            if (fabsf(yp/lambda) > 3.0f/4.0f) factor = 0.0f;  // phase < 3*PI/2 (no second positive band)
 
             float d2 = xp * xp + (aspect * (yp - shift) * aspect * (yp - shift));
             float wt = factor * expf(-d2 / (2.0f*sigma*sigma));

--- a/tests/InitWeightsTest/src/InitGaborWeightsParams.cpp
+++ b/tests/InitWeightsTest/src/InitGaborWeightsParams.cpp
@@ -25,10 +25,10 @@ InitGaborWeightsParams::~InitGaborWeightsParams()
 
 int InitGaborWeightsParams::initialize_base() {
 
-   aspect = 4.0; // circular (not line oriented)
-   sigma = 2.0;
-   rMax = 8.0;
-   strength = 1.0;
+   aspect = 4.0f; // circular (not line oriented)
+   sigma = 2.0f;
+   rMax = 8.0f;
+   strength = 1.0f;
    r2Max = rMax * rMax;
 
    //numFlanks = 1;
@@ -36,7 +36,7 @@ int InitGaborWeightsParams::initialize_base() {
    //rotate = 1.0f; // rotate so that axis isn't aligned
    setRotate(0.0f); // rotate so that axis isn't aligned
 
-   lambda = (int)(sigma/0.8);
+   lambda = (int)(sigma/0.8f);
    phi=0;
    invert=true;
 

--- a/tests/InitWeightsTest/src/InitWeightTestProbe.cpp
+++ b/tests/InitWeightsTest/src/InitWeightTestProbe.cpp
@@ -39,10 +39,10 @@ int InitWeightTestProbe::outputState(double timed)
       return 0;
    }
    for(int b = 0; b < parent->getNBatch(); b++){
-      if(timed>2.0f){
-         pvErrorIf(!((fMin[b]>-0.001)&&(fMin[b]<0.001)), "Test failed.\n");
-         pvErrorIf(!((fMax[b]>-0.001)&&(fMax[b]<0.001)), "Test failed.\n");
-         pvErrorIf(!((avg[b]>-0.001)&&(avg[b]<0.001)), "Test failed.\n");
+      if(timed>2.0){
+         pvErrorIf(!((fMin[b]>-0.001f)&&(fMin[b]<0.001f)), "Test failed.\n");
+         pvErrorIf(!((fMax[b]>-0.001f)&&(fMax[b]<0.001f)), "Test failed.\n");
+         pvErrorIf(!((avg[b]>-0.001f)&&(avg[b]<0.001f)), "Test failed.\n");
       }
    }
 

--- a/tests/InitWeightsTest/src/KernelConnDebugInitWeights.cpp
+++ b/tests/InitWeightsTest/src/KernelConnDebugInitWeights.cpp
@@ -101,32 +101,13 @@ PVPatch *** KernelConnDebugInitWeights::initializeWeights(PVPatch *** arbors, pv
            else if(( weightInitTypeStr!=0 )&&(!strcmp(weightInitTypeStr, "SmartWeight"))) {
                   initializeSmartWeights(NULL, arborStart, numKernelPatches);
            }
-//         else if(( weightInitTypeStr!=0 )&&(!strcmp(weightInitTypeStr, "UniformRandomWeight"))) {
-//            weightInitializer = new InitUniformRandomWeights();
-//         }
-//         else if(( weightInitTypeStr!=0 )&&(!strcmp(weightInitTypeStr, "GaussianRandomWeight"))) {
-//            weightInitializer = new InitGaussianRandomWeights();
-//         }
            else if(( weightInitTypeStr!=0 )&&(!strcmp(weightInitTypeStr, "GaborWeight"))) {
                    initializeGaborWeights(NULL, arborStart, numKernelPatches);
            }
-//         else if(( weightInitTypeStr!=0 )&&(!strcmp(weightInitTypeStr, "PoolWeight"))) {
-//            weightInitializer = new InitPoolWeights();
-//         }
-//         else if(( weightInitTypeStr!=0 )&&(!strcmp(weightInitTypeStr, "RuleWeight"))) {
-//            weightInitializer = new InitRuleWeights();
-//         }
-//         else if(( weightInitTypeStr!=0 )&&(!strcmp(weightInitTypeStr, "SubUnitWeight"))) {
-//            weightInitializer = new InitSubUnitWeights();
-//         }
-//         else if(( weightInitTypeStr!=0 )&&(!strcmp(weightInitTypeStr, "InitIdentWeight"))) {
-//            weightInitializer = new InitIdentWeights();
-//         }
            else if(( weightInitTypeStr!=0 )&&(!strcmp(weightInitTypeStr, "Gauss2DWeight"))) {
                    initializeGaussian2DWeights(NULL, arborStart, numKernelPatches);
            }
            else { //default is also Gauss2D
-              //pvWarn().printf("weightInitType not set or unrecognized.  Using default (2D Gaussian).\n");
               initializeGaussian2DWeights(NULL, arborStart, numKernelPatches);
            }
 
@@ -173,10 +154,10 @@ int KernelConnDebugInitWeights::smartWeights(pvdata_t * dataStart, int k)
 PVPatch ** KernelConnDebugInitWeights::initializeCocircWeights(PVPatch ** patches, pvdata_t * dataStart, int numPatches)
 {
    PVParams * params = parent->parameters();
-   float aspect = 1.0; // circular (not line oriented)
-   float sigma = 0.8;
-   float rMax = 1.4;
-   float strength = 1.0;
+   float aspect = 1.0f; // circular (not line oriented)
+   float sigma = 0.8f;
+   float rMax = 1.4f;
+   float strength = 1.0f;
 
    aspect = params->value(name, "aspect", aspect);
    sigma = params->value(name, "sigma", sigma);
@@ -203,17 +184,17 @@ PVPatch ** KernelConnDebugInitWeights::initializeCocircWeights(PVPatch ** patche
    pvErrorIf(!(noPost > 0), "Test failed.\n");
    pvErrorIf(!(noPost <= post->getLayerLoc()->nf), "Test failed.\n");
 
-   float sigma_cocirc = PI / 2.0;
+   float sigma_cocirc = PI / 2.0f;
    sigma_cocirc = params->value(name, "sigmaCocirc", sigma_cocirc);
 
-   float sigma_kurve = 1.0; // fraction of delta_radius_curvature
+   float sigma_kurve = 1.0f; // fraction of delta_radius_curvature
    sigma_kurve = params->value(name, "sigmaKurve", sigma_kurve);
 
    // sigma_chord = % of PI * R, where R == radius of curvature (1/curvature)
-   float sigma_chord = 0.5;
+   float sigma_chord = 0.5f;
    sigma_chord = params->value(name, "sigmaChord", sigma_chord);
 
-   float delta_theta_max = PI / 2.0;
+   float delta_theta_max = PI / 2.0f;
    delta_theta_max = params->value(name, "deltaThetaMax", delta_theta_max);
 
    float cocirc_self = (pre != post);
@@ -221,7 +202,7 @@ PVPatch ** KernelConnDebugInitWeights::initializeCocircWeights(PVPatch ** patche
 
    // from pv_common.h
    // // DK (1.0/(6*(NK-1)))   /*1/(sqrt(DX*DX+DY*DY)*(NK-1))*/         //  change in curvature
-   float delta_radius_curvature = 1.0; // 1 = minimum radius of curvature
+   float delta_radius_curvature = 1.0f; // 1 = minimum radius of curvature
    delta_radius_curvature = params->value(name, "deltaRadiusCurvature",
          delta_radius_curvature);
 
@@ -334,8 +315,8 @@ int KernelConnDebugInitWeights::cocircCalcWeights(pvdata_t * dataStart, int data
            const int nKurvePost = post->getLayerLoc()->nf / noPost;
            const float dThPre = PI / noPre;
            const float dThPost = PI / noPost;
-           const float th0Pre = rotate * dThPre / 2.0;
-           const float th0Post = rotate * dThPost / 2.0;
+           const float th0Pre = rotate * dThPre / 2.0f;
+           const float th0Post = rotate * dThPost / 2.0f;
            const int iThPre = dataPatchIndex % noPre;
            //const int iThPre = kfPre / nKurvePre;
            const float thetaPre = th0Pre + iThPre * dThPre;
@@ -361,7 +342,7 @@ int KernelConnDebugInitWeights::cocircCalcWeights(pvdata_t * dataStart, int data
            float sigma_kurve_pre = sigma_kurve * radKurvPre;
            float sigma_kurve_pre2 = 2 * sigma_kurve_pre * sigma_kurve_pre;
            sigma_chord *= PI * radKurvPre;
-           float sigma_chord2 = 2.0 * sigma_chord * sigma_chord;
+           float sigma_chord2 = 2.0f * sigma_chord * sigma_chord;
 
 
 
@@ -396,7 +377,7 @@ int KernelConnDebugInitWeights::cocircCalcWeights(pvdata_t * dataStart, int data
               float sigma_kurve_post2 = 2 * sigma_kurve_post * sigma_kurve_post;
 
               float deltaTheta = fabsf(thetaPre - thetaPost);
-              deltaTheta = (deltaTheta <= PI / 2.0) ? deltaTheta : PI - deltaTheta;
+              deltaTheta = (deltaTheta <= PI / 2.0f) ? deltaTheta : PI - deltaTheta;
               if (deltaTheta > delta_theta_max) {
                  continue;
               }
@@ -406,11 +387,11 @@ int KernelConnDebugInitWeights::cocircCalcWeights(pvdata_t * dataStart, int data
                  for (int iPost = 0; iPost < nxPatch_tmp; iPost++) {
                     float xDelta = (xDistHeadPreUnits + iPost * dxPost);
 
-                    float gDist = 0.0;
-                    float gChord = 1.0;
-                    float gCocirc = 1.0;
-                    float gKurvePre = 1.0;
-                    float gKurvePost = 1.0;
+                    float gDist = 0.0f;
+                    float gChord = 1.0f;
+                    float gCocirc = 1.0f;
+                    float gKurvePre = 1.0f;
+                    float gKurvePost = 1.0f;
 
                     // rotate the reference frame by th
                     float dxP = +xDelta * cosf(thetaPre) + yDelta * sinf(thetaPre);
@@ -431,13 +412,13 @@ int KernelConnDebugInitWeights::cocircCalcWeights(pvdata_t * dataStart, int data
                           gDist += expf(-d2_shift2 / sigma2);
                        }
                     }
-                    if (gDist == 0.0) continue;
+                    if (gDist == 0.0f) continue;
                     if (d2 == 0) {
                        bool sameLoc = (kfPre == kfPost);
                        if ((!sameLoc) || (cocirc_self)) {
                           gCocirc = sigma_cocirc > 0 ? expf(-deltaTheta * deltaTheta
                                 / sigma_cocirc2) : expf(-deltaTheta * deltaTheta / sigma_cocirc2)
-                                - 1.0;
+                                - 1.0f;
                           if ((nKurvePre > 1) && (nKurvePost > 1)) {
                              gKurvePre = expf(-(kurvePre - kurvePost) * (kurvePre - kurvePost)
                                    / 2 * (sigma_kurve_pre * sigma_kurve_pre + sigma_kurve_post
@@ -445,24 +426,24 @@ int KernelConnDebugInitWeights::cocircCalcWeights(pvdata_t * dataStart, int data
                           }
                        }
                        else { // sameLoc && !cocircSelf
-                          gCocirc = 0.0;
+                          gCocirc = 0.0f;
                           continue;
                        }
                     }
                     else { // d2 > 0
 
-                       float atanx2_shift = thetaPre + 2. * atan2f(dyP_shift, dxP); // preferred angle (rad)
-                       atanx2_shift += 2. * PI;
+                       float atanx2_shift = thetaPre + 2.0f * atan2f(dyP_shift, dxP); // preferred angle (rad)
+                       atanx2_shift += 2.0f * PI;
                        atanx2_shift = fmodf(atanx2_shift, PI);
                        atanx2_shift = fabsf(atanx2_shift - thetaPost);
                        float chi_shift = atanx2_shift; //fabsf(atanx2_shift - thetaPost); // radians
-                       if (chi_shift >= PI / 2.0) {
+                       if (chi_shift >= PI / 2.0f) {
                           chi_shift = PI - chi_shift;
                        }
                        if (noPre > 1 && noPost > 1) {
                           gCocirc = sigma_cocirc2 > 0 ? expf(-chi_shift * chi_shift
                                 / sigma_cocirc2) : expf(-chi_shift * chi_shift / sigma_cocirc2)
-                                - 1.0;
+                                - 1.0f;
                        }
 
                        // compute curvature of cocircular contour
@@ -496,32 +477,32 @@ int KernelConnDebugInitWeights::cocircCalcWeights(pvdata_t * dataStart, int data
                           }
                        } // POS_KURVE_FLAG
                        gKurvePre = (nKurvePre > 1) ? expf(-powf((cocircKurve_shift - fabsf(
-                             kurvePre)), 2) / sigma_kurve_pre2) : 1.0;
+                             kurvePre)), 2) / sigma_kurve_pre2) : 1.0f;
                        gKurvePost
                              = ((nKurvePre > 1) && (nKurvePost > 1) && (sigma_cocirc2 > 0)) ? expf(
                                    -powf((cocircKurve_shift - fabsf(kurvePost)), 2)
                                          / sigma_kurve_post2)
-                                   : 1.0;
+                                   : 1.0f;
 
                        // compute distance along contour
                        float d_chord_shift = (cocircKurve_shift != 0.0f) ? atanx2_shift
-                             / cocircKurve_shift : sqrt(d2_shift);
+                             / cocircKurve_shift : sqrtf(d2_shift);
                        gChord = (nKurvePre > 1) ? expf(-powf(d_chord_shift, 2) / sigma_chord2)
-                             : 1.0;
+                             : 1.0f;
 
                        if (numFlanks > 1) {
-                          float atanx2_shift2 = thetaPre + 2. * atan2f(dyP_shift2, dxP); // preferred angle (rad)
-                          atanx2_shift2 += 2. * PI;
+                          float atanx2_shift2 = thetaPre + 2.0f * atan2f(dyP_shift2, dxP); // preferred angle (rad)
+                          atanx2_shift2 += 2.0f * PI;
                           atanx2_shift2 = fmodf(atanx2_shift2, PI);
                           atanx2_shift2 = fabsf(atanx2_shift2 - thetaPost);
                           float chi_shift2 = atanx2_shift2; //fabsf(atanx2_shift2 - thetaPost); // radians
-                          if (chi_shift2 >= PI / 2.0) {
+                          if (chi_shift2 >= PI / 2.0f) {
                              chi_shift2 = PI - chi_shift2;
                           }
                           if (noPre > 1 && noPost > 1) {
                              gCocirc += sigma_cocirc2 > 0 ? expf(-chi_shift2 * chi_shift2
                                    / sigma_cocirc2) : expf(-chi_shift2 * chi_shift2
-                                   / sigma_cocirc2) - 1.0;
+                                   / sigma_cocirc2) - 1.0f;
                           }
 
                           float cocircKurve_shift2 = d2_shift2 > 0 ? fabsf(2 * dyP_shift2)
@@ -553,15 +534,15 @@ int KernelConnDebugInitWeights::cocircCalcWeights(pvdata_t * dataStart, int data
                              } // SADDLE_FLAG
                           } // POS_KURVE_FLAG
                           gKurvePre += (nKurvePre > 1) ? expf(-powf((cocircKurve_shift2 - fabsf(
-                                kurvePre)), 2) / sigma_kurve_pre2) : 1.0;
+                                kurvePre)), 2) / sigma_kurve_pre2) : 1.0f;
                           gKurvePost += ((nKurvePre > 1) && (nKurvePost > 1) && (sigma_cocirc2
                                 > 0)) ? expf(-powf((cocircKurve_shift2 - fabsf(kurvePost)), 2)
-                                / sigma_kurve_post2) : 1.0;
+                                / sigma_kurve_post2) : 1.0f;
 
                           float d_chord_shift2 = cocircKurve_shift2 != 0.0f ? atanx2_shift2
-                                / cocircKurve_shift2 : sqrt(d2_shift2);
+                                / cocircKurve_shift2 : sqrtf(d2_shift2);
                           gChord += (nKurvePre > 1) ? expf(-powf(d_chord_shift2, 2) / sigma_chord2)
-                                : 1.0;
+                                : 1.0f;
 
                        }
                     }
@@ -573,24 +554,6 @@ int KernelConnDebugInitWeights::cocircCalcWeights(pvdata_t * dataStart, int data
               }
            }
 
-           // copy weights from full sized temporary patch to (possibly shrunken) patch
-           // copyToKernelPatch(wp_tmp, 0, kPre);
-/*
-           w = wp->data;
-           pvdata_t * data_head = (pvdata_t *) ((char*) wp + sizeof(PVPatch));
-           size_t data_offset = w - data_head;
-           w_tmp = &wp_tmp->data[data_offset];
-           int nk = nxPatch * nfPatch;
-           for (int ky = 0; ky < nyPatch; ky++) {
-              for (int iWeight = 0; iWeight < nk; iWeight++) {
-                 w[iWeight] = w_tmp[iWeight];
-              }
-              w += sy;
-              w_tmp += sy_tmp;
-           }
-*/
-
-           // free(wp_tmp);
            return 0;
 
 }
@@ -757,7 +720,7 @@ int KernelConnDebugInitWeights::gauss2DCalcWeights(pvdata_t * dataStart, int dat
          thPost = thPre;
       }
       //TODO: add additional weight factor for difference between thPre and thPost
-      if (fabs(thPre - thPost) > deltaThetaMax) {
+      if (fabsf(thPre - thPost) > deltaThetaMax) {
          continue;
       }
       for (int jPost = 0; jPost < nyPatch_tmp; jPost++) {
@@ -803,24 +766,6 @@ int KernelConnDebugInitWeights::gauss2DCalcWeights(pvdata_t * dataStart, int dat
       }
    }
 
-   // copy weights from full sized temporary patch to (possibly shrunken) patch
-   // copyToKernelPatch(wp_tmp, 0, kPre);
-/*
-   w = wp->data;
-   pvdata_t * data_head =  (pvdata_t *) ((char*) wp + sizeof(PVPatch));
-   size_t data_offset = w - data_head;
-   w_tmp = &wp_tmp->data[data_offset];
-   int nk = nxPatch * nfPatch;
-   for (int ky = 0; ky < nyPatch; ky++) {
-      for (int iWeight = 0; iWeight < nk; iWeight++) {
-         w[iWeight] = w_tmp[iWeight];
-      }
-      w += sy;
-      w_tmp += sy_tmp;
-   }
-*/
-
-   // free(wp_tmp);
    return 0;
 }
 
@@ -832,11 +777,11 @@ PVPatch ** KernelConnDebugInitWeights::initializeGaborWeights(PVPatch ** patches
 
    PVParams * params = parent->parameters();
 
-   float aspect = 4.0;
-   float sigma  = 2.0;
-   float rMax   = 8.0;
-   float lambda = sigma/0.8;    // gabor wavelength
-   float strength = 1.0;
+   float aspect = 4.0f;
+   float sigma  = 2.0f;
+   float rMax   = 8.0f;
+   float lambda = sigma/0.8f;    // gabor wavelength
+   float strength = 1.0f;
    float phi = 0;
 
    aspect   = params->value(name, "aspect", aspect);
@@ -860,8 +805,8 @@ int KernelConnDebugInitWeights::gaborWeights(pvdata_t * dataStart, int xScale, i
 {
    PVParams * params = parent->parameters();
 
-   float rotate = 1.0;
-   float invert = 0.0;
+   float rotate = 1.0f;
+   float invert = 0.0f;
    if (params->present(name, "rotate")) rotate = params->value(name, "rotate");
    if (params->present(name, "invert")) invert = params->value(name, "invert");
 
@@ -905,7 +850,7 @@ int KernelConnDebugInitWeights::gaborWeights(pvdata_t * dataStart, int xScale, i
             float u2 = -xp * sinf(th) + yp * cosf(th);
 
             float factor = cos(2.0f*PI*u2/lambda + phi);
-            if (fabs(u2/lambda) > 3.0f/4.0f) factor = 0.0f;  // phase < 3*PI/2 (no second positive band)
+            if (fabsf(u2/lambda) > 3.0f/4.0f) factor = 0.0f;  // phase < 3*PI/2 (no second positive band)
             float d2 = u1 * u1 + (aspect*u2 * aspect*u2);
             float wt = factor * expf(-d2 / (2.0f*sigma*sigma));
 

--- a/tests/KernelActivationTest/src/KernelActivationTest.cpp
+++ b/tests/KernelActivationTest/src/KernelActivationTest.cpp
@@ -105,8 +105,8 @@ int dumponeweight(HyPerConn * conn) {
                //The pixel value from the input is actually 127, where we divide it by 255.
                //Not exaclty .5, a little less
                //Squared because both pre and post is grabbing it's activity from the image
-               pvdata_t correct = usingMirrorBCs ? pow(float(127)/float(255),2) : (float(127)/float(255)) * .5;
-               if( fabs(wgt-correct)>1.0e-5 ) {
+               pvdata_t correct = usingMirrorBCs ? powf(127.0f / 255.0f, 2.0f) : (127.0f / 255.0f) * 0.5f;
+               if( fabsf(wgt-correct)>1.0e-5f ) {
                   pvErrorNoExit(errorMessage);
                   if( errorfound == false ) {
                       errorfound = true;
@@ -114,7 +114,7 @@ int dumponeweight(HyPerConn * conn) {
                       errorMessage.printf("\n");
                       errorMessage.printf("Rank %d, %s:\n",rank, conn->getDescription_c());
                   }
-                  errorMessage.printf("Rank %d, Patch %d, x=%d, y=%d, f=%d: weight=%f, correct=%f, off by a factor of %f\n", rank, p, x, y, f, wgt, correct, wgt/correct);
+                  errorMessage.printf("Rank %d, Patch %d, x=%d, y=%d, f=%d: weight=%f, correct=%f, off by a factor of %f\n", rank, p, x, y, f, (double)wgt, (double)correct, (double)(wgt/correct));
                   status = PV_FAILURE;
                }
             }

--- a/tests/KernelTest/src/KernelTestProbe.cpp
+++ b/tests/KernelTest/src/KernelTestProbe.cpp
@@ -39,10 +39,10 @@ int KernelTestProbe::outputState(double timed)
       return 0;
    }
    for(int b = 0; b < parent->getNBatch(); b++){
-      if(timed>2.0f){
-         pvErrorIf(!((fMin[b]>0.99)&&(fMin[b]<1.010)), "Test failed.\n");
-         pvErrorIf(!((fMax[b]>0.99)&&(fMax[b]<1.010)), "Test failed.\n");
-         pvErrorIf(!((avg[b]>0.99)&&(avg[b]<1.010)), "Test failed.\n");
+      if(timed>2.0){
+         pvErrorIf(!((fMin[b]>0.99f)&&(fMin[b]<1.010f)), "Test failed.\n");
+         pvErrorIf(!((fMax[b]>0.99f)&&(fMax[b]<1.010f)), "Test failed.\n");
+         pvErrorIf(!((avg[b]>0.99f)&&(avg[b]<1.010f)), "Test failed.\n");
       }
    }
 

--- a/tests/LIFTest/src/LIFTestProbe.cpp
+++ b/tests/LIFTest/src/LIFTestProbe.cpp
@@ -110,19 +110,19 @@ int LIFTestProbe::outputState(double timed) {
    HyPerLayer * l = getTargetLayer();
    const PVLayerLoc * loc = l->getLayerLoc();
    int n = l->getNumNeurons();
-   double xctr = 0.5*(loc->nxGlobal-1) - loc->kx0;
-   double yctr = 0.5*(loc->nyGlobal-1) - loc->ky0;
+   float xctr = 0.5f*(loc->nxGlobal-1) - loc->kx0;
+   float yctr = 0.5f*(loc->nyGlobal-1) - loc->ky0;
    for (int j=0; j<LIFTESTPROBE_BINS; j++) {
       rates[j] = 0;
    }
    for (int k=0; k<n; k++) {
       int x = kxPos(k, loc->nx, loc->ny, loc->nf);
       int y = kyPos(k, loc->nx, loc->ny, loc->nf);
-      double r = sqrt((x-xctr)*(x-xctr) + (y-yctr)*(y-yctr));
-      int bin_number = (int) floor(r/5.0);
+      float r = sqrtf((x-xctr)*(x-xctr) + (y-yctr)*(y-yctr));
+      int bin_number = (int) floor(r/5.0f);
       bin_number -= bin_number > 0 ? 1 : 0;
       if (bin_number < LIFTESTPROBE_BINS) {
-         rates[bin_number] += l->getV()[k];
+         rates[bin_number] += (double)l->getV()[k];
       }
    }
    int root_proc = 0;
@@ -132,17 +132,17 @@ int LIFTestProbe::outputState(double timed) {
       pvInfo(dumpRates);
       dumpRates.printf("%s t=%f:", getMessage(), timed);
       for (int j=0; j<LIFTESTPROBE_BINS; j++) {
-         rates[j] /= counts[j]*timed/1000.0;
-         dumpRates.printf(" %f", rates[j]);
+         rates[j] /= (double)counts[j] * timed / 1000.0;
+         dumpRates.printf(" %f", (double)rates[j]);
       }
       dumpRates.printf("\n");
-      if (timed >= endingTime) {
+      if (timed >= (double)endingTime) {
          double stdfactor = sqrt(timed/2000.0); // Since the values of std are based on t=2000.
          for (int j=0; j<LIFTESTPROBE_BINS; j++) {
             double scaledstdev = stddevs[j]/stdfactor;
             double observed = (rates[j]-targetrates[j])/scaledstdev;
             if(fabs(observed)>tolerance) {
-               pvErrorNoExit().printf("Bin number %d failed at time %f: %f standard deviations off, with tolerance %f.\n", j, timed, observed, tolerance);
+               pvErrorNoExit().printf("Bin number %d failed at time %f: %f standard deviations off, with tolerance %f.\n", j, timed, observed, (double)tolerance);
                status = PV_FAILURE;
             }
          }

--- a/tests/LayerRestartTest/src/LayerRestartTest.cpp
+++ b/tests/LayerRestartTest/src/LayerRestartTest.cpp
@@ -130,7 +130,7 @@ int checkComparisonZero(HyPerCol * hc, int argc, char * argv[]) {
    pvdata_t * V = layer->getV();
    for( int k=0; k<layer->getNumNeurons(); k++ ) {
       if( V[k] ) {
-         pvErrorNoExit().printf("Neuron %d: discrepancy %f\n", k, V[k]);
+         pvErrorNoExit().printf("Neuron %d: discrepancy %f\n", k, (double)V[k]);
          status = PV_FAILURE;
       }
    }

--- a/tests/MPITest/src/MPITestProbe.cpp
+++ b/tests/MPITest/src/MPITestProbe.cpp
@@ -40,7 +40,7 @@ int MPITestProbe::outputState(double timed) {
    if( icComm->commRank() != rcvProc ) {
       return status;
    }
-   double tol = 1e-4f;
+   float tol = 1e-4f;
 
    // if many to one connection, each neuron should receive its global x/y/f position
    // if one to many connection, the position of the nearest sending cell is received
@@ -57,17 +57,17 @@ int MPITestProbe::outputState(double timed) {
    float max_global_xpos = xPosGlobal(kGlobal, xScaleLog2, nxGlobal, nyGlobal, nf);
 
    if (xScaleLog2 < 0) {
-      float xpos_shift = 0.5 - min_global_xpos;
-      min_global_xpos = 0.5;
+      float xpos_shift = 0.5f - min_global_xpos;
+      min_global_xpos = 0.5f;
       max_global_xpos -= xpos_shift;
    }
    float ave_global_xpos = (min_global_xpos + max_global_xpos) / 2.0f;
 
    outputStream->printf("%s min_global_xpos==%f ave_global_xpos==%f max_global_xpos==%f",
-         getMessage(), min_global_xpos, ave_global_xpos, max_global_xpos);
+         getMessage(), (double)min_global_xpos, (double)ave_global_xpos, (double)max_global_xpos);
    output() << std::endl;
    for(int b = 0; b < parent->getNBatch(); b++){
-      if (timed > 3.0f) {
+      if (timed > 3.0) {
          pvErrorIf(!((fMin[b]/min_global_xpos > (1 - tol)) && (fMin[b]/min_global_xpos < (1 + tol))), "Test failed.\n");
          pvErrorIf(!((fMax[b]/max_global_xpos > (1 - tol)) && (fMax[b]/max_global_xpos < (1 + tol))), "Test failed.\n");
          pvErrorIf(!((avg[b]/ave_global_xpos > (1 - tol)) && (avg[b]/ave_global_xpos < (1 + tol))), "Test failed.\n");

--- a/tests/MaxPoolTest/src/GateMaxPoolTestLayer.cpp
+++ b/tests/MaxPoolTest/src/GateMaxPoolTestLayer.cpp
@@ -37,10 +37,10 @@ int GateMaxPoolTestLayer::updateState(double timef, double dt){
       
       //Must be 25% active
       float percentActive = (float)numActive/getNumNeurons();
-      if(percentActive != .25){
+      if(percentActive != 0.25f){
          pvError() << "Percent active for " << name << " is " << percentActive << ", where expected is .25 at timestep " << timef << " for batch " << b << "\n";
       }
-      pvErrorIf(!(percentActive == .25), "Test failed.\n");
+      pvErrorIf(!(percentActive == 0.25f), "Test failed.\n");
    }
 
    if(!isCorrect){

--- a/tests/MomentumTest/src/MomentumConnTestProbe.cpp
+++ b/tests/MomentumTest/src/MomentumConnTestProbe.cpp
@@ -69,18 +69,18 @@ int MomentumConnTestProbe::outputState(double timed) {
          if(isViscosity){
             wCorrect = 1;
             for(int i = 0; i < (timed - 3); i++){
-               wCorrect += exp(-(2*(i+1)));
+               wCorrect += expf(-(2*(i+1)));
             }
          }
          else{
-            wCorrect = 2 - pow(2, -(timed - 3));
+            wCorrect = 2 - powf(2, -(timed - 3));
          }
       }
 
       if( fabs( ((double) (wObserved - wCorrect))/timed ) > 1e-4 ) {
          int y=kyPos(k,nxp,nyp,nfp);
          int f=featureIndex(k,nxp,nyp,nfp);
-         outputStream->printf("        w = %f, should be %f\n", wObserved, wCorrect);
+         outputStream->printf("        w = %f, should be %f\n", (double)wObserved, (double)wCorrect);
          exit(-1);
       }
    }

--- a/tests/NormalizeSubclassSystemTest/src/NormalizeL3.cpp
+++ b/tests/NormalizeSubclassSystemTest/src/NormalizeL3.cpp
@@ -58,7 +58,7 @@ int NormalizeL3::normalizeWeights() {
    if (normalizeArborsIndividually) {
       for (int arborID = 0; arborID<nArbors; arborID++) {
          for (int patchindex = 0; patchindex<numDataPatches; patchindex++) {
-            double sumcubed = 0.0;
+            float sumcubed = 0.0f;
             for (int c=0; c<numConnections; c++) {
                HyPerConn * conn = connectionList[c];
                int nxp = conn->xPatchSize();
@@ -73,10 +73,11 @@ int NormalizeL3::normalizeWeights() {
                   sumcubed += w*w*w;
                }
             }
-            double l3norm = pow(sumcubed, 1.0/3.0);
-            if (fabs(l3norm) <= minL3NormTolerated) {
-               pvWarn().printf("NormalizeL3 \"%s\": L^3 norm in patch %d of arbor %d is within minL3NormTolerated=%f of zero.  Weights in this patch unchanged.\n", getName(), patchindex, arborID, minL3NormTolerated);
-               break;
+            float l3norm = powf(sumcubed, 1.0f/3.0f);
+            if (fabsf(l3norm) <= minL3NormTolerated) {
+               pvWarn().printf("NormalizeL3 \"%s\": L^3 norm in patch %d of arbor %d is within minL3NormTolerated=%f of zero.  Weights in this patch unchanged.\n",
+                     getName(), patchindex, arborID, (double)minL3NormTolerated);
+               continue;
             }
             for (int c=0; c<numConnections; c++) {
                HyPerConn * conn = connectionList[c];
@@ -92,7 +93,7 @@ int NormalizeL3::normalizeWeights() {
    }
    else {
       for (int patchindex = 0; patchindex<numDataPatches; patchindex++) {
-         double sumcubed = 0.0;
+         float sumcubed = 0.0f;
          for (int arborID = 0; arborID<nArbors; arborID++) {
             for (int c=0; c<numConnections; c++) {
                HyPerConn * conn = connectionList[c];
@@ -109,10 +110,11 @@ int NormalizeL3::normalizeWeights() {
                }
             }
          }
-         double l3norm = pow(sumcubed, 1.0/3.0);
-         if (fabs(sumcubed) <= minL3NormTolerated) {
-            pvWarn().printf("NormalizeL3 \"%s\": sum of squares of weights in patch %d is within minL3NormTolerated=%f of zero.  Weights in this patch unchanged.\n", getName(), patchindex, minL3NormTolerated);
-            break;
+         float l3norm = powf(sumcubed, 1.0f/3.0f);
+         if (fabsf(sumcubed) <= minL3NormTolerated) {
+            pvWarn().printf("NormalizeL3 \"%s\": sum of squares of weights in patch %d is within minL3NormTolerated=%f of zero.  Weights in this patch unchanged.\n",
+                  getName(), patchindex, (double)minL3NormTolerated);
+            continue;
          }
          for (int arborID = 0; arborID<nArbors; arborID++) {
             for (int c=0; c<numConnections; c++) {

--- a/tests/NormalizeSystemTest/src/NormalizeSystemTest.cpp
+++ b/tests/NormalizeSystemTest/src/NormalizeSystemTest.cpp
@@ -16,7 +16,7 @@ int main(int argc, char * argv[]) {
 }
 
 int customexit(HyPerCol * hc, int argc, char * argv[]) {
-   float tol = 1e-5;
+   float tol = 1e-4;
 
    // check normalizeSum
    BaseConnection * baseConn;

--- a/tests/PlasticConnTest/src/PlasticConnTestProbe.cpp
+++ b/tests/PlasticConnTest/src/PlasticConnTestProbe.cpp
@@ -56,7 +56,7 @@ int PlasticConnTestProbe::outputState(double timed) {
          if( fabs( ((double) (wObserved - wCorrect))/timed ) > 1e-4 ) {
             int y=kyPos(k,nxp,nyp,nfp);
             int f=featureIndex(k,nxp,nyp,nfp);
-            outputStream->printf("        index %d (x=%d, y=%d, f=%d: w = %f, should be %f\n", k, x, y, f, wObserved, wCorrect);
+            outputStream->printf("        index %d (x=%d, y=%d, f=%d: w = %f, should be %f\n", k, x, y, f, (double)wObserved, (double)wCorrect);
          }
       }
       if(timed > 0 && getOutputPlasticIncr() && dw != NULL) {
@@ -65,7 +65,7 @@ int PlasticConnTestProbe::outputState(double timed) {
          if( dwObserved != dwCorrect ) {
             int y=kyPos(k,nxp,nyp,nfp);
             int f=featureIndex(k,nxp,nyp,nfp);
-            outputStream->printf("        index %d (x=%d, y=%d, f=%d: dw = %f, should be %f\n", k, x, y, f, dwObserved, dwCorrect);
+            outputStream->printf("        index %d (x=%d, y=%d, f=%d: dw = %f, should be %f\n", k, x, y, f, (double)dwObserved, (double)dwCorrect);
          }
       }
    }

--- a/tests/ReceiveFromPostTest/src/ReceiveFromPostProbe.cpp
+++ b/tests/ReceiveFromPostTest/src/ReceiveFromPostProbe.cpp
@@ -18,7 +18,7 @@ ReceiveFromPostProbe::ReceiveFromPostProbe(const char * probeName, HyPerCol * hc
 }
 
 int ReceiveFromPostProbe::initReceiveFromPostProbe_base() {
-   tolerance = (pvadata_t) 1e-3;
+   tolerance = (pvadata_t) 1e-3f;
    return PV_SUCCESS;
 }
 
@@ -46,16 +46,16 @@ int ReceiveFromPostProbe::outputState(double timed){
    int numExtNeurons = getTargetLayer()->getNumExtended();
    const pvdata_t * A = getTargetLayer()->getLayerData();
    for (int i = 0; i < numExtNeurons; i++){
-      if(fabs(A[i]) != 0){
+      if(fabsf(A[i]) != 0){
          int xpos = kxPos(i, loc->nx+loc->halo.lt+loc->halo.rt, loc->ny+loc->halo.dn+loc->halo.up, loc->nf);
          int ypos = kyPos(i, loc->nx+loc->halo.lt+loc->halo.rt, loc->ny+loc->halo.dn+loc->halo.up, loc->nf);
          int fpos = featureIndex(i, loc->nx+loc->halo.lt+loc->halo.rt, loc->ny+loc->halo.dn+loc->halo.up, loc->nf);
          //pvInfo() << "[" << xpos << "," << ypos << "," << fpos << "] = " << std::fixed << A[i] << "\n";
       }
       //For roundoff errors
-      if(fabs(A[i]) >= tolerance) {
+      if(fabsf(A[i]) >= tolerance) {
          pvErrorNoExit().printf("%s %s activity outside of tolerance %f: extended index %d has activity %f\n",
-               getMessage(), getTargetLayer()->getDescription_c(), tolerance, i, A[i]);
+               getMessage(), getTargetLayer()->getDescription_c(), (double)tolerance, i, (double)A[i]);
          status = PV_FAILURE;
       }
       if (status != PV_SUCCESS) {

--- a/tests/SegmentTest/src/AssertZerosProbe.cpp
+++ b/tests/SegmentTest/src/AssertZerosProbe.cpp
@@ -41,14 +41,7 @@ int AssertZerosProbe::outputState(double timed){
    //getOutputStream().precision(15);
    float sumsq = 0;
    for (int i = 0; i < numExtNeurons; i++){
-      //if(fabs(A[i]) != 0){
-      //   int xpos = kxPos(i, loc->nx+loc->halo.lt+loc->halo.rt, loc->ny+loc->halo.dn+loc->halo.up, loc->nf);
-      //   int ypos = kyPos(i, loc->nx+loc->halo.lt+loc->halo.rt, loc->ny+loc->halo.dn+loc->halo.up, loc->nf);
-      //   int fpos = featureIndex(i, loc->nx+loc->halo.lt+loc->halo.rt, loc->ny+loc->halo.dn+loc->halo.up, loc->nf);
-      //   pvInfo() << "[" << xpos << "," << ypos << "," << fpos << "] = " << std::fixed << A[i] << "\n";
-      //}
-      //For max difference roundoff errors
-      pvErrorIf(!(fabs(A[i]) < 5e-4), "Test failed.\n");
+      pvErrorIf(!(fabsf(A[i]) < 5e-4f), "Test failed.\n");
    }
 
    if(timed > 0){
@@ -66,7 +59,7 @@ int AssertZerosProbe::outputState(double timed){
 
    for(int b = 0; b < loc->nbatch; b++){
       //For max std of 5e-5
-      pvErrorIf(!(sigma[b] <= 5e-5), "Test failed.\n");
+      pvErrorIf(!(sigma[b] <= 5e-5f), "Test failed.\n");
    }
 
    return status;

--- a/tests/Shared/CPTestInputLayer.cpp
+++ b/tests/Shared/CPTestInputLayer.cpp
@@ -55,7 +55,7 @@ int CPTestInputLayer::allocateDataStructures() {
 }
 
 int CPTestInputLayer::initializeV() {
-   pvErrorIf(!(parent->parameters()->value(name, "restart", 0.0f, false)==0.0f), "Test failed.\n"); // initializeV should only be called if restart is false
+   pvErrorIf(!(parent->parameters()->value(name, "restart", 0.0, false) == 0.0), "Test failed.\n"); // initializeV should only be called if restart is false
    const PVLayerLoc * loc = getLayerLoc();
    for (int b = 0; b < parent->getNBatch(); b++){
       pvdata_t * VBatch = getV() + b * getNumNeurons();

--- a/tests/ShrunkenPatchTest/src/ShrunkenPatchTestProbe.cpp
+++ b/tests/ShrunkenPatchTest/src/ShrunkenPatchTestProbe.cpp
@@ -112,19 +112,19 @@ int ShrunkenPatchTestProbe::outputState(double timed) {
    pvErrorIf(!(correctValues!=NULL), "Test failed.\n");
 
    int status = StatsProbe::outputState(timed);
-   double tol = 1e-4f;
+   float tol = 1e-4f;
 
    const pvdata_t * buf = getTargetLayer()->getLayerData();
 
-   if (timed>=3.0f) {
+   if (timed>=3.0) {
       for (int k=0; k<num_neurons; k++) {
          int kex = kIndexExtended(k, loc->nx, loc->ny, loc->nf, loc->halo.lt, loc->halo.rt, loc->halo.dn, loc->halo.up);
          int x = kxPos(k,loc->nx, loc->ny, loc->nf);
-         if (fabs(buf[kex]-correctValues[x])>tol) {
+         if (fabsf(buf[kex]-correctValues[x])>tol) {
             int y = kyPos(k,loc->nx, loc->ny, loc->nf);
             int f = featureIndex(k,loc->nx,loc->ny,loc->nf);
             pvError().printf("%s: Incorrect value %f (should be %f) in process %d, x=%d, y=%d, f=%d\n",
-                  l->getDescription_c(), buf[kex], correctValues[x], getTargetLayer()->getParent()->columnId(), x, y, f);
+                  l->getDescription_c(), (double)buf[kex], (double)correctValues[x], getTargetLayer()->getParent()->columnId(), x, y, f);
          }
       }
    }

--- a/tests/StochasticReleaseTest/src/StochasticReleaseTestProbe.cpp
+++ b/tests/StochasticReleaseTest/src/StochasticReleaseTestProbe.cpp
@@ -134,7 +134,7 @@ int StochasticReleaseTestProbe::computePValues(long int step, int f) {
          }
       }
    }
-   preact *= getParent()->getDeltaTime();
+   preact *= (float)getParent()->getDeltaTime();
    if (preact < 0.0f) preact = 0.0f;
    if (preact > 1.0f) preact = 1.0f;
 

--- a/tests/SumPoolTest/src/SumPoolTestLayer.cpp
+++ b/tests/SumPoolTest/src/SumPoolTestLayer.cpp
@@ -39,8 +39,8 @@ int SumPoolTestLayer::updateState(double timef, double dt){
 
               //expectedValue is set for avg pool, multiply by patch size for actual answer
               float expectedvalue;
-              if(nxScale == .5){
-                 expectedvalue = iFeature * 64 + yval * 16 + xval * 2 + 4.5;
+              if(nxScale == 0.5f){
+                 expectedvalue = iFeature * 64 + yval * 16 + xval * 2 + 4.5f;
                  expectedvalue *= 4;
               }
               else{

--- a/tests/TransposeConnTest/src/TransposeConnTest.cpp
+++ b/tests/TransposeConnTest/src/TransposeConnTest.cpp
@@ -211,7 +211,7 @@ int testDataPatchEqual(pvdata_t * w1, pvdata_t * w2, int patchSize, const char *
    int status_out = status_in;
    for (int w=0; w<patchSize; w++) {
       if (w1[w] != w2[w]) {
-         pvErrorNoExit().printf("TransposeConnTest: value %d of \"%s\" and \"%s\" are not equal (%f versus %f).\n", w, name1, name2, w1[w], w2[w]);
+         pvErrorNoExit().printf("TransposeConnTest: value %d of \"%s\" and \"%s\" are not equal (%f versus %f).\n", w, name1, name2, (double)w1[w], (double)w2[w]);
          status_out = PV_FAILURE;
          if (status_out != PV_SUCCESS) break;
       }
@@ -244,7 +244,7 @@ int dumpWeights(HyPerConn * conn) {
          for(int k=0; k<nxp*nyp*nfp; k++) {
             pvErrorNoExit().printf("    Arbor %d, Data Patch %d, Index %4d, (x=%3d, y=%3d, f=%3d): Value %g\n",
                     arbor, n, k, kxPos(k, nxp, nyp, nfp), kyPos(k, nxp, nyp, nfp),
-                    featureIndex(k, nxp, nyp, nfp), conn->get_wData(arbor, n)[k]);
+                    featureIndex(k, nxp, nyp, nfp), (double)conn->get_wData(arbor, n)[k]);
          }
       }
    }

--- a/tests/TransposeHyPerConnTest/src/TransposeHyPerConnTest.cpp
+++ b/tests/TransposeHyPerConnTest/src/TransposeHyPerConnTest.cpp
@@ -101,39 +101,6 @@ int main(int argc, char * argv[]) {
    return status;
 }
 
-//int manyToOneForTransposeConn(int argc, char * argv[]) {
-//   HyPerCol * hc = new HyPerCol("column", argc, argv);
-//   // Layers
-//   const char * layerAname = "Layer A";
-//   const char * layerB1to1name = "Layer B One to one";
-//   const char * layerB_ManyTo1Name = "Layer B Many to one";
-//   const char * layerB1toManyName = "Layer B One to many";
-//   const char * originalConnName = "Many to one original map";
-//   const char * transposeConnName = "Many to one transpose";
-//   const char * transposeOfTransposeConnName = "Many to one double transpose";
-//
-//   ANNLayer * layerA = new ANNLayer(layerAname, hc);
-//   pvErrorIf(!(layerA), "Test failed.\n");
-//   ANNLayer * layerB_ManyTo1 = new ANNLayer(layerB_ManyTo1Name, hc);
-//   pvErrorIf(!(layerB_ManyTo1), "Test failed.\n");
-//   new ANNLayer(layerB1to1name, hc); // This layer and the next are unused in this test, but get created anyway
-//   new ANNLayer(layerB1toManyName, hc); // to cause the params to be read, so we don't get unused-parameter warnings.
-//
-//   // Connections
-//   HyPerConn * originalMapManyto1 = new HyPerConn(originalConnName, hc);
-//   pvErrorIf(!(originalMapManyto1), "Test failed.\n");
-//   TransposeConn * transposeManyto1 = new TransposeConn(transposeConnName, hc);
-//   pvErrorIf(!(transposeManyto1), "Test failed.\n");
-//   TransposeConn * transposeOfTransposeManyto1 = new TransposeConn(transposeOfTransposeConnName, hc);
-//   pvErrorIf(!(transposeOfTransposeManyto1), "Test failed.\n");
-//
-//   hc->run(); // Weight values are initialized when run calls allocateDataStructures
-//
-//   int status = testTransposeOfTransposeWeights(originalMapManyto1, transposeManyto1, transposeOfTransposeManyto1, "Many-to-one case, TransposeConn");
-//   delete hc;
-//   return status;
-//}
-
 int testTransposeOfTransposeWeights(HyPerConn * originalMap, TransposeConn * transpose, TransposeConn * transposeOfTranspose, const char * message) {
    int status = testWeightsEqual(originalMap, transposeOfTranspose);
    if( status == PV_SUCCESS ) {
@@ -215,7 +182,7 @@ int testDataPatchEqual(pvdata_t * wgts1, pvdata_t * wgts2, int patchSize, const 
       pvdata_t w2 = wgts2[w];
       // w2 will be either 0 or in the range [1,2].  It's nonzero iff the weight has any pre-neurons in restricted space.
       if (w2 && w1!=w2) { // If the weight is from an extended neuron, and sharedWeights is off, the transpose will be zero.
-         pvErrorNoExit().printf("TransposeHyPerConnTest: value %d of \"%s\" and \"%s\" are not equal (%f versus %f).\n", w, name1, name2, wgts1[w], wgts2[w]);
+         pvErrorNoExit().printf("TransposeHyPerConnTest: value %d of \"%s\" and \"%s\" are not equal (%f versus %f).\n", w, name1, name2, (double)wgts1[w], (double)wgts2[w]);
          status_out = PV_FAILURE;
          if (status_out != PV_SUCCESS) break;
       }
@@ -248,7 +215,7 @@ int dumpWeights(HyPerConn * conn) {
          for(int k=0; k<nxp*nyp*nfp; k++) {
             pvErrorNoExit().printf("    Arbor %d, Data Patch %d, Index %4d, (x=%3d, y=%3d, f=%3d): Value %g\n",
                     arbor, n, k, kxPos(k, nxp, nyp, nfp), kyPos(k, nxp, nyp, nfp),
-                    featureIndex(k, nxp, nyp, nfp), conn->get_wData(arbor, n)[k]);
+                    featureIndex(k, nxp, nyp, nfp), (double)conn->get_wData(arbor, n)[k]);
          }
       }
    }

--- a/tests/UpdateFromCloneTest/src/MomentumTestConnProbe.cpp
+++ b/tests/UpdateFromCloneTest/src/MomentumTestConnProbe.cpp
@@ -44,12 +44,12 @@ int MomentumTestConnProbe::outputState(double timed){
                wCorrect = 0;
             }
             else{
-               wCorrect = .376471;
+               wCorrect = 0.376471f;
                for(int i = 0; i < (timed-3); i++){
-                  wCorrect += .376471 * exp(-(2*(i+1)));
+                  wCorrect += 0.376471f * expf(-(2*(i+1)));
                }
             }
-            pvErrorIf(!(fabs(wObserved - wCorrect) <= 1e-4), "Test failed.\n");
+            pvErrorIf(!(fabsf(wObserved - wCorrect) <= 1e-4f), "Test failed.\n");
          }
       }
    }

--- a/tests/UpdateFromCloneTest/src/TestConnProbe.cpp
+++ b/tests/UpdateFromCloneTest/src/TestConnProbe.cpp
@@ -39,16 +39,16 @@ int TestConnProbe::outputState(double timed){
          pvwdata_t * dataYStart = data + y * syw;
          for(int k = 0; k < nk; k++){
             if(fabs(timed - 0) < (parent->getDeltaTime()/2)){
-               if(fabs(dataYStart[k] - 1) > .01){
+               if(fabsf(dataYStart[k] - 1) > 0.01f){
                   pvError() << "dataYStart[k]: " << dataYStart[k] << "\n";
                }
-               pvErrorIf(!(fabs(dataYStart[k] - 1) <= .01), "Test failed.\n");
+               pvErrorIf(!(fabsf(dataYStart[k] - 1) <= 0.01f), "Test failed.\n");
             }
             else if(fabs(timed - 1) < (parent->getDeltaTime()/2)){
-               if(fabs(dataYStart[k] - 1.375) > .01){
+               if(fabsf(dataYStart[k] - 1.375f) > 0.01f){
                   pvError() << "dataYStart[k]: " << dataYStart[k] << "\n";
                }
-               pvErrorIf(!(fabs(dataYStart[k] - 1.375) <= .01), "Test failed.\n");
+               pvErrorIf(!(fabsf(dataYStart[k] - 1.375f) <= 0.01f), "Test failed.\n");
             }
 
          }

--- a/tests/test_cocirc/src/test_cocirc.cpp
+++ b/tests/test_cocirc/src/test_cocirc.cpp
@@ -120,13 +120,13 @@ int check_cocirc_vs_hyper(HyPerConn * cHyPer, HyPerConn * cKernel, int kPre, int
    for (int y = 0; y < ny; y++) {
       for (int k = 0; k < nk; k++) {
          test_cond = cocircWeights[k] - hyperWeights[k];
-         if (fabs(test_cond) > 0.001f) {
+         if (fabsf(test_cond) > 0.001f) {
             const char * cHyper_filename = "cocirc_hyper.txt";
             cHyPer->writeTextWeights(cHyper_filename, kPre);
             const char * cKernel_filename = "cocirc_cocirc.txt";
             cKernel->writeTextWeights(cKernel_filename, kPre);
          }
-         pvErrorIf(!(fabs(test_cond) <= 0.001f), "Test failed.\n");
+         pvErrorIf(!(fabsf(test_cond) <= 0.001f), "Test failed.\n");
       }
       // advance pointers in y
       hyperWeights += sy;

--- a/tests/test_datatypes/src/test_datatypes.cpp
+++ b/tests/test_datatypes/src/test_datatypes.cpp
@@ -147,7 +147,7 @@ static int check_borders(pvdata_t * image, PV::Communicator * comm, PVLayerLoc l
             float * buf = image + ky * sy;
             for (int kx = 0; kx < halo->lt; kx++) {
                if ((int) buf[kx] != k++) {
-                  pvErrorNoExit().printf("[?]: northwest check_borders failed kx==%d ky==%d observed==%f correct==%d addr==%p\n", kx, ky, buf[kx], k-1, &buf[kx]);
+                  pvErrorNoExit().printf("[?]: northwest check_borders failed kx==%d ky==%d observed==%f correct==%d addr==%p\n", kx, ky, (double)buf[kx], k-1, &buf[kx]);
                   return 1;
                }
             }
@@ -158,7 +158,7 @@ static int check_borders(pvdata_t * image, PV::Communicator * comm, PVLayerLoc l
             float * buf = image + ky * sy;
             for (int kx = 0; kx < halo->lt; kx++) {
                if ((int) buf[kx] != 0) {
-                  pvErrorNoExit().printf("[?]: northwest check_borders failed kx==%d ky==%d observed==%f correct==0 addr==%p\n", kx, ky, buf[kx], &buf[kx]);
+                  pvErrorNoExit().printf("[?]: northwest check_borders failed kx==%d ky==%d observed==%f correct==0 addr==%p\n", kx, ky, (double)buf[kx], &buf[kx]);
                   return 1;
                }
             }
@@ -173,7 +173,7 @@ static int check_borders(pvdata_t * image, PV::Communicator * comm, PVLayerLoc l
          float * buf = image + (ky + halo->up) * sy;
          for (int kx = 0; kx < halo->lt; kx++) {
             if ((int) buf[kx] != k++) {
-               pvErrorNoExit().printf("[?]: check_borders failed kx==%d ky==%d k0==%d observed==%f correct==%d addr==%p\n", kx, ky, k0, buf[kx], k-1, &buf[kx]);
+               pvErrorNoExit().printf("[?]: check_borders failed kx==%d ky==%d k0==%d observed==%f correct==%d addr==%p\n", kx, ky, k0, (double)buf[kx], k-1, &buf[kx]);
                return 1;
             }
          }
@@ -187,7 +187,7 @@ static int check_borders(pvdata_t * image, PV::Communicator * comm, PVLayerLoc l
          float * buf = image + (nx + halo->lt) + (ky + halo->up) * sy;
          for (int kx = 0; kx < halo->rt; kx++) {
             if ((int) buf[kx] != k++) {
-               pvErrorNoExit().printf("[?]: check_borders failed kx==%d ky==%d k0==%d observed==%f correct==%d addr==%p\n", kx, ky, k0, buf[kx], k-1, &buf[kx]);
+               pvErrorNoExit().printf("[?]: check_borders failed kx==%d ky==%d k0==%d observed==%f correct==%d addr==%p\n", kx, ky, k0, (double)buf[kx], k-1, &buf[kx]);
                return 1;
             }
          }

--- a/tests/test_delta/src/test_delta.cpp
+++ b/tests/test_delta/src/test_delta.cpp
@@ -14,63 +14,63 @@ int main(int argc, char* argv[])
 {
   float dx, max;
 
-  max = 2.0;
+  max = 2.0f;
   
-  dx = deltaWithPBC(1., 1., max);
+  dx = deltaWithPBC(1.0f, 1.0f, max);
   if ( !zero(dx) ) {
-      pvError().printf("FAILED:TEST_DELTA: (1.,1.)\n");
+      pvError().printf("FAILED:TEST_DELTA: (1, 1)\n");
   }
 
-  dx = deltaWithPBC(2., 1., max);
-  if ( !zero(-1.0 - dx) ) {
-      pvError().printf("FAILED:TEST_DELTA: (2.,1.)\n");
+  dx = deltaWithPBC(2.0f, 1.0f, max);
+  if ( !zero(-1.0f - dx) ) {
+      pvError().printf("FAILED:TEST_DELTA: (2, 1)\n");
   }
 
-  dx = deltaWithPBC(1., 2., max);
-  if ( !zero(1.0 - dx) ) {
-      pvError().printf("FAILED:TEST_DELTA: (1.,2.)\n");
+  dx = deltaWithPBC(1.0f, 2.0f, max);
+  if ( !zero(1.0f - dx) ) {
+      pvError().printf("FAILED:TEST_DELTA: (1, 2)\n");
   }
 
-  dx = deltaWithPBC(1., 3.0, max);
-  if ( !zero(2.0 - fabs(dx)) ) {
-      pvError().printf("FAILED:TEST_DELTA: (1.,3.)\n");
+  dx = deltaWithPBC(1.0f, 3.0f, max);
+  if ( !zero(2.0f - fabsf(dx)) ) {
+      pvError().printf("FAILED:TEST_DELTA: (1, 3)\n");
   }
 
-  dx = deltaWithPBC(2.4, 0.4, max);
-  if ( !zero(2.0 - fabs(dx)) ) {
-      pvError().printf("FAILED:TEST_DELTA: (2.4,0.4)\n");
+  dx = deltaWithPBC(2.4f, 0.4f, max);
+  if ( !zero(2.0f - fabsf(dx)) ) {
+      pvError().printf("FAILED:TEST_DELTA: (2.4, 0.4)\n");
   }
 
-  dx = deltaWithPBC(0., 4., max);
-  if ( !zero(0.0 - dx) ) {
-      pvError().printf("FAILED:TEST_DELTA: (0.,4.)\n");
+  dx = deltaWithPBC(0.0f, 4.0f, max);
+  if ( !zero(0.0f - dx) ) {
+      pvError().printf("FAILED:TEST_DELTA: (0, 4)\n");
   }
 
-  dx = deltaWithPBC(1., 4., max);
-  if ( !zero(-1.0 - dx) ) {
-      pvError().printf("FAILED:TEST_DELTA: (1.,4.)\n");
+  dx = deltaWithPBC(1.0f, 4.0f, max);
+  if ( !zero(-1.0f - dx) ) {
+      pvError().printf("FAILED:TEST_DELTA: (1, 4)\n");
   }
 
-  dx = deltaWithPBC(3.4, 1.0, max);
-  if ( !zero(1.6 - dx) ) {
-      pvError().printf("FAILED:TEST_DELTA: (3.4,1.0)\n");
+  dx = deltaWithPBC(3.4f, 1.0f, max);
+  if ( !zero(1.6f - dx) ) {
+      pvError().printf("FAILED:TEST_DELTA: (3.4, 1.0)\n");
   }
 
-  max = 2.5;
+  max = 2.5f;
 
-  dx = deltaWithPBC(3.5, 1.0, max);
-  if ( !zero(-2.5 - dx) ) {
-      pvError().printf("FAILED:TEST_DELTA: (3.5,1.0)\n");
+  dx = deltaWithPBC(3.5f, 1.0f, max);
+  if ( !zero(-2.5f - dx) ) {
+      pvError().printf("FAILED:TEST_DELTA: (3.5, 1.0)\n");
   }
 
-  dx = deltaWithPBC(3.6, 1.0, max);
-  if ( !zero(2.4 - dx) ) {
-      pvError().printf("FAILED:TEST_DELTA: (3.6,1.0)\n");
+  dx = deltaWithPBC(3.6f, 1.0f, max);
+  if ( !zero(2.4f - dx) ) {
+      pvError().printf("FAILED:TEST_DELTA: (3.6, 1.0)\n");
   }
 
-  dx = deltaWithPBC(1.1, 3.7, max);
-  if ( !zero(-2.4 - dx) ) {
-      pvError().printf("FAILED:TEST_DELTA: (1.1,3.7\n");
+  dx = deltaWithPBC(1.1f, 3.7f, max);
+  if ( !zero(-2.4f - dx) ) {
+      pvError().printf("FAILED:TEST_DELTA: (1.1, 3.7)\n");
   }
 
   return 0;

--- a/tests/test_delta_pos/src/test_delta_pos.cpp
+++ b/tests/test_delta_pos/src/test_delta_pos.cpp
@@ -11,48 +11,48 @@ int main(int argc, char* argv[])
 
    for (kPre = 0; kPre < 7; kPre++) {
       dx = deltaPosLayers(kPre, scale);
-      if (dx != 0.0) {
-         pvError().printf("FAILED:TEST_DELTA_POS: scale=%d, kPre=%d, dx=%f\n", scale, kPre, dx);
+      if (dx != 0.0f) {
+         pvError().printf("FAILED:TEST_DELTA_POS: scale=%d, kPre=%d, dx=%f\n", scale, kPre, (double)dx);
       }
    }
 
    scale = 1;
    for (kPre = 0; kPre < 7; kPre++) {
       dx = deltaPosLayers(kPre, scale);
-      float val = (kPre % 2) ? -0.25 : 0.25;
+      float val = (kPre % 2) ? -0.25f : 0.25f;
       if (dx != val) {
-         pvError().printf("FAILED:TEST_DELTA_POS: scale=%d, kPre=%d, dx=%f\n", scale, kPre, dx);
+         pvError().printf("FAILED:TEST_DELTA_POS: scale=%d, kPre=%d, dx=%f\n", scale, kPre, (double)dx);
       }
    }
 
    scale = 2;
    for (kPre = 0; kPre < 7; kPre++) {
       dx = deltaPosLayers(kPre, scale);
-      float val = 1./8.;
-      if (kPre % 4 == 0) val =  3.0 * val;
-      if (kPre % 4 == 1) val =  1.0 * val;
-      if (kPre % 4 == 2) val = -1.0 * val;
-      if (kPre % 4 == 3) val = -3.0 * val;
+      float val = 1.0f/8.0f;
+      if (kPre % 4 == 0) val =  3.0f * val;
+      if (kPre % 4 == 1) val =  1.0f * val;
+      if (kPre % 4 == 2) val = -1.0f * val;
+      if (kPre % 4 == 3) val = -3.0f * val;
       if (dx != val) {
-         pvError().printf("FAILED:TEST_DELTA_POS: scale=%d, kPre=%d, dx=%f\n", scale, kPre, dx);
+         pvError().printf("FAILED:TEST_DELTA_POS: scale=%d, kPre=%d, dx=%f\n", scale, kPre, (double)dx);
       }
    }
 
    scale = -1;
    for (kPre = 0; kPre < 7; kPre++) {
       dx = deltaPosLayers(kPre, scale);
-      float val = -0.5;
+      float val = -0.5f;
       if (dx != val) {
-         pvError().printf("FAILED:TEST_DELTA_POS: scale=%d, kPre=%d, dx=%f\n", scale, kPre, dx);
+         pvError().printf("FAILED:TEST_DELTA_POS: scale=%d, kPre=%d, dx=%f\n", scale, kPre, (double)dx);
       }
    }
 
    scale = -2;
    for (kPre = 0; kPre < 7; kPre++) {
       dx = deltaPosLayers(kPre, scale);
-      float val = -1.5;
+      float val = -1.5f;
       if (dx != val) {
-         pvError().printf("FAILED:TEST_DELTA_POS: scale=%d, kPre=%d, dx=%f\n", scale, kPre, dx);
+         pvError().printf("FAILED:TEST_DELTA_POS: scale=%d, kPre=%d, dx=%f\n", scale, kPre, (double)dx);
       }
    }
 

--- a/tests/test_gauss2d/src/test_gauss2d.cpp
+++ b/tests/test_gauss2d/src/test_gauss2d.cpp
@@ -141,12 +141,12 @@ int check_kernel_vs_hyper(HyPerConn * cHyPer, HyPerConn * cKernel, int kPre, int
    for (int y = 0; y < ny; y++) {
       for (int k = 0; k < nk; k++) {
          test_cond = kernelWeights[k] - hyperWeights[k];
-         if (fabs(test_cond) > 0.001f) {
+         if (fabsf(test_cond) > 0.001f) {
             pvError(errorMessage);
             errorMessage.printf("y %d\n", y);
             errorMessage.printf("k %d\n", k);
-            errorMessage.printf("kernelweight %f\n", kernelWeights[k]);
-            errorMessage.printf("hyperWeights %f\n", hyperWeights[k]);
+            errorMessage.printf("kernelweight %f\n", (double)kernelWeights[k]);
+            errorMessage.printf("hyperWeights %f\n", (double)hyperWeights[k]);
             const char * cHyper_filename = "gauss2d_hyper.txt";
             cHyPer->writeTextWeights(cHyper_filename, kPre);
             const char * cKernel_filename = "gauss2d_kernel.txt";

--- a/tests/test_kxpos/src/test_kxpos.cpp
+++ b/tests/test_kxpos/src/test_kxpos.cpp
@@ -27,7 +27,7 @@ int main(int argc, char* argv[])
       float kx = kxPos(kl, nxLocal, nyLocal, nf);
 
       if (kx != (float)kxx) {
-         pvError().printf("FAILED:TEST_KXPOS: (k,kx) = (%d,%f)\n", kl, kx);
+         pvError().printf("FAILED:TEST_KXPOS: (k,kx) = (%d,%f)\n", kl, (double)kx);
       }
    }
 
@@ -49,7 +49,7 @@ int main(int argc, char* argv[])
       float kx = kxPos(kl, nxLocal, nyLocal, nf);
 
       if ((int)kx-kxx != 0) {
-         pvError().printf("FAILED:TEST_KXPOS: (k,kx) = (%d,%f)\n", kl, kx);
+         pvError().printf("FAILED:TEST_KXPOS: (k,kx) = (%d,%f)\n", kl, (double)kx);
       }
    }
 
@@ -72,7 +72,7 @@ int main(int argc, char* argv[])
       float kx = kxPos(kl, nxLocal, nyLocal, nf);
 
       if ((int)kx-kxx != 0) {
-         pvError().printf("FAILED:TEST_KXPOS: (k,kx) = (%d,%f)\n", kl, kx);
+         pvError().printf("FAILED:TEST_KXPOS: (k,kx) = (%d,%f)\n", kl, (double)kx);
       }
    }
 
@@ -96,7 +96,7 @@ int main(int argc, char* argv[])
       float kx = kxPos(kl, nxLocal, nyLocal, nf);
 
       if ((int)kx-kxx != 0) {
-         pvError().printf("FAILED:TEST_KXPOS: (k,kx) = (%d,%f)\n", kl, kx);
+         pvError().printf("FAILED:TEST_KXPOS: (k,kx) = (%d,%f)\n", kl, (double)kx);
       }
    }
 

--- a/tests/test_kypos/src/test_kypos.cpp
+++ b/tests/test_kypos/src/test_kypos.cpp
@@ -26,7 +26,7 @@ int main(int argc, char* argv[])
       float ky = kyPos(kl, nxLocal, nyLocal, nf);
 
       if (ky != (float)kk) {
-         pvError().printf("FAILED:TEST_KYPOS: (k,ky) = (%d,%f)\n", kl, ky);
+         pvError().printf("FAILED:TEST_KYPOS: (k,ky) = (%d,%f)\n", kl, (double)ky);
       }
    }
 
@@ -47,7 +47,7 @@ int main(int argc, char* argv[])
       float ky = kyPos(kl, nxLocal, nyLocal, nf);
 
       if ((int)ky-kk != 0) {
-         pvError().printf("FAILED:TEST_KYPOS: (k,ky) = (%d,%f)\n", kl, ky);
+         pvError().printf("FAILED:TEST_KYPOS: (k,ky) = (%d,%f)\n", kl, (double)ky);
       }
    }
 
@@ -69,7 +69,7 @@ int main(int argc, char* argv[])
       float ky = kyPos(kl, nxLocal, nyLocal, nf);
 
       if ((int)ky-kk != 0) {
-         pvError().printf("FAILED:TEST_KYPOS: (k,ky) = (%d,%f)\n", kl, ky);
+         pvError().printf("FAILED:TEST_KYPOS: (k,ky) = (%d,%f)\n", kl, (double)ky);
       }
    }
 
@@ -92,7 +92,7 @@ int main(int argc, char* argv[])
       float ky = kyPos(kl, nxLocal, nyLocal, nf);
 
       if ((int)ky-kk != 0) {
-         pvError().printf("FAILED:TEST_KYPOS: (k,ky) = (%d,%f)\n", kl, ky);
+         pvError().printf("FAILED:TEST_KYPOS: (k,ky) = (%d,%f)\n", kl, (double)ky);
       }
    }
 

--- a/tests/test_sign/src/test_sign.cpp
+++ b/tests/test_sign/src/test_sign.cpp
@@ -6,7 +6,7 @@
 
 static int zero(float x)
 {
-  if (fabs(x) < .00001) return 1;
+  if (fabsf(x) < 0.00001f) return 1;
   return 0;
 }
 
@@ -14,23 +14,23 @@ int main(int argc, char* argv[])
 {
   float s;
 
-  s = sign(3.3);
-  if ( !zero(1.0 - s) ) {
+  s = sign(3.3f);
+  if ( !zero(1.0f - s) ) {
       pvError().printf("FAILED:TEST_SIGN: (3.3)\n");
   }
 
-  s = sign(.001);
-  if ( !zero(1.0 - s) ) {
+  s = sign(0.001f);
+  if ( !zero(1.0f - s) ) {
       pvError().printf("FAILED:TEST_SIGN: (.001)\n");
   }
 
-  s = sign(-.001);
-  if ( !zero(-1.0 - s) ) {
+  s = sign(-0.001f);
+  if ( !zero(-1.0f - s) ) {
       pvError().printf("FAILED:TEST_SIGN: (-.001)\n");
   }
 
-  s = sign(0.0);
-  if ( !zero(1.0 - s) ) {
+  s = sign(0.0f);
+  if ( !zero(1.0f - s) ) {
       pvError().printf("FAILED:TEST_SIGN: (0.0)\n");
   }
 


### PR DESCRIPTION
This pull request enables the -Wdouble-promotion warning in GCC and fixes all occurrences of the warning. This warning occurs when an operation is performed between double and float operands without casting, or when passing a float as a double argument. The most common cause is writing a decimal literal without a suffix (0.1 instead of 0.1f). While some of this is most likely optimized out by the compiler, there were plenty of locations where the intended type was ambiguous. Now the type of any operation should be made clear.

For reference, doubles are used for time values. Floats are used for layer values and weights. Because these cannot be easily swapped out without significant changes to the code, the pvdata_t defines should be replaced with float in a future pull request.

This pull request passes all tests and is ready to merge.
