### PR TITLE
receiveGpu true with PV_USE_CUDA off gives a warning instead of an error

### DIFF
--- a/src/connections/BaseConnection.cpp
+++ b/src/connections/BaseConnection.cpp
@@ -32,9 +32,7 @@ int BaseConnection::initialize_base() {
    this->delays = NULL;
    numAxonalArborLists = 1;
    convertRateToSpikeCount = false;
-#ifdef PV_USE_CUDA
    receiveGpu = false;
-#endif //  PV_USE_CUDA
    this->initializeFromCheckpointFlag = false;
    this->probes = NULL;
    this->numProbes = 0;
@@ -319,12 +317,11 @@ void BaseConnection::ioParam_receiveGpu(enum ParamsIOFlag ioFlag) {
 #ifdef PV_USE_CUDA
    parent->ioParamValue(ioFlag, name, "receiveGpu", &receiveGpu, false/*default*/, true/*warn if absent*/);
 #else
-   bool receiveGpu = false;
+   receiveGpu = false;
    parent->ioParamValue(ioFlag, name, "receiveGpu", &receiveGpu, receiveGpu/*default*/, false/*warn if absent*/);
    if (ioFlag==PARAMS_IO_READ && receiveGpu) {
       if (parent->columnId()==0) {
-         pvErrorNoExit().printf("%s: receiveGpu is set to true, but PetaVision was compiled without GPU acceleration.\n",
-               this->getDescription_c());
+         pvWarn() << getDescription_c() << ": receiveGpu is set to true in params, but PetaVision was compiled without GPU acceleration. receiveGpu has been set to false.\n";
       }
       MPI_Barrier(parent->getCommunicator()->communicator());
       exit(EXIT_FAILURE);

--- a/src/connections/BaseConnection.hpp
+++ b/src/connections/BaseConnection.hpp
@@ -187,9 +187,7 @@ public:
    inline int getDelay(int arbor) { return (arbor >= 0 && arbor < this->numberOfAxonalArborLists()) ? delays[arbor] : -1; }
 
    inline bool getConvertRateToSpikeCount() { return convertRateToSpikeCount; }
-#ifdef PV_USE_CUDA
    inline bool getReceiveGpu() { return receiveGpu; }
-#endif // PV_USE_CUDA 
 
    /**
     * Returns the number of probes that have been attached to this connection
@@ -486,9 +484,7 @@ protected:
    int numAxonalArborLists; // number of axonal arbors from presynaptic layer
    bool plasticityFlag;
    bool convertRateToSpikeCount; // Whether to check if pre-layer is spiking and, if it is not, scale activity by dt to convert it to a spike count
-#ifdef PV_USE_CUDA
    bool receiveGpu; // Whether to use GPU acceleration in updating post's GSyn
-#endif // PV_USE_CUDA
    bool initializeFromCheckpointFlag;
 
    BaseConnectionProbe** probes; // probes used to output data

--- a/src/connections/HyPerConn.cpp
+++ b/src/connections/HyPerConn.cpp
@@ -575,14 +575,15 @@ int HyPerConn::ioParamsFillGroup(enum ParamsIOFlag ioFlag)
    ioParam_maskLayerName(ioFlag);
    ioParam_maskFeatureIdx(ioFlag);
 
+#ifdef PV_USE_CUDA
    // GPU-specific parameters.  If not using GPUs, we read them anyway, with warnIfAbsent set to false, to prevent unnecessary warnings from unread or missing parameters.
    ioParam_gpuGroupIdx(ioFlag);
-   // ioParam_receiveGpu(ioFlag); // read by parent class BaseConnection
    ioParam_preDataLocal(ioFlag);
    //Only read numX, Y, and F local if not using CUDNN
    ioParam_numXLocal(ioFlag);
    ioParam_numYLocal(ioFlag);
    ioParam_numFLocal(ioFlag);
+#endif // PV_USE_CUDA
    // Weight sparsity
    ioParam_weightSparsity(ioFlag);
    return PV_SUCCESS;
@@ -647,30 +648,6 @@ void HyPerConn::ioParam_numFLocal(enum ParamsIOFlag ioFlag) {
       parent->ioParamValue(ioFlag, name, "numFLocal", &numFLocal, 1, true);
 # endif
    }
-}
-
-#else // PV_USE_CUDA
-// Some dummy ioParam_ functions to read GPU-specific params, without generating a warning if
-// they are present, or generating a warning if they are absent.
-void HyPerConn::ioParam_gpuGroupIdx(enum ParamsIOFlag ioFlag) {
-   int dummyVar = 0;
-   parent->ioParamValue(ioFlag, name, "gpuGroupIdx", &dummyVar, dummyVar/*default*/, false/*warnIfAbsent*/);
-}
-void HyPerConn::ioParam_preDataLocal(enum ParamsIOFlag ioFlag) {
-   bool dummyFlag = false;
-   parent->ioParamValue(ioFlag, name, "preDataLocal", &dummyFlag, dummyFlag/*default*/, false/*warnIfAbsent*/);
-}
-void HyPerConn::ioParam_numXLocal(enum ParamsIOFlag ioFlag) {
-   int dummyVar = 0;
-   parent->ioParamValue(ioFlag, name, "numXLocal", &dummyVar, dummyVar/*default*/, false/*warnIfAbsent*/);
-}
-void HyPerConn::ioParam_numYLocal(enum ParamsIOFlag ioFlag) {
-   int dummyVar = 0;
-   parent->ioParamValue(ioFlag, name, "numYLocal", &dummyVar, dummyVar/*default*/, false/*warnIfAbsent*/);
-}
-void HyPerConn::ioParam_numFLocal(enum ParamsIOFlag ioFlag) {
-   int dummyVar = 0;
-   parent->ioParamValue(ioFlag, name, "numFLocal", &dummyVar, dummyVar/*default*/, false/*warnIfAbsent*/);
 }
 #endif // PV_USE_CUDA
 

--- a/src/connections/HyPerConn.hpp
+++ b/src/connections/HyPerConn.hpp
@@ -834,6 +834,7 @@ protected:
     */
    virtual void ioParam_maskFeatureIdx(enum ParamsIOFlag ioFlag);
 
+#ifdef PV_USE_CUDA
    /**
     * @brief gpuGroupIdx: All connections in the same group uses the same GPU memory for weights
     * @details Specify a group index. An index of -1 means no group (default).
@@ -868,6 +869,7 @@ protected:
     * This parameter is ignored if PetaVision was compiled without GPU acceleration.
     */
    virtual void ioParam_numFLocal(enum ParamsIOFlag ioFlag);
+#endif // PV_USE_CUDA
 
    /**
     * @brief weightSparsity: Specifies what percentage of weights will be ignored. Default is 0.0

--- a/tests/DryRunFlagTest/input/correct.params
+++ b/tests/DryRunFlagTest/input/correct.params
@@ -144,11 +144,6 @@ HyPerConn "InputToOutputBase" = {
     normalize_cutoff                    = 0;
     normalizeFromPostPerspective        = false;
     minSumTolerated                     = 0;
-    gpuGroupIdx                         = 0;
-    preDataLocal                        = false;
-    numXLocal                           = 0;
-    numYLocal                           = 0;
-    numFLocal                           = 0;
     weightSparsity                      = 0;
 };
 
@@ -191,10 +186,5 @@ HyPerConn "InputToOutputImported" = {
     normalize_cutoff                    = 0;
     normalizeFromPostPerspective        = false;
     minSumTolerated                     = 0;
-    gpuGroupIdx                         = 0;
-    preDataLocal                        = false;
-    numXLocal                           = 0;
-    numYLocal                           = 0;
-    numFLocal                           = 0;
     weightSparsity                      = 0;
 };


### PR DESCRIPTION
This pull request changes the behavior when a HyPerConn sets receiveGpu to true when compiled with PV_USE_CUDA off.   It now issues a warning and proceeds with receiveGpu=false, instead of giving an error message and exiting with failure.

It also updates DryRunFlagTest/input/correct.params, which now passes for both PV_USE_CUDA on and PV_USE_CUDA off.
