### PR TITLE
Fixes a memory issue when pooling on the GPU

### DIFF
--- a/src/arch/cuda/CudaDevice.cpp
+++ b/src/arch/cuda/CudaDevice.cpp
@@ -41,8 +41,6 @@ void CudaDevice::incrementConvKernels(){
 
 long CudaDevice::reserveMem(size_t size){
    deviceMem -= size;
-   pvInfo() << "Reserving " << size << " bytes of VRAM. "
-      << deviceMem << " bytes remaining.\n";
    return deviceMem;
 }
 
@@ -118,9 +116,13 @@ int CudaDevice::query_device_info()
    return 0;
 }
 
-CudaBuffer* CudaDevice::createBuffer(size_t size){
+CudaBuffer* CudaDevice::createBuffer(size_t size, std::string const* str){
    long memLeft = reserveMem(size);
+   pvInfo() << "Reserving " << size << " bytes of VRAM";
+   if (str) {pvInfo() << " (" << *str << ")";}
+   pvInfo() << ". " << deviceMem << " bytes remaining.\n";
    if(memLeft < 0){
+      pvInfo().flush();
       pvError().printf("CudaDevice createBuffer: out of memory\n");
    }
    return(new CudaBuffer(size, this, stream));

--- a/src/arch/cuda/CudaDevice.hpp
+++ b/src/arch/cuda/CudaDevice.hpp
@@ -12,6 +12,7 @@
 #include "CudaBuffer.hpp"
 #include <stdio.h>
 #include <cuda_runtime_api.h>
+#include <string>
 
 namespace PVCuda{
    
@@ -24,7 +25,6 @@ protected:
 
 public:
 
-   long reserveMem(size_t size);
    void incrementConvKernels();
    size_t getMemory(){return deviceMem;}
    size_t getNumConvKernels(){return numConvKernels;}
@@ -53,9 +53,10 @@ public:
    /**
     * A function to create a buffer from the given stream
     * @param size The size of the buffer being created
+    * @param str  A string used in the message logging the buffer creation.
     * @return The CudaBuffer object from creating the buffer
     */
-   CudaBuffer * createBuffer(size_t size);
+   CudaBuffer * createBuffer(size_t size, std::string const* str);
 
    /**
     * A function to return the cuda stream the device is using
@@ -114,6 +115,12 @@ public:
    void* getCudnnHandle(){return handle;}
 #endif
 
+private:
+   /**
+    * Decrements deviceMem by the given number of bytes, and exits with an error if deviceMem drops below zero.
+    * Called by createBuffer.
+    */
+   long reserveMem(size_t size);
 
 protected:
    int num_devices;                  // number of computing devices

--- a/src/connections/HyPerConn.cpp
+++ b/src/connections/HyPerConn.cpp
@@ -1516,10 +1516,10 @@ int HyPerConn::allocatePostDeviceWeights(){
 int HyPerConn::allocateDeviceWeights(){
    PVCuda::CudaDevice * device = parent->getDevice();
    const size_t size = numberOfAxonalArborLists() * getNumDataPatches() * xPatchSize() * yPatchSize() * fPatchSize() * sizeof(pvwdata_t);
-   d_WData = device->createBuffer(size);
+   d_WData = device->createBuffer(size, &description);
    pvAssert(d_WData);
 # ifdef PV_USE_CUDNN
-   cudnn_WData = device->createBuffer(size);
+   cudnn_WData = device->createBuffer(size, &description);
 # endif
    return PV_SUCCESS;
 }
@@ -1591,10 +1591,10 @@ int HyPerConn::allocateDeviceBuffers()
    if(receiveGpu){
       if(updateGSynFromPostPerspective){
          int numPostRes = post->getNumNeurons();
-         d_PostToPreActivity = device->createBuffer(numPostRes*sizeof(long)); 
+         d_PostToPreActivity = device->createBuffer(numPostRes*sizeof(long), &description); 
          if(sharedWeights){
             int numWeightPatches = postConn->getNumWeightPatches();
-            d_Patch2DataLookupTable = device->createBuffer(numWeightPatches * sizeof(int));  
+            d_Patch2DataLookupTable = device->createBuffer(numWeightPatches * sizeof(int), &description);  
          }
       }
       else{
@@ -1616,11 +1616,11 @@ int HyPerConn::allocateDeviceBuffers()
 
          int numWeightPatches = pre->getNumExtended() ;
          int patchSize = numWeightPatches * sizeof(PVPatch);
-         d_Patches = device->createBuffer(patchSize); 
+         d_Patches = device->createBuffer(patchSize, &description); 
 
          //Need a buffer for gsynpatch start for one arbor
          int gsynPatchStartIndexSize = numWeightPatches * sizeof(size_t);
-         d_GSynPatchStart = device->createBuffer(gsynPatchStartIndexSize); 
+         d_GSynPatchStart = device->createBuffer(gsynPatchStartIndexSize, &description); 
 
          if(numberOfAxonalArborLists() == 1){
             PVPatch* h_patches = weights(0)[0]; //0 beacuse it's one block of memory
@@ -1635,7 +1635,7 @@ int HyPerConn::allocateDeviceBuffers()
 
          if(sharedWeights){
             int numWeightPatches = getNumWeightPatches();
-            d_Patch2DataLookupTable = device->createBuffer(numWeightPatches * sizeof(int));  
+            d_Patch2DataLookupTable = device->createBuffer(numWeightPatches * sizeof(int), &description);  
          }
       }
    }

--- a/src/connections/PoolingConn.hpp
+++ b/src/connections/PoolingConn.hpp
@@ -58,6 +58,7 @@ protected:
     */
    void ioParam_normalizeMethod(enum ParamsIOFlag ioFlag);
 #ifdef PV_USE_CUDA
+   virtual int allocatePostDeviceWeights() override { return PV_SUCCESS; }
    virtual int allocateDeviceWeights() override { return PV_SUCCESS; }
    virtual int initializeReceivePostKernelArgs() override { return PV_SUCCESS; }
    virtual int initializeReceivePreKernelArgs() override { return PV_SUCCESS; }

--- a/src/connections/PoolingConn.hpp
+++ b/src/connections/PoolingConn.hpp
@@ -58,6 +58,10 @@ protected:
     */
    void ioParam_normalizeMethod(enum ParamsIOFlag ioFlag);
 #ifdef PV_USE_CUDA
+   virtual int allocateDeviceWeights() override { return PV_SUCCESS; }
+   virtual int initializeReceivePostKernelArgs() override { return PV_SUCCESS; }
+   virtual int initializeReceivePreKernelArgs() override { return PV_SUCCESS; }
+   virtual void updateDeviceWeights() override {}
    int initializeDeliverKernelArgs();
 #endif // PV_USE_CUDA
    virtual int setInitialValues() override;

--- a/src/connections/TransposePoolingConn.hpp
+++ b/src/connections/TransposePoolingConn.hpp
@@ -60,6 +60,10 @@ protected:
     virtual int ioParamsFillGroup(enum ParamsIOFlag ioFlag);
     virtual int setPatchSize();
 #ifdef PV_USE_CUDA
+    virtual int allocateDeviceWeights() override { return PV_SUCCESS; }
+    virtual int initializeReceivePostKernelArgs() override { return PV_SUCCESS; }
+    virtual int initializeReceivePreKernelArgs() override { return PV_SUCCESS; }
+    virtual void updateDeviceWeights() override {}
     int initializeTransposePoolingDeliverKernelArgs();
 #endif // PV_USE_CUDA
     virtual int setInitialValues();

--- a/src/connections/TransposePoolingConn.hpp
+++ b/src/connections/TransposePoolingConn.hpp
@@ -60,6 +60,7 @@ protected:
     virtual int ioParamsFillGroup(enum ParamsIOFlag ioFlag);
     virtual int setPatchSize();
 #ifdef PV_USE_CUDA
+    virtual int allocatePostDeviceWeights() override { return PV_SUCCESS; }
     virtual int allocateDeviceWeights() override { return PV_SUCCESS; }
     virtual int initializeReceivePostKernelArgs() override { return PV_SUCCESS; }
     virtual int initializeReceivePreKernelArgs() override { return PV_SUCCESS; }

--- a/src/cudakernels/CudaPoolingDeliverKernel.cpp
+++ b/src/cudakernels/CudaPoolingDeliverKernel.cpp
@@ -14,6 +14,7 @@
 namespace PVCuda {
 
 CudaPoolingDeliverKernel::CudaPoolingDeliverKernel(CudaDevice* inDevice) : CudaKernel(inDevice) {
+   kernelName = "CudaPoolingDeliverKernel";
 }
 
 CudaPoolingDeliverKernel::~CudaPoolingDeliverKernel() {

--- a/src/cudakernels/CudaPoolingDeliverKernel.cpp
+++ b/src/cudakernels/CudaPoolingDeliverKernel.cpp
@@ -101,14 +101,15 @@ void CudaPoolingDeliverKernel::setArgs(
    ); //nx restricted
    cudnnHandleError(status, "Set output tensor descriptor");
 
-   mCudnnDataStore = device->createBuffer(dataStoreBuffer->getSize());
+   std::string str(kernelName);
+   mCudnnDataStore = device->createBuffer(dataStoreBuffer->getSize(), &str);
 
    int numGSynNeuronsAcrossBatch = postLoc->nf*postLoc->ny*postLoc->nf*postLoc->nbatch;
    float * gSynHead = (float*) gSynBuffer->getPointer();
    mGSyn = &gSynHead[channel*numGSynNeuronsAcrossBatch];
 
    size_t gSynSize = gSynBuffer->getSize();
-   mCudnnGSyn = device->createBuffer(numGSynNeuronsAcrossBatch);
+   mCudnnGSyn = device->createBuffer(numGSynNeuronsAcrossBatch, &str);
 }
 
 int CudaPoolingDeliverKernel::calcBorderExcess(int preRestricted, int postRestricted, int border, int patchSizePostPerspective) {

--- a/src/cudakernels/CudaRecvPost.cpp
+++ b/src/cudakernels/CudaRecvPost.cpp
@@ -14,7 +14,7 @@ namespace PVCuda{
 #endif // PV_USE_CUDNN
 
 CudaRecvPost::CudaRecvPost(CudaDevice* inDevice):CudaKernel(inDevice){
-   //inDevice->incrementConvKernels();
+   kernelName = "CudaRecvPost";
 }
 
 CudaRecvPost::~CudaRecvPost(){

--- a/src/cudakernels/CudaRecvPre.cpp
+++ b/src/cudakernels/CudaRecvPre.cpp
@@ -6,6 +6,7 @@
 namespace PVCuda{
 
 CudaRecvPre::CudaRecvPre(CudaDevice* inDevice):CudaKernel(inDevice){
+   kernelName = "CudaRecvPre";
    numActive = nullptr;
 }
 

--- a/src/cudakernels/CudaTransposePoolingDeliverKernel.cpp
+++ b/src/cudakernels/CudaTransposePoolingDeliverKernel.cpp
@@ -87,7 +87,8 @@ void CudaTransposePoolingDeliverKernel::setArgs(
          ); //Width of each feature map
    cudnnHandleError(status, "Set input tensor descriptor");
    mDataStore = (float*) dataStoreBuffer->getPointer();
-   mCudnnDataStore = device->createBuffer(dataStoreBuffer->getSize());
+   std::string str(kernelName);
+   mCudnnDataStore = device->createBuffer(dataStoreBuffer->getSize(), &str);
 
    status = cudnnCreateTensorDescriptor(&mGSynDescriptor);
    cudnnHandleError(status, "Create input tensor descriptor");
@@ -104,7 +105,7 @@ void CudaTransposePoolingDeliverKernel::setArgs(
    int numGSynNeuronsAcrossBatch = mPostLoc->nx*mPostLoc->ny*mPostLoc->nf*mPostLoc->nbatch;
    float * gSynHead = (float*) gSynBuffer->getPointer();
    mGSyn = &gSynHead[channel*numGSynNeuronsAcrossBatch];
-   mCudnnGSyn = device->createBuffer(numGSynNeuronsAcrossBatch*sizeof(float));
+   mCudnnGSyn = device->createBuffer(numGSynNeuronsAcrossBatch*sizeof(float), &str);
 
    mOrigConnPreLoc = origConnPreLoc;
    mOrigConnPostLoc = origConnPostLoc;
@@ -125,7 +126,7 @@ void CudaTransposePoolingDeliverKernel::setArgs(
          ); //Width of each feature map
    cudnnHandleError(status, "Set original conn pre datastore tensor descriptor");
    mOrigConnDataStore = (float*) origConnDataStoreBuffer->getPointer();
-   mCudnnOrigConnDataStore = device->createBuffer(origConnDataStoreBuffer->getSize());
+   mCudnnOrigConnDataStore = device->createBuffer(origConnDataStoreBuffer->getSize(), &str);
 
    status = cudnnCreateTensorDescriptor(&mOrigConnGSynDescriptor);
    cudnnHandleError(status, "Create original conn post gsyn tensor descriptor");
@@ -142,7 +143,7 @@ void CudaTransposePoolingDeliverKernel::setArgs(
    int numOrigConnGSynNeuronsAcrossBatch = mOrigConnPostLoc->nf*mOrigConnPostLoc->ny*mOrigConnPostLoc->nf*mOrigConnPostLoc->nbatch;
    float * origConnGSynHead = (float*) origConnGSynBuffer->getPointer();
    mOrigConnGSyn = &origConnGSynHead[channel*numOrigConnGSynNeuronsAcrossBatch];
-   mCudnnOrigConnGSyn = device->createBuffer(numOrigConnGSynNeuronsAcrossBatch*sizeof(float));
+   mCudnnOrigConnGSyn = device->createBuffer(numOrigConnGSynNeuronsAcrossBatch*sizeof(float), &str);
 }
 
 int CudaTransposePoolingDeliverKernel::calcBorderExcess(int preRestricted, int postRestricted, int border, int patchSizePostPerspective) {

--- a/src/cudakernels/CudaTransposePoolingDeliverKernel.cpp
+++ b/src/cudakernels/CudaTransposePoolingDeliverKernel.cpp
@@ -13,6 +13,10 @@
 
 namespace PVCuda {
 
+CudaTransposePoolingDeliverKernel::CudaTransposePoolingDeliverKernel(CudaDevice* inDevice) : CudaKernel(inDevice) {
+   kernelName = "CudaTransposePoolingDeliverKernel";
+}
+
 CudaTransposePoolingDeliverKernel::~CudaTransposePoolingDeliverKernel() {
 }
 

--- a/src/cudakernels/CudaTransposePoolingDeliverKernel.hpp
+++ b/src/cudakernels/CudaTransposePoolingDeliverKernel.hpp
@@ -14,7 +14,7 @@ namespace PVCuda {
 
 class CudaTransposePoolingDeliverKernel: public CudaKernel {
 public:
-   CudaTransposePoolingDeliverKernel(CudaDevice * inDevice) : CudaKernel(inDevice) {}
+   CudaTransposePoolingDeliverKernel(CudaDevice * inDevice);
    virtual ~CudaTransposePoolingDeliverKernel();
    void setArgs(
           PVLayerLoc const * preLoc,

--- a/src/layers/HyPerLCALayer.cpp
+++ b/src/layers/HyPerLCALayer.cpp
@@ -152,12 +152,12 @@ int HyPerLCALayer::allocateUpdateKernel(){
    PVCuda::CudaBuffer* d_activity = getDeviceActivity();
 
    size_t size = parent->getNBatch() * sizeof(double);
-   d_dtAdapt = device->createBuffer(size);
+   d_dtAdapt = device->createBuffer(size, &description);
 
    size = (size_t) numVertices * sizeof(*verticesV);
-   d_verticesV = device->createBuffer(size);
-   d_verticesA = device->createBuffer(size);
-   d_slopes = device->createBuffer(size+sizeof(*slopes));
+   d_verticesV = device->createBuffer(size, &description);
+   d_verticesA = device->createBuffer(size, &description);
+   d_slopes = device->createBuffer(size+sizeof(*slopes), &description);
 
    d_verticesV->copyToDevice(verticesV);
    d_verticesA->copyToDevice(verticesA);

--- a/src/layers/HyPerLayer.cpp
+++ b/src/layers/HyPerLayer.cpp
@@ -998,34 +998,34 @@ int HyPerLayer::allocateDeviceBuffers()
 
    //Allocate based on which flags are set
    if(allocDeviceV){
-     d_V = device->createBuffer(size);
+     d_V = device->createBuffer(size, &description);
    }
 
    if(allocDeviceDatastore){
-     d_Datastore= device->createBuffer(size_ex);
+     d_Datastore= device->createBuffer(size_ex, &description);
       assert(d_Datastore);
 #ifdef PV_USE_CUDNN
-      cudnn_Datastore = device->createBuffer(size_ex);
+      cudnn_Datastore = device->createBuffer(size_ex, &description);
       assert(cudnn_Datastore);
 #endif
    }
 
    if(allocDeviceActiveIndices){
-      d_numActive = device->createBuffer(parent->getNBatch() * sizeof(long));
-      d_ActiveIndices= device->createBuffer(size_ex);
+      d_numActive = device->createBuffer(parent->getNBatch() * sizeof(long), &description);
+      d_ActiveIndices= device->createBuffer(size_ex, &description);
       assert(d_ActiveIndices);
    }
 
    if(allocDeviceActivity){
-      d_Activity = device->createBuffer(size_ex);
+      d_Activity = device->createBuffer(size_ex, &description);
    }
 
    //d_GSyn is the entire gsyn buffer. cudnn_GSyn is only one gsyn channel
    if(allocDeviceGSyn){
-      d_GSyn = device->createBuffer(size * numChannels);
+      d_GSyn = device->createBuffer(size * numChannels, &description);
       assert(d_GSyn);
 #ifdef PV_USE_CUDNN
-      cudnn_GSyn = device->createBuffer(size);
+      cudnn_GSyn = device->createBuffer(size, &description);
 #endif
    }
 

--- a/src/layers/ISTALayer.cpp
+++ b/src/layers/ISTALayer.cpp
@@ -140,7 +140,7 @@ int ISTALayer::allocateUpdateKernel(){
    PVCuda::CudaBuffer* d_activity = getDeviceActivity();
 
    size_t size = parent->getNBatch() * sizeof(double);
-   d_dtAdapt = device->createBuffer(size);
+   d_dtAdapt = device->createBuffer(size, &description);
 
    //Set arguments to kernel
    updateKernel->setArgs(

--- a/src/layers/MomentumLCALayer.cpp
+++ b/src/layers/MomentumLCALayer.cpp
@@ -111,7 +111,7 @@ void MomentumLCALayer::ioParam_LCAMomentumRate(enum ParamsIOFlag ioFlag) {
 #ifdef PV_USE_CUDA
 int MomentumLCALayer::allocateUpdateKernel(){
    PVCuda::CudaDevice * device = parent->getDevice();
-   d_prevDrive = device->createBuffer(getNumNeuronsAllBatches() * sizeof(float));
+   d_prevDrive = device->createBuffer(getNumNeuronsAllBatches() * sizeof(float), &description);
    //Set to temp pointer of the subclass
    PVCuda::CudaUpdateMomentumLCALayer * updateKernel = new PVCuda::CudaUpdateMomentumLCALayer(device);
    //Set arguments
@@ -140,12 +140,12 @@ int MomentumLCALayer::allocateUpdateKernel(){
    PVCuda::CudaBuffer* d_activity = getDeviceActivity();
 
    size_t size = parent->getNBatch() * sizeof(double);
-   d_dtAdapt = device->createBuffer(size);
+   d_dtAdapt = device->createBuffer(size, &description);
 
    size = (size_t) numVertices * sizeof(*verticesV);
-   d_verticesV = device->createBuffer(size);
-   d_verticesA = device->createBuffer(size);
-   d_slopes = device->createBuffer(size+sizeof(*slopes));
+   d_verticesV = device->createBuffer(size, &description);
+   d_verticesA = device->createBuffer(size, &description);
+   d_slopes = device->createBuffer(size+sizeof(*slopes), &description);
 
    d_verticesV->copyToDevice(verticesV);
    d_verticesA->copyToDevice(verticesA);


### PR DESCRIPTION
PoolingConn and TransposePoolingConn do not need to create buffers for wData on the GPU.  In this pull request, PoolingConn and TransposePoolingConn override several methods that allocate or refer to these buffers. Specifically,
- allocatePostDeviceWeights
- allocateDeviceWeights
- initializeReceivePostKernelArgs
- initializeReceivePreKernelArgs
- updateDeviceWeights
  CudaDevice::createBuffer takes a string as a second argument, which is included in the log message.  Layers and connections pass their description.  Cuda kernels pass a string generated from kernelName.
