### PR TITLE
Param input output refactor

### DIFF
--- a/demos/HeatMapLocalization/src/BBFindConfRemapLayer.cpp
+++ b/demos/HeatMapLocalization/src/BBFindConfRemapLayer.cpp
@@ -68,67 +68,67 @@ int BBFindConfRemapLayer::ioParamsFillGroup(enum PV::ParamsIOFlag ioFlag) {
 }
 
 void BBFindConfRemapLayer::ioParam_displayedCategories(enum PV::ParamsIOFlag ioFlag) {
-   this->getParent()->ioParamArray(ioFlag, this->getName(), "displayedCategories", &displayedCategories, &numDisplayedCategories);
+   this->getParent()->parameters()->ioParamArray(ioFlag, this->getName(), "displayedCategories", &displayedCategories, &numDisplayedCategories);
 }
 
 void BBFindConfRemapLayer::ioParam_imageLayer(enum PV::ParamsIOFlag ioFlag) {
-   parent->ioParamString(ioFlag, name, "imageLayer", &imageLayerName, "", true/*warnIfAbsent*/);
+   parent->parameters()->ioParamString(ioFlag, name, "imageLayer", &imageLayerName, "", true/*warnIfAbsent*/);
 }
 
 void BBFindConfRemapLayer::ioParam_framesPerMap(enum PV::ParamsIOFlag ioFlag) {
-   parent->ioParamValue(ioFlag, name, "framesPerMap", &framesPerMap, framesPerMap, true/*warnIfAbsent*/);
+   parent->parameters()->ioParamValue(ioFlag, name, "framesPerMap", &framesPerMap, framesPerMap, true/*warnIfAbsent*/);
 }
 
 void BBFindConfRemapLayer::ioParam_threshold(enum PV::ParamsIOFlag ioFlag) {
-   parent->ioParamValue(ioFlag, name, "threshold", &threshold, threshold, true/*warnIfAbsent*/);
+   parent->parameters()->ioParamValue(ioFlag, name, "threshold", &threshold, threshold, true/*warnIfAbsent*/);
 }
 
 void BBFindConfRemapLayer::ioParam_contrast(enum PV::ParamsIOFlag ioFlag) {
-   parent->ioParamValue(ioFlag, name, "contrast", &contrast, contrast, true/*warnIfAbsent*/);
+   parent->parameters()->ioParamValue(ioFlag, name, "contrast", &contrast, contrast, true/*warnIfAbsent*/);
 }
 
 void BBFindConfRemapLayer::ioParam_contrastStrength(enum PV::ParamsIOFlag ioFlag) {
-   parent->ioParamValue(ioFlag, name, "contrastStrength", &contrastStrength, contrastStrength, true/*warnIfAbsent*/);
+   parent->parameters()->ioParamValue(ioFlag, name, "contrastStrength", &contrastStrength, contrastStrength, true/*warnIfAbsent*/);
 }
 
 void BBFindConfRemapLayer::ioParam_prevInfluence(enum PV::ParamsIOFlag ioFlag) {
-   parent->ioParamValue(ioFlag, name, "prevInfluence", &prevInfluence, prevInfluence, true/*warnIfAbsent*/);
+   parent->parameters()->ioParamValue(ioFlag, name, "prevInfluence", &prevInfluence, prevInfluence, true/*warnIfAbsent*/);
 }
 
 void BBFindConfRemapLayer::ioParam_accumulateAmount(enum PV::ParamsIOFlag ioFlag) {
-   parent->ioParamValue(ioFlag, name, "accumulateAmount", &accumulateAmount, accumulateAmount, true/*warnIfAbsent*/);
+   parent->parameters()->ioParamValue(ioFlag, name, "accumulateAmount", &accumulateAmount, accumulateAmount, true/*warnIfAbsent*/);
 }
 
 void BBFindConfRemapLayer::ioParam_prevLeakTau(enum PV::ParamsIOFlag ioFlag) {
-   parent->ioParamValue(ioFlag, name, "prevLeakTau", &prevLeakTau, prevLeakTau, true/*warnIfAbsent*/);
+   parent->parameters()->ioParamValue(ioFlag, name, "prevLeakTau", &prevLeakTau, prevLeakTau, true/*warnIfAbsent*/);
 }
 
 void BBFindConfRemapLayer::ioParam_minBlobSize(enum PV::ParamsIOFlag ioFlag) {
-   parent->ioParamValue(ioFlag, name, "minBlobSize", &minBlobSize, minBlobSize, true/*warnIfAbsent*/);
+   parent->parameters()->ioParamValue(ioFlag, name, "minBlobSize", &minBlobSize, minBlobSize, true/*warnIfAbsent*/);
 }
 
 void BBFindConfRemapLayer::ioParam_boundingboxGuessSize(enum PV::ParamsIOFlag ioFlag) {
-   parent->ioParamValue(ioFlag, name, "boundingboxGuessSize", &boundingboxGuessSize, boundingboxGuessSize, true/*warnIfAbsent*/);
+   parent->parameters()->ioParamValue(ioFlag, name, "boundingboxGuessSize", &boundingboxGuessSize, boundingboxGuessSize, true/*warnIfAbsent*/);
 }
 
 void BBFindConfRemapLayer::ioParam_slidingAverageSize(enum PV::ParamsIOFlag ioFlag) {
-   parent->ioParamValue(ioFlag, name, "slidingAverageSize", &slidingAverageSize, slidingAverageSize, true/*warnIfAbsent*/);
+   parent->parameters()->ioParamValue(ioFlag, name, "slidingAverageSize", &slidingAverageSize, slidingAverageSize, true/*warnIfAbsent*/);
 }
 
 void BBFindConfRemapLayer::ioParam_maxRectangleMemory(enum PV::ParamsIOFlag ioFlag) {
-   parent->ioParamValue(ioFlag, name, "maxRectangleMemory", &maxRectangleMemory, maxRectangleMemory, true/*warnIfAbsent*/);
+   parent->parameters()->ioParamValue(ioFlag, name, "maxRectangleMemory", &maxRectangleMemory, maxRectangleMemory, true/*warnIfAbsent*/);
 }
 
 void BBFindConfRemapLayer::ioParam_detectionWait(enum PV::ParamsIOFlag ioFlag) {
-   parent->ioParamValue(ioFlag, name, "detectionWait", &detectionWait, detectionWait, true/*warnIfAbsent*/);
+   parent->parameters()->ioParamValue(ioFlag, name, "detectionWait", &detectionWait, detectionWait, true/*warnIfAbsent*/);
 }
 
 void BBFindConfRemapLayer::ioParam_internalMapWidth(enum PV::ParamsIOFlag ioFlag) {
-   parent->ioParamValue(ioFlag, name, "internalMapWidth", &internalMapWidth, internalMapWidth, true/*warnIfAbsent*/);
+   parent->parameters()->ioParamValue(ioFlag, name, "internalMapWidth", &internalMapWidth, internalMapWidth, true/*warnIfAbsent*/);
 }
 
 void BBFindConfRemapLayer::ioParam_internalMapHeight(enum PV::ParamsIOFlag ioFlag) {
-   parent->ioParamValue(ioFlag, name, "internalMapHeight", &internalMapHeight, internalMapHeight, true/*warnIfAbsent*/);
+   parent->parameters()->ioParamValue(ioFlag, name, "internalMapHeight", &internalMapHeight, internalMapHeight, true/*warnIfAbsent*/);
 }
 
 int BBFindConfRemapLayer::communicateInitInfo() {

--- a/demos/HeatMapLocalization/src/BBFindConfRemapProbe.cpp
+++ b/demos/HeatMapLocalization/src/BBFindConfRemapProbe.cpp
@@ -50,68 +50,68 @@ int BBFindConfRemapProbe::ioParamsFillGroup(enum PV::ParamsIOFlag ioFlag) {
 }
 
 void BBFindConfRemapProbe::ioParam_imageLayer(enum PV::ParamsIOFlag ioFlag) {
-   parent->ioParamStringRequired(ioFlag, name, "imageLayer", &imageLayerName);
+   parent->parameters()->ioParamStringRequired(ioFlag, name, "imageLayer", &imageLayerName);
 }
 
 void BBFindConfRemapProbe::ioParam_reconLayer(enum PV::ParamsIOFlag ioFlag) {
-   parent->ioParamStringRequired(ioFlag, name, "reconLayer", &reconLayerName);
+   parent->parameters()->ioParamStringRequired(ioFlag, name, "reconLayer", &reconLayerName);
 }
 
 void BBFindConfRemapProbe::ioParam_classNamesFile(enum PV::ParamsIOFlag ioFlag) {
-   parent->ioParamString(ioFlag, name, "classNamesFile", &classNamesFile, "");
+   parent->parameters()->ioParamString(ioFlag, name, "classNamesFile", &classNamesFile, "");
 }
 
 void BBFindConfRemapProbe::ioParam_minBoundingBoxWidth(enum PV::ParamsIOFlag ioFlag) {
-   this->getParent()->ioParamValue(ioFlag, this->getName(), "minBoundingBoxWidth", &minBoundingBoxWidth, minBoundingBoxWidth, true/*warnIfAbsent*/);
+   this->getParent()->parameters()->ioParamValue(ioFlag, this->getName(), "minBoundingBoxWidth", &minBoundingBoxWidth, minBoundingBoxWidth, true/*warnIfAbsent*/);
 }
 
 void BBFindConfRemapProbe::ioParam_minBoundingBoxHeight(enum PV::ParamsIOFlag ioFlag) {
-   this->getParent()->ioParamValue(ioFlag, this->getName(), "minBoundingBoxHeight", &minBoundingBoxHeight, minBoundingBoxHeight, true/*warnIfAbsent*/);
+   this->getParent()->parameters()->ioParamValue(ioFlag, this->getName(), "minBoundingBoxHeight", &minBoundingBoxHeight, minBoundingBoxHeight, true/*warnIfAbsent*/);
 }
 
 void BBFindConfRemapProbe::ioParam_drawMontage(enum PV::ParamsIOFlag ioFlag) {
-   this->getParent()->ioParamValue(ioFlag, this->getName(), "drawMontage", &drawMontage, drawMontage, true/*warnIfAbsent*/);
+   this->getParent()->parameters()->ioParamValue(ioFlag, this->getName(), "drawMontage", &drawMontage, drawMontage, true/*warnIfAbsent*/);
 }
 
 void BBFindConfRemapProbe::ioParam_heatMapMontageDir(enum PV::ParamsIOFlag ioFlag) {
    assert(!parent->parameters()->presentAndNotBeenRead(this->getName(), "drawMontage"));
    if (drawMontage) {
-      this->getParent()->ioParamStringRequired(ioFlag, this->getName(), "heatMapMontageDir", &heatMapMontageDir);
+      this->getParent()->parameters()->ioParamStringRequired(ioFlag, this->getName(), "heatMapMontageDir", &heatMapMontageDir);
    }
 }
 
 void BBFindConfRemapProbe::ioParam_heatMapThreshold(enum PV::ParamsIOFlag ioFlag) {
    assert(!parent->parameters()->presentAndNotBeenRead(this->getName(), "drawMontage"));
    if (drawMontage) {
-      parent->ioParamArray(ioFlag, name, "heatMapThreshold", &heatMapThreshold, &numHeatMapThresholds);
+      parent->parameters()->ioParamArray(ioFlag, name, "heatMapThreshold", &heatMapThreshold, &numHeatMapThresholds);
    }
 }
 
 void BBFindConfRemapProbe::ioParam_heatMapMaximum(enum PV::ParamsIOFlag ioFlag) {
    assert(!parent->parameters()->presentAndNotBeenRead(this->getName(), "drawMontage"));
    if (drawMontage) {
-      parent->ioParamArray(ioFlag, name, "heatMapMaximum", &heatMapMaximum, &numHeatMapMaxima);
+      parent->parameters()->ioParamArray(ioFlag, name, "heatMapMaximum", &heatMapMaximum, &numHeatMapMaxima);
    }
 }
 
 void BBFindConfRemapProbe::ioParam_imageBlendCoeff(enum PV::ParamsIOFlag ioFlag) {
    assert(!parent->parameters()->presentAndNotBeenRead(this->getName(), "drawMontage"));
    if (drawMontage) {
-      this->getParent()->ioParamValue(ioFlag, this->getName(), "imageBlendCoeff", &imageBlendCoeff, imageBlendCoeff/*default value*/, true/*warnIfAbsent*/);
+      this->getParent()->parameters()->ioParamValue(ioFlag, this->getName(), "imageBlendCoeff", &imageBlendCoeff, imageBlendCoeff/*default value*/, true/*warnIfAbsent*/);
    }
 }
 
 void BBFindConfRemapProbe::ioParam_boundingBoxLineWidth(enum PV::ParamsIOFlag ioFlag) {
    assert(!parent->parameters()->presentAndNotBeenRead(this->getName(), "drawMontage"));
    if (drawMontage) {
-      this->getParent()->ioParamValue(ioFlag, this->getName(), "boundingBoxLineWidth", &boundingBoxLineWidth, boundingBoxLineWidth/*default value*/, true/*warnIfAbsent*/);
+      this->getParent()->parameters()->ioParamValue(ioFlag, this->getName(), "boundingBoxLineWidth", &boundingBoxLineWidth, boundingBoxLineWidth/*default value*/, true/*warnIfAbsent*/);
    }
 }
 
 void BBFindConfRemapProbe::ioParam_displayCommand(enum PV::ParamsIOFlag ioFlag) {
    assert(!parent->parameters()->presentAndNotBeenRead(this->getName(), "drawMontage"));
    if (drawMontage) {
-      this->getParent()->ioParamString(ioFlag, this->getName(), "displayCommand", &displayCommand, NULL, true/*warnIfAbsent*/);
+      this->getParent()->parameters()->ioParamString(ioFlag, this->getName(), "displayCommand", &displayCommand, NULL, true/*warnIfAbsent*/);
    }
 }
 

--- a/demos/HeatMapLocalization/src/ConvertFromTable.cpp
+++ b/demos/HeatMapLocalization/src/ConvertFromTable.cpp
@@ -36,7 +36,7 @@ int ConvertFromTable::ioParamsFillGroup(enum PV::ParamsIOFlag ioFlag) {
 }
 
 void ConvertFromTable::ioParam_dataFile(enum PV::ParamsIOFlag ioFlag) {
-   parent->ioParamStringRequired(ioFlag, name, "dataFile", &dataFile);
+   parent->parameters()->ioParamStringRequired(ioFlag, name, "dataFile", &dataFile);
 }
 
 int ConvertFromTable::allocateDataStructures() {

--- a/demos/HeatMapLocalization/src/LocalizationBBFindProbe.cpp
+++ b/demos/HeatMapLocalization/src/LocalizationBBFindProbe.cpp
@@ -70,59 +70,59 @@ int LocalizationBBFindProbe::ioParamsFillGroup(enum PV::ParamsIOFlag ioFlag) {
 }
 
 void LocalizationBBFindProbe::ioParam_framesPerMap(enum PV::ParamsIOFlag ioFlag) {
-   this->getParent()->ioParamValue(ioFlag, this->getName(), "framesPerMap", &framesPerMap, framesPerMap, true/*warnIfAbsent*/);
+   this->getParent()->parameters()->ioParamValue(ioFlag, this->getName(), "framesPerMap", &framesPerMap, framesPerMap, true/*warnIfAbsent*/);
 }
 
 void LocalizationBBFindProbe::ioParam_threshold(enum PV::ParamsIOFlag ioFlag) {
-   parent->ioParamValue(ioFlag, name, "threshold", &threshold, threshold, true/*warnIfAbsent*/);
+   parent->parameters()->ioParamValue(ioFlag, name, "threshold", &threshold, threshold, true/*warnIfAbsent*/);
 }
 
 void LocalizationBBFindProbe::ioParam_contrast(enum PV::ParamsIOFlag ioFlag) {
-   parent->ioParamValue(ioFlag, name, "contrast", &contrast, contrast, true/*warnIfAbsent*/);
+   parent->parameters()->ioParamValue(ioFlag, name, "contrast", &contrast, contrast, true/*warnIfAbsent*/);
 }
 
 void LocalizationBBFindProbe::ioParam_contrastStrength(enum PV::ParamsIOFlag ioFlag) {
-   parent->ioParamValue(ioFlag, name, "contrastStrength", &contrastStrength, contrastStrength, true/*warnIfAbsent*/);
+   parent->parameters()->ioParamValue(ioFlag, name, "contrastStrength", &contrastStrength, contrastStrength, true/*warnIfAbsent*/);
 }
 
 void LocalizationBBFindProbe::ioParam_prevInfluence(enum PV::ParamsIOFlag ioFlag) {
-   parent->ioParamValue(ioFlag, name, "prevInfluence", &prevInfluence, prevInfluence, true/*warnIfAbsent*/);
+   parent->parameters()->ioParamValue(ioFlag, name, "prevInfluence", &prevInfluence, prevInfluence, true/*warnIfAbsent*/);
 }
 
 void LocalizationBBFindProbe::ioParam_accumulateAmount(enum PV::ParamsIOFlag ioFlag) {
-   parent->ioParamValue(ioFlag, name, "accumulateAmount", &accumulateAmount, accumulateAmount, true/*warnIfAbsent*/);
+   parent->parameters()->ioParamValue(ioFlag, name, "accumulateAmount", &accumulateAmount, accumulateAmount, true/*warnIfAbsent*/);
 }
 
 void LocalizationBBFindProbe::ioParam_prevLeakTau(enum PV::ParamsIOFlag ioFlag) {
-   parent->ioParamValue(ioFlag, name, "prevLeakTau", &prevLeakTau, prevLeakTau, true/*warnIfAbsent*/);
+   parent->parameters()->ioParamValue(ioFlag, name, "prevLeakTau", &prevLeakTau, prevLeakTau, true/*warnIfAbsent*/);
 }
 
 void LocalizationBBFindProbe::ioParam_minBlobSize(enum PV::ParamsIOFlag ioFlag) {
-   parent->ioParamValue(ioFlag, name, "minBlobSize", &minBlobSize, minBlobSize, true/*warnIfAbsent*/);
+   parent->parameters()->ioParamValue(ioFlag, name, "minBlobSize", &minBlobSize, minBlobSize, true/*warnIfAbsent*/);
 }
 
 void LocalizationBBFindProbe::ioParam_boundingboxGuessSize(enum PV::ParamsIOFlag ioFlag) {
-   parent->ioParamValue(ioFlag, name, "boundingboxGuessSize", &boundingboxGuessSize, boundingboxGuessSize, true/*warnIfAbsent*/);
+   parent->parameters()->ioParamValue(ioFlag, name, "boundingboxGuessSize", &boundingboxGuessSize, boundingboxGuessSize, true/*warnIfAbsent*/);
 }
 
 void LocalizationBBFindProbe::ioParam_slidingAverageSize(enum PV::ParamsIOFlag ioFlag) {
-   parent->ioParamValue(ioFlag, name, "slidingAverageSize", &slidingAverageSize, slidingAverageSize, true/*warnIfAbsent*/);
+   parent->parameters()->ioParamValue(ioFlag, name, "slidingAverageSize", &slidingAverageSize, slidingAverageSize, true/*warnIfAbsent*/);
 }
 
 void LocalizationBBFindProbe::ioParam_maxRectangleMemory(enum PV::ParamsIOFlag ioFlag) {
-   parent->ioParamValue(ioFlag, name, "maxRectangleMemory", &maxRectangleMemory, maxRectangleMemory, true/*warnIfAbsent*/);
+   parent->parameters()->ioParamValue(ioFlag, name, "maxRectangleMemory", &maxRectangleMemory, maxRectangleMemory, true/*warnIfAbsent*/);
 }
 
 void LocalizationBBFindProbe::ioParam_detectionWait(enum PV::ParamsIOFlag ioFlag) {
-   parent->ioParamValue(ioFlag, name, "detectionWait", &detectionWait, detectionWait, true/*warnIfAbsent*/);
+   parent->parameters()->ioParamValue(ioFlag, name, "detectionWait", &detectionWait, detectionWait, true/*warnIfAbsent*/);
 }
 
 void LocalizationBBFindProbe::ioParam_internalMapWidth(enum PV::ParamsIOFlag ioFlag) {
-   parent->ioParamValue(ioFlag, name, "internalMapWidth", &internalMapWidth, internalMapWidth, true/*warnIfAbsent*/);
+   parent->parameters()->ioParamValue(ioFlag, name, "internalMapWidth", &internalMapWidth, internalMapWidth, true/*warnIfAbsent*/);
 }
 
 void LocalizationBBFindProbe::ioParam_internalMapHeight(enum PV::ParamsIOFlag ioFlag) {
-   parent->ioParamValue(ioFlag, name, "internalMapHeight", &internalMapHeight, internalMapHeight, true/*warnIfAbsent*/);
+   parent->parameters()->ioParamValue(ioFlag, name, "internalMapHeight", &internalMapHeight, internalMapHeight, true/*warnIfAbsent*/);
 }
 
 int LocalizationBBFindProbe::communicateInitInfo() {

--- a/demos/HeatMapLocalization/src/LocalizationProbe.cpp
+++ b/demos/HeatMapLocalization/src/LocalizationProbe.cpp
@@ -96,43 +96,43 @@ int LocalizationProbe::ioParamsFillGroup(enum PV::ParamsIOFlag ioFlag) {
 }
 
 void LocalizationProbe::ioParam_imageLayer(enum PV::ParamsIOFlag ioFlag) {
-   parent->ioParamStringRequired(ioFlag, name, "imageLayer", &imageLayerName);
+   parent->parameters()->ioParamStringRequired(ioFlag, name, "imageLayer", &imageLayerName);
 }
 
 void LocalizationProbe::ioParam_reconLayer(enum PV::ParamsIOFlag ioFlag) {
-   parent->ioParamStringRequired(ioFlag, name, "reconLayer", &reconLayerName);
+   parent->parameters()->ioParamStringRequired(ioFlag, name, "reconLayer", &reconLayerName);
 }
 
 void LocalizationProbe::ioParam_displayedCategories(enum PV::ParamsIOFlag ioFlag) {
-   this->getParent()->ioParamArray(ioFlag, this->getName(), "displayedCategories", &displayedCategories, &numDisplayedCategories);
+   this->getParent()->parameters()->ioParamArray(ioFlag, this->getName(), "displayedCategories", &displayedCategories, &numDisplayedCategories);
 }
 
 void LocalizationProbe::ioParam_displayCategoryIndexStart(enum PV::ParamsIOFlag ioFlag) {
    assert(!parent->parameters()->presentAndNotBeenRead(this->getName(), "displayedCategories"));
    if (numDisplayedCategories==0) {
-      this->getParent()->ioParamValue(ioFlag, this->getName(), "displayCategoryIndexStart", &displayCategoryIndexStart, -1, true/*warnIfAbsent*/);
+      this->getParent()->parameters()->ioParamValue(ioFlag, this->getName(), "displayCategoryIndexStart", &displayCategoryIndexStart, -1, true/*warnIfAbsent*/);
    }
 }
 
 void LocalizationProbe::ioParam_displayCategoryIndexEnd(enum PV::ParamsIOFlag ioFlag) {
    assert(!parent->parameters()->presentAndNotBeenRead(this->getName(), "displayedCategories"));
    if (numDisplayedCategories==0) {
-      this->getParent()->ioParamValue(ioFlag, this->getName(), "displayCategoryIndexEnd", &displayCategoryIndexEnd, -1, true/*warnIfAbsent*/);
+      this->getParent()->parameters()->ioParamValue(ioFlag, this->getName(), "displayCategoryIndexEnd", &displayCategoryIndexEnd, -1, true/*warnIfAbsent*/);
    }
 }
 
 void LocalizationProbe::ioParam_detectionThreshold(enum PV::ParamsIOFlag ioFlag) {
-   parent->ioParamArray(ioFlag, name, "detectionThreshold", &detectionThreshold, &numDetectionThresholds);
+   parent->parameters()->ioParamArray(ioFlag, name, "detectionThreshold", &detectionThreshold, &numDetectionThresholds);
 }
 
 void LocalizationProbe::ioParam_classNamesFile(enum PV::ParamsIOFlag ioFlag) {
-   parent->ioParamString(ioFlag, name, "classNamesFile", &classNamesFile, "");
+   parent->parameters()->ioParamString(ioFlag, name, "classNamesFile", &classNamesFile, "");
 }
 
 void LocalizationProbe::ioParam_outputPeriod(enum PV::ParamsIOFlag ioFlag) {
    assert(!parent->parameters()->presentAndNotBeenRead(this->getName(), "triggerLayer"));
    if (!triggerLayer) {
-      this->getParent()->ioParamValue(ioFlag, this->getName(), "outputPeriod", &outputPeriod, outputPeriod, true/*warnIfAbsent*/);
+      this->getParent()->parameters()->ioParamValue(ioFlag, this->getName(), "outputPeriod", &outputPeriod, outputPeriod, true/*warnIfAbsent*/);
    }
    if (ioFlag==PV::PARAMS_IO_READ) {
       nextOutputTime = outputPeriod;
@@ -140,53 +140,53 @@ void LocalizationProbe::ioParam_outputPeriod(enum PV::ParamsIOFlag ioFlag) {
 }
 
 void LocalizationProbe::ioParam_minBoundingBoxWidth(enum PV::ParamsIOFlag ioFlag) {
-   this->getParent()->ioParamValue(ioFlag, this->getName(), "minBoundingBoxWidth", &minBoundingBoxWidth, minBoundingBoxWidth, true/*warnIfAbsent*/);
+   this->getParent()->parameters()->ioParamValue(ioFlag, this->getName(), "minBoundingBoxWidth", &minBoundingBoxWidth, minBoundingBoxWidth, true/*warnIfAbsent*/);
 }
 
 void LocalizationProbe::ioParam_minBoundingBoxHeight(enum PV::ParamsIOFlag ioFlag) {
-   this->getParent()->ioParamValue(ioFlag, this->getName(), "minBoundingBoxHeight", &minBoundingBoxHeight, minBoundingBoxHeight, true/*warnIfAbsent*/);
+   this->getParent()->parameters()->ioParamValue(ioFlag, this->getName(), "minBoundingBoxHeight", &minBoundingBoxHeight, minBoundingBoxHeight, true/*warnIfAbsent*/);
 }
 
 void LocalizationProbe::ioParam_drawMontage(enum PV::ParamsIOFlag ioFlag) {
-   this->getParent()->ioParamValue(ioFlag, this->getName(), "drawMontage", &drawMontage, drawMontage, true/*warnIfAbsent*/);
+   this->getParent()->parameters()->ioParamValue(ioFlag, this->getName(), "drawMontage", &drawMontage, drawMontage, true/*warnIfAbsent*/);
 }
 
 void LocalizationProbe::ioParam_heatMapMontageDir(enum PV::ParamsIOFlag ioFlag) {
    assert(!parent->parameters()->presentAndNotBeenRead(this->getName(), "drawMontage"));
    if (drawMontage) {
-      this->getParent()->ioParamStringRequired(ioFlag, this->getName(), "heatMapMontageDir", &heatMapMontageDir);
+      this->getParent()->parameters()->ioParamStringRequired(ioFlag, this->getName(), "heatMapMontageDir", &heatMapMontageDir);
    }
 }
 
 void LocalizationProbe::ioParam_heatMapMaximum(enum PV::ParamsIOFlag ioFlag) {
    assert(!parent->parameters()->presentAndNotBeenRead(this->getName(), "drawMontage"));
    if (drawMontage) {
-      parent->ioParamArray(ioFlag, name, "heatMapMaximum", &heatMapMaximum, &numHeatMapMaxima);
+      parent->parameters()->ioParamArray(ioFlag, name, "heatMapMaximum", &heatMapMaximum, &numHeatMapMaxima);
    }
 }
 
 void LocalizationProbe::ioParam_imageBlendCoeff(enum PV::ParamsIOFlag ioFlag) {
    assert(!parent->parameters()->presentAndNotBeenRead(this->getName(), "drawMontage"));
    if (drawMontage) {
-      this->getParent()->ioParamValue(ioFlag, this->getName(), "imageBlendCoeff", &imageBlendCoeff, imageBlendCoeff/*default value*/, true/*warnIfAbsent*/);
+      this->getParent()->parameters()->ioParamValue(ioFlag, this->getName(), "imageBlendCoeff", &imageBlendCoeff, imageBlendCoeff/*default value*/, true/*warnIfAbsent*/);
    }
 }
 
 void LocalizationProbe::ioParam_maxDetections(enum PV::ParamsIOFlag ioFlag) {
-   this->getParent()->ioParamValue(ioFlag, this->getName(), "maxDetections", &maxDetections, maxDetections, true/*warnIfAbsent*/);
+   this->getParent()->parameters()->ioParamValue(ioFlag, this->getName(), "maxDetections", &maxDetections, maxDetections, true/*warnIfAbsent*/);
 }
 
 void LocalizationProbe::ioParam_boundingBoxLineWidth(enum PV::ParamsIOFlag ioFlag) {
    assert(!parent->parameters()->presentAndNotBeenRead(this->getName(), "drawMontage"));
    if (drawMontage) {
-      this->getParent()->ioParamValue(ioFlag, this->getName(), "boundingBoxLineWidth", &boundingBoxLineWidth, boundingBoxLineWidth/*default value*/, true/*warnIfAbsent*/);
+      this->getParent()->parameters()->ioParamValue(ioFlag, this->getName(), "boundingBoxLineWidth", &boundingBoxLineWidth, boundingBoxLineWidth/*default value*/, true/*warnIfAbsent*/);
    }
 }
 
 void LocalizationProbe::ioParam_displayCommand(enum PV::ParamsIOFlag ioFlag) {
    assert(!parent->parameters()->presentAndNotBeenRead(this->getName(), "drawMontage"));
    if (drawMontage) {
-      this->getParent()->ioParamString(ioFlag, this->getName(), "displayCommand", &displayCommand, NULL, true/*warnIfAbsent*/);     
+      this->getParent()->parameters()->ioParamString(ioFlag, this->getName(), "displayCommand", &displayCommand, NULL, true/*warnIfAbsent*/);     
    }
 }
 

--- a/demos/HeatMapLocalization/src/MaskFromMemoryBuffer.cpp
+++ b/demos/HeatMapLocalization/src/MaskFromMemoryBuffer.cpp
@@ -40,7 +40,7 @@ int MaskFromMemoryBuffer::ioParamsFillGroup(enum PV::ParamsIOFlag ioFlag) {
 }
 
 void MaskFromMemoryBuffer::ioParam_imageLayerName(enum PV::ParamsIOFlag ioFlag) {
-   parent->ioParamStringRequired(ioFlag, name, "imageLayerName", &imageLayerName);
+   parent->parameters()->ioParamStringRequired(ioFlag, name, "imageLayerName", &imageLayerName);
 }
 
 int MaskFromMemoryBuffer::communicateInitInfo() {

--- a/src/columns/HyPerCol.hpp
+++ b/src/columns/HyPerCol.hpp
@@ -347,19 +347,8 @@ public:
    template <typename T>
    int writeScalarToFile(const char* cp_dir, const char* group_name, const char* val_name, T val);
    NormalizeBase* getNormalizerFromName(const char* normalizerName);
-   template <typename T>
-   void ioParamValueRequired(enum ParamsIOFlag ioFlag, const char * group_name, const char * param_name, T * val);
-   template <typename T>
-   void ioParamValue(enum ParamsIOFlag ioFlag, const char * group_name, const char * param_name, T * val, T defaultValue, bool warnIfAbsent=true);
-   void ioParamString(enum ParamsIOFlag ioFlag, const char * group_name, const char * param_name, char ** value, const char * defaultValue, bool warnIfAbsent=true);
-   void ioParamStringRequired(enum ParamsIOFlag ioFlag, const char * group_name, const char * param_name, char ** value);
-   template <typename T>
-   void ioParamArray(enum ParamsIOFlag ioFlag, const char * group_name, const char * param_name, T ** value, int * arraysize);
-   template <typename T>
-   void writeParam(const char* param_name, T value);
-   template <typename T>
-   void writeParamArray(const char* param_name, const T* array, int arraysize);
-   void writeParamString(const char* param_name, const char* svalue);
+
+   // Sep 26, 2016: HyPerCol methods for parameter input/output have been moved to PVParams.
 
 #ifdef PV_USE_CUDA
    int finalizeThreads();

--- a/src/connections/BaseConnection.cpp
+++ b/src/connections/BaseConnection.cpp
@@ -241,17 +241,17 @@ int BaseConnection::ioParamsFillGroup(enum ParamsIOFlag ioFlag) {
 }
 
 void BaseConnection::ioParam_preLayerName(enum ParamsIOFlag ioFlag) {
-   this->getParent()->ioParamString(ioFlag, this->getName(), "preLayerName", &preLayerName, NULL, false/*warnIfAbsent*/);
+   this->getParent()->parameters()->ioParamString(ioFlag, this->getName(), "preLayerName", &preLayerName, NULL, false/*warnIfAbsent*/);
 }
 
 void BaseConnection::ioParam_postLayerName(enum ParamsIOFlag ioFlag) {
-   this->getParent()->ioParamString(ioFlag, this->getName(), "postLayerName", &postLayerName, NULL, false/*warnIfAbsent*/);
+   this->getParent()->parameters()->ioParamString(ioFlag, this->getName(), "postLayerName", &postLayerName, NULL, false/*warnIfAbsent*/);
 }
 
 void BaseConnection::ioParam_channelCode(enum ParamsIOFlag ioFlag) {
    if (ioFlag==PARAMS_IO_READ) {
       int ch = 0;
-      this->getParent()->ioParamValueRequired(ioFlag, this->getName(), "channelCode", &ch);
+      this->getParent()->parameters()->ioParamValueRequired(ioFlag, this->getName(), "channelCode", &ch);
       int status = decodeChannel(ch, &channel);
       if (status != PV_SUCCESS) {
          if (this->getParent()->columnId()==0) {
@@ -264,7 +264,7 @@ void BaseConnection::ioParam_channelCode(enum ParamsIOFlag ioFlag) {
    }
    else if (ioFlag==PARAMS_IO_WRITE) {
       int ch = (int) channel;
-      this->getParent()->ioParamValueRequired(ioFlag, this->getName(), "channelCode", &ch);
+      this->getParent()->parameters()->ioParamValueRequired(ioFlag, this->getName(), "channelCode", &ch);
    }
    else {
       assert(0); // All possibilities of ioFlag are covered above.
@@ -274,7 +274,7 @@ void BaseConnection::ioParam_channelCode(enum ParamsIOFlag ioFlag) {
 void BaseConnection::ioParam_delay(enum ParamsIOFlag ioFlag) {
    //Grab delays in ms and load into fDelayArray.
    //initializeDelays() will convert the delays to timesteps store into delays.
-   this->getParent()->ioParamArray(ioFlag, this->getName(), "delay", &fDelayArray, &delayArraySize);
+   this->getParent()->parameters()->ioParamArray(ioFlag, this->getName(), "delay", &fDelayArray, &delayArraySize);
    if (ioFlag==PARAMS_IO_READ && delayArraySize==0) {
       assert(fDelayArray==NULL);
       fDelayArray = (float *) malloc(sizeof(float));
@@ -293,7 +293,7 @@ void BaseConnection::ioParam_delay(enum ParamsIOFlag ioFlag) {
 
 void BaseConnection::ioParam_numAxonalArbors(enum ParamsIOFlag ioFlag) {
    int numArbors = this->numberOfAxonalArborLists();
-   this->getParent()->ioParamValue(ioFlag, this->getName(), "numAxonalArbors", &numArbors, 1);
+   this->getParent()->parameters()->ioParamValue(ioFlag, this->getName(), "numAxonalArbors", &numArbors, 1);
    if (ioFlag == PARAMS_IO_READ) {
       this->setNumberOfAxonalArborLists(numArbors);
       if (ioFlag == PARAMS_IO_READ && this->numberOfAxonalArborLists()==0 && this->getParent()->columnId()==0) {
@@ -303,22 +303,22 @@ void BaseConnection::ioParam_numAxonalArbors(enum ParamsIOFlag ioFlag) {
 }
 
 void BaseConnection::ioParam_plasticityFlag(enum ParamsIOFlag ioFlag) {
-   parent->ioParamValue(ioFlag, name, "plasticityFlag", &plasticityFlag, true/*default value*/);
+   parent->parameters()->ioParamValue(ioFlag, name, "plasticityFlag", &plasticityFlag, true/*default value*/);
 }
 
 // preActivityIsNotRate was replaced with convertRateToSpikeCount on Dec 31, 2014.
 // The warning issued if the params file contained preActivityIsNotRate was removed on Aug 5, 2014.
 
 void BaseConnection::ioParam_convertRateToSpikeCount(enum ParamsIOFlag ioFlag) {
-   getParent()->ioParamValue(ioFlag, this->getName(), "convertRateToSpikeCount", &convertRateToSpikeCount, false/*default value*/);
+   getParent()->parameters()->ioParamValue(ioFlag, this->getName(), "convertRateToSpikeCount", &convertRateToSpikeCount, false/*default value*/);
 }
 
 void BaseConnection::ioParam_receiveGpu(enum ParamsIOFlag ioFlag) {
 #ifdef PV_USE_CUDA
-   parent->ioParamValue(ioFlag, name, "receiveGpu", &receiveGpu, false/*default*/, true/*warn if absent*/);
+   parent->parameters()->ioParamValue(ioFlag, name, "receiveGpu", &receiveGpu, false/*default*/, true/*warn if absent*/);
 #else
    receiveGpu = false;
-   parent->ioParamValue(ioFlag, name, "receiveGpu", &receiveGpu, receiveGpu/*default*/, false/*warn if absent*/);
+   parent->parameters()->ioParamValue(ioFlag, name, "receiveGpu", &receiveGpu, receiveGpu/*default*/, false/*warn if absent*/);
    if (ioFlag==PARAMS_IO_READ && receiveGpu) {
       if (parent->columnId()==0) {
          pvWarn() << getDescription_c() << ": receiveGpu is set to true in params, but PetaVision was compiled without GPU acceleration. receiveGpu has been set to false.\n";
@@ -333,7 +333,7 @@ void BaseConnection::ioParam_receiveGpu(enum ParamsIOFlag ioFlag) {
 void BaseConnection::ioParam_initializeFromCheckpointFlag(enum ParamsIOFlag ioFlag) {
    assert(parent->getInitializeFromCheckpointDir()); // If we're not initializing any layers or connections from a checkpoint, this should be the empty string, not null.
    if (parent->getInitializeFromCheckpointDir() && parent->getInitializeFromCheckpointDir()[0]) {
-      parent->ioParamValue(ioFlag, name, "initializeFromCheckpointFlag", &initializeFromCheckpointFlag, parent->getDefaultInitializeFromCheckpointFlag(), true/*warnIfAbsent*/);
+      parent->parameters()->ioParamValue(ioFlag, name, "initializeFromCheckpointFlag", &initializeFromCheckpointFlag, parent->getDefaultInitializeFromCheckpointFlag(), true/*warnIfAbsent*/);
    }
 }
 

--- a/src/connections/CloneConn.cpp
+++ b/src/connections/CloneConn.cpp
@@ -53,7 +53,7 @@ void CloneConn::ioParam_normalizeMethod(enum ParamsIOFlag ioFlag) {
 }
 
 void CloneConn::ioParam_originalConnName(enum ParamsIOFlag ioFlag) {
-   parent->ioParamStringRequired(ioFlag, name, "originalConnName", &originalConnName);
+   parent->parameters()->ioParamStringRequired(ioFlag, name, "originalConnName", &originalConnName);
 }
 
 int CloneConn::setWeightInitializer() {

--- a/src/connections/CopyConn.cpp
+++ b/src/connections/CopyConn.cpp
@@ -130,7 +130,7 @@ void CopyConn::ioParam_maskLayerName(enum ParamsIOFlag ioFlag) {
 }
 
 void CopyConn::ioParam_originalConnName(enum ParamsIOFlag ioFlag) {
-   parent->ioParamStringRequired(ioFlag, name, "originalConnName", &originalConnName);
+   parent->parameters()->ioParamStringRequired(ioFlag, name, "originalConnName", &originalConnName);
 }
 
 int CopyConn::communicateInitInfo() {

--- a/src/connections/GapConn.cpp
+++ b/src/connections/GapConn.cpp
@@ -50,7 +50,7 @@ void GapConn::ioParam_sharedWeights(enum ParamsIOFlag ioFlag) {
    // Default of true for sharedWeights for GapConns was deprecated Aug 11, 2014.
    // This default was chosen for backwards compatibility because GapConn used to require sharedWeights be true.
    // Now GapConn can be used with or without shared weights, so eventually the default will false as it is for other HyPerConns.
-   parent->ioParamValue(ioFlag, name, "sharedWeights", &sharedWeights, true/*default*/, true/*warn if absent*/);
+   parent->parameters()->ioParamValue(ioFlag, name, "sharedWeights", &sharedWeights, true/*default*/, true/*warn if absent*/);
    if (ioFlag==PARAMS_IO_READ && !parent->parameters()->present(name, "sharedWeights")) {
       sharedWeights = true;
       if (parent->columnId()==0) {

--- a/src/connections/HyPerConn.cpp
+++ b/src/connections/HyPerConn.cpp
@@ -583,7 +583,7 @@ int HyPerConn::ioParamsFillGroup(enum ParamsIOFlag ioFlag)
 void HyPerConn::ioParam_gpuGroupIdx(enum ParamsIOFlag ioFlag) {
    pvAssert(!parent->parameters()->presentAndNotBeenRead(name, "receiveGpu"));
    if(receiveGpu){
-      parent->ioParamValue(ioFlag, name, "gpuGroupIdx", &gpuGroupIdx, gpuGroupIdx/*default*/, false/*warn if absent*/);
+      parent->parameters()->ioParamValue(ioFlag, name, "gpuGroupIdx", &gpuGroupIdx, gpuGroupIdx/*default*/, false/*warn if absent*/);
    }
 }
 #endif // PV_USE_CUDA
@@ -591,7 +591,7 @@ void HyPerConn::ioParam_gpuGroupIdx(enum ParamsIOFlag ioFlag) {
 void HyPerConn::ioParam_channelCode(enum ParamsIOFlag ioFlag) {
    if (ioFlag==PARAMS_IO_READ) {
       int ch = 0;
-      parent->ioParamValueRequired(ioFlag, name, "channelCode", &ch);
+      parent->parameters()->ioParamValueRequired(ioFlag, name, "channelCode", &ch);
       int status = decodeChannel(ch, &channel);
       if (status != PV_SUCCESS) {
          if (parent->columnId()==0) {
@@ -603,7 +603,7 @@ void HyPerConn::ioParam_channelCode(enum ParamsIOFlag ioFlag) {
    }
    else if (ioFlag==PARAMS_IO_WRITE) {
       int ch = (int) channel;
-      parent->ioParamValueRequired(ioFlag, name, "channelCode", &ch);
+      parent->parameters()->ioParamValueRequired(ioFlag, name, "channelCode", &ch);
    }
    else {
       pvError().printf("All possibilities of ioFlag are covered above.");
@@ -611,11 +611,11 @@ void HyPerConn::ioParam_channelCode(enum ParamsIOFlag ioFlag) {
 }
 
 void HyPerConn::ioParam_sharedWeights(enum ParamsIOFlag ioFlag) {
-   parent->ioParamValue(ioFlag, name, "sharedWeights", &sharedWeights, true/*default*/, true/*warn if absent*/);
+   parent->parameters()->ioParamValue(ioFlag, name, "sharedWeights", &sharedWeights, true/*default*/, true/*warn if absent*/);
 }
 
 void HyPerConn::ioParam_weightInitType(enum ParamsIOFlag ioFlag) {
-   parent->ioParamString(ioFlag, name, "weightInitType", &weightInitTypeString, NULL, true/*warnIfAbsent*/);
+   parent->parameters()->ioParamString(ioFlag, name, "weightInitType", &weightInitTypeString, NULL, true/*warnIfAbsent*/);
    // The constructor that took a weightInitializer as an argument was deprecated June 22, 2022.
    // Once that constructor is removed, the weightInitializer==NULL part of the if-statement below can be removed.
    if (ioFlag==PARAMS_IO_READ && weightInitializer==NULL) {
@@ -627,7 +627,7 @@ void HyPerConn::ioParam_weightInitType(enum ParamsIOFlag ioFlag) {
 void HyPerConn::ioParam_triggerLayerName(enum ParamsIOFlag ioFlag) {
    pvAssert(!parent->parameters()->presentAndNotBeenRead(name, "plasticityFlag"));
    if (plasticityFlag) {
-      parent->ioParamString(ioFlag, name, "triggerLayerName", &triggerLayerName, NULL, false/*warnIfAbsent*/);
+      parent->parameters()->ioParamString(ioFlag, name, "triggerLayerName", &triggerLayerName, NULL, false/*warnIfAbsent*/);
       if (ioFlag==PARAMS_IO_READ) {
          triggerFlag = (triggerLayerName!=NULL && triggerLayerName[0]!='\0');
       }
@@ -639,7 +639,7 @@ void HyPerConn::ioParam_triggerOffset(enum ParamsIOFlag ioFlag) {
    if (plasticityFlag) {
       pvAssert(!parent->parameters()->presentAndNotBeenRead(name, "triggerLayerName"));
       if (triggerFlag) {
-         parent->ioParamValue(ioFlag, name, "triggerOffset", &triggerOffset, triggerOffset);
+         parent->parameters()->ioParamValue(ioFlag, name, "triggerOffset", &triggerOffset, triggerOffset);
          if(triggerOffset < 0){
             pvError().printf("%s error in rank %d process: TriggerOffset (%f) must be positive", getDescription_c(), parent->columnId(), triggerOffset);
          }
@@ -652,7 +652,7 @@ void HyPerConn::ioParam_weightUpdatePeriod(enum ParamsIOFlag ioFlag) {
    if (plasticityFlag) {
 	   pvAssert(!parent->parameters()->presentAndNotBeenRead(name, "triggerLayerName"));
 	   if (!triggerLayerName) {
-	      parent->ioParamValue(ioFlag, name, "weightUpdatePeriod", &weightUpdatePeriod, parent->getDeltaTime());
+	      parent->parameters()->ioParamValue(ioFlag, name, "weightUpdatePeriod", &weightUpdatePeriod, parent->getDeltaTime());
 	   }
    }
 }
@@ -663,7 +663,7 @@ void HyPerConn::ioParam_initialWeightUpdateTime(enum ParamsIOFlag ioFlag) {
       pvAssert(!parent->parameters()->presentAndNotBeenRead(name, "triggerLayerName"));
       initialWeightUpdateTime = parent->getStartTime();
       if (!triggerLayerName) {
-         parent->ioParamValue(ioFlag, name, "initialWeightUpdateTime", &initialWeightUpdateTime, initialWeightUpdateTime, true/*warnIfAbsent*/);
+         parent->parameters()->ioParamValue(ioFlag, name, "initialWeightUpdateTime", &initialWeightUpdateTime, initialWeightUpdateTime, true/*warnIfAbsent*/);
       }
    }
    if (ioFlag==PARAMS_IO_READ) {
@@ -673,7 +673,7 @@ void HyPerConn::ioParam_initialWeightUpdateTime(enum ParamsIOFlag ioFlag) {
 
 void HyPerConn::ioParam_pvpatchAccumulateType(enum ParamsIOFlag ioFlag) {
    PVParams * params = parent->parameters();
-   parent->ioParamString(ioFlag, name, "pvpatchAccumulateType", &pvpatchAccumulateTypeString, "convolve");
+   parent->parameters()->ioParamString(ioFlag, name, "pvpatchAccumulateType", &pvpatchAccumulateTypeString, "convolve");
    if (ioFlag==PARAMS_IO_READ) {
       if (pvpatchAccumulateTypeString==NULL) {
          unsetAccumulateType();
@@ -731,14 +731,14 @@ void HyPerConn::unsetAccumulateType() {
 
 
 void HyPerConn::ioParam_writeStep(enum ParamsIOFlag ioFlag) {
-   parent->ioParamValue(ioFlag, name, "writeStep", &writeStep, parent->getDeltaTime());
+   parent->parameters()->ioParamValue(ioFlag, name, "writeStep", &writeStep, parent->getDeltaTime());
 }
 
 void HyPerConn::ioParam_initialWriteTime(enum ParamsIOFlag ioFlag) {
    pvAssert(!parent->parameters()->presentAndNotBeenRead(name, "writeStep"));
    if (writeStep>=0) {
       double start_time = parent->getStartTime();
-      parent->ioParamValue(ioFlag, name, "initialWriteTime", &initialWriteTime, start_time);
+      parent->parameters()->ioParamValue(ioFlag, name, "initialWriteTime", &initialWriteTime, start_time);
       if (ioFlag == PARAMS_IO_READ) {
          if (writeStep>0 && initialWriteTime < start_time) {
             if (parent->columnId()==0) {
@@ -763,13 +763,13 @@ void HyPerConn::ioParam_initialWriteTime(enum ParamsIOFlag ioFlag) {
 void HyPerConn::ioParam_writeCompressedWeights(enum ParamsIOFlag ioFlag) {
    pvAssert(!parent->parameters()->presentAndNotBeenRead(name, "writeStep"));
    if (writeStep>=0) {
-      parent->ioParamValue(ioFlag, name, "writeCompressedWeights", &writeCompressedWeights, writeCompressedWeights, /*warnifabsent*/true);
+      parent->parameters()->ioParamValue(ioFlag, name, "writeCompressedWeights", &writeCompressedWeights, writeCompressedWeights, /*warnifabsent*/true);
    }
 }
 
 void HyPerConn::ioParam_writeCompressedCheckpoints(enum ParamsIOFlag ioFlag) {
    if (parent->getCheckpointWriteFlag() || !parent->getSuppressLastOutputFlag()) {
-      parent->ioParamValue(ioFlag, name, "writeCompressedCheckpoints", &writeCompressedCheckpoints, writeCompressedCheckpoints, /*warnifabsent*/true);
+      parent->parameters()->ioParamValue(ioFlag, name, "writeCompressedCheckpoints", &writeCompressedCheckpoints, writeCompressedCheckpoints, /*warnifabsent*/true);
    }
 }
 
@@ -779,23 +779,23 @@ void HyPerConn::ioParam_selfFlag(enum ParamsIOFlag ioFlag) {
    // pre and post have not been set.  So we read the value with no warning if it's present;
    // if it's absent, set the value to pre==post in the communicateInitInfo stage and issue
    // the using-default-value warning then.
-   parent->ioParamValue(ioFlag, name, "selfFlag", &selfFlag, selfFlag, false/*warnIfAbsent*/);
+   parent->parameters()->ioParamValue(ioFlag, name, "selfFlag", &selfFlag, selfFlag, false/*warnIfAbsent*/);
 }
 
 void HyPerConn::ioParam_combine_dW_with_W_flag(enum ParamsIOFlag ioFlag) {
    pvAssert(!parent->parameters()->presentAndNotBeenRead(name, "plasticityFlag"));
    if (plasticityFlag){
-      parent->ioParamValue(ioFlag, name, "combine_dW_with_W_flag", &combine_dW_with_W_flag, combine_dW_with_W_flag, true/*warnIfAbsent*/);
+      parent->parameters()->ioParamValue(ioFlag, name, "combine_dW_with_W_flag", &combine_dW_with_W_flag, combine_dW_with_W_flag, true/*warnIfAbsent*/);
    }
 
 }
 
 void HyPerConn::ioParam_nxp(enum ParamsIOFlag ioFlag) {
-   parent->ioParamValue(ioFlag, name, "nxp", &nxp, 1);
+   parent->parameters()->ioParamValue(ioFlag, name, "nxp", &nxp, 1);
 }
 
 void HyPerConn::ioParam_nyp(enum ParamsIOFlag ioFlag) {
-   parent->ioParamValue(ioFlag, name, "nyp", &nyp, 1);
+   parent->parameters()->ioParamValue(ioFlag, name, "nyp", &nyp, 1);
 }
 
 // nxpShrunken and nypShrunken were deprecated Feb 2, 2015 and marked obsolete Jun 27, 2016
@@ -804,7 +804,7 @@ void HyPerConn::ioParam_nxpShrunken(enum ParamsIOFlag ioFlag) {
    if (ioFlag==PARAMS_IO_READ) {
       if (parent->parameters()->present(name, "nxpShrunken")) {
          int nxpShrunken;
-         parent->ioParamValue(ioFlag, name, "nxpShrunken", &nxpShrunken, nxp);
+         parent->parameters()->ioParamValue(ioFlag, name, "nxpShrunken", &nxpShrunken, nxp);
          if (parent->columnId()==0) {
             pvError().printf("%s: nxpShrunken is obsolete, as nxp can now take any of the values nxpShrunken could take before.  nxp will be set to %d and nxpShrunken will not be used.",
                   getDescription_c(), nxp);
@@ -820,7 +820,7 @@ void HyPerConn::ioParam_nypShrunken(enum ParamsIOFlag ioFlag) {
    if (ioFlag==PARAMS_IO_READ) {
       if (parent->parameters()->present(name, "nypShrunken")) {
          int nypShrunken;
-         parent->ioParamValue(ioFlag, name, "nypShrunken", &nypShrunken, nyp);
+         parent->parameters()->ioParamValue(ioFlag, name, "nypShrunken", &nypShrunken, nyp);
          if (parent->columnId()==0) {
             pvWarn().printf("%s: nypShrunken is deprecated, as nyp can now take any of the values nypShrunken could take before.  nyp will be set to %d and nypShrunken will not be used.",
                   getDescription_c(), nyp);
@@ -832,7 +832,7 @@ void HyPerConn::ioParam_nypShrunken(enum ParamsIOFlag ioFlag) {
 }
 
 void HyPerConn::ioParam_nfp(enum ParamsIOFlag ioFlag) {
-   parent->ioParamValue(ioFlag, name, "nfp", &nfp, -1, false);
+   parent->parameters()->ioParamValue(ioFlag, name, "nfp", &nfp, -1, false);
    if (ioFlag==PARAMS_IO_READ && nfp==-1 && !parent->parameters()->present(name, "nfp") && parent->columnId()==0) {
       pvInfo().printf("%s: nfp will be set in the communicateInitInfo() stage.\n",
             getDescription_c());
@@ -840,29 +840,29 @@ void HyPerConn::ioParam_nfp(enum ParamsIOFlag ioFlag) {
 }
 
 void HyPerConn::ioParam_shrinkPatches(enum ParamsIOFlag ioFlag) {
-   parent->ioParamValue(ioFlag, name, "shrinkPatches", &shrinkPatches_flag, shrinkPatches_flag);
+   parent->parameters()->ioParamValue(ioFlag, name, "shrinkPatches", &shrinkPatches_flag, shrinkPatches_flag);
 }
 
 void HyPerConn::ioParam_shrinkPatchesThresh(enum ParamsIOFlag ioFlag) {
    pvAssert(!parent->parameters()->presentAndNotBeenRead(name, "shrinkPatches"));
    if (shrinkPatches_flag) {
-      parent->ioParamValue(ioFlag, name, "shrinkPatchesThresh", &shrinkPatchesThresh, shrinkPatchesThresh);
+      parent->parameters()->ioParamValue(ioFlag, name, "shrinkPatchesThresh", &shrinkPatchesThresh, shrinkPatchesThresh);
    }
 }
 
 void HyPerConn::ioParam_updateGSynFromPostPerspective(enum ParamsIOFlag ioFlag) {
-   parent->ioParamValue(ioFlag, name, "updateGSynFromPostPerspective", &updateGSynFromPostPerspective, updateGSynFromPostPerspective);
+   parent->parameters()->ioParamValue(ioFlag, name, "updateGSynFromPostPerspective", &updateGSynFromPostPerspective, updateGSynFromPostPerspective);
 }
 
 void HyPerConn::ioParam_dWMax(enum ParamsIOFlag ioFlag) {
    pvAssert(!parent->parameters()->presentAndNotBeenRead(name, "plasticityFlag"));
    if (plasticityFlag) {
-      parent->ioParamValueRequired(ioFlag, name, "dWMax", &dWMax);
+      parent->parameters()->ioParamValueRequired(ioFlag, name, "dWMax", &dWMax);
    }
 }
 
 void HyPerConn::ioParam_normalizeMethod(enum ParamsIOFlag ioFlag) {
-   parent->ioParamString(ioFlag, name, "normalizeMethod", &normalizeMethod, NULL, true/*warnIfAbsent*/);
+   parent->parameters()->ioParamString(ioFlag, name, "normalizeMethod", &normalizeMethod, NULL, true/*warnIfAbsent*/);
    if (ioFlag==PARAMS_IO_READ) {
       if (normalizeMethod==NULL) {
          if (parent->columnId()==0) {
@@ -885,7 +885,7 @@ void HyPerConn::ioParam_normalizeMethod(enum ParamsIOFlag ioFlag) {
 }
 
 void HyPerConn::ioParam_weightSparsity(enum ParamsIOFlag ioFlag) {
-   parent->ioParamValue(ioFlag, name, "weightSparsity", &_weightSparsity, 0.0f, false);
+   parent->parameters()->ioParamValue(ioFlag, name, "weightSparsity", &_weightSparsity, 0.0f, false);
 }
 
 int HyPerConn::setWeightNormalizer() {
@@ -916,21 +916,21 @@ void HyPerConn::ioParam_keepKernelsSynchronized(enum ParamsIOFlag ioFlag) {
    pvAssert(!parent->parameters()->presentAndNotBeenRead(name, "sharedWeights"));
    pvAssert(!parent->parameters()->presentAndNotBeenRead(name, "plasticityFlag"));
    if (sharedWeights && plasticityFlag) {
-      parent->ioParamValue(ioFlag, name, "keepKernelsSynchronized", &keepKernelsSynchronized_flag, true/*default*/, true/*warnIfAbsent*/);
+      parent->parameters()->ioParamValue(ioFlag, name, "keepKernelsSynchronized", &keepKernelsSynchronized_flag, true/*default*/, true/*warnIfAbsent*/);
    }
 }
 
 void HyPerConn::ioParam_normalizeDw(enum ParamsIOFlag ioFlag) {
    pvAssert(!parent->parameters()->presentAndNotBeenRead(name, "plasticityFlag"));
    if(plasticityFlag){
-      getParent()->ioParamValue(ioFlag, getName(), "normalizeDw", &normalizeDwFlag, true, false/*warnIfAbsent*/);
+      getParent()->parameters()->ioParamValue(ioFlag, getName(), "normalizeDw", &normalizeDwFlag, true, false/*warnIfAbsent*/);
    }
 }
 
 void HyPerConn::ioParam_useMask(enum ParamsIOFlag ioFlag) {
    pvAssert(!parent->parameters()->presentAndNotBeenRead(name, "plasticityFlag"));
    if(plasticityFlag){
-      getParent()->ioParamValue(ioFlag, getName(), "useMask", &useMask, false, false/*warnIfAbsent*/);
+      getParent()->parameters()->ioParamValue(ioFlag, getName(), "useMask", &useMask, false, false/*warnIfAbsent*/);
    }
 }
 
@@ -939,7 +939,7 @@ void HyPerConn::ioParam_maskLayerName(enum ParamsIOFlag ioFlag) {
    if(plasticityFlag){
       pvAssert(!parent->parameters()->presentAndNotBeenRead(name, "useMask"));
       if(useMask){
-         parent->ioParamStringRequired(ioFlag, name, "maskLayerName", &maskLayerName);
+         parent->parameters()->ioParamStringRequired(ioFlag, name, "maskLayerName", &maskLayerName);
       }
    }
 }
@@ -949,7 +949,7 @@ void HyPerConn::ioParam_maskFeatureIdx(enum ParamsIOFlag ioFlag) {
    if(plasticityFlag){
       pvAssert(!parent->parameters()->presentAndNotBeenRead(name, "useMask"));
       if(useMask){
-         parent->ioParamValue(ioFlag, name, "maskFeatureIdx", &maskFeatureIdx, maskFeatureIdx);
+         parent->parameters()->ioParamValue(ioFlag, name, "maskFeatureIdx", &maskFeatureIdx, maskFeatureIdx);
       }
    }
 }

--- a/src/connections/IdentConn.cpp
+++ b/src/connections/IdentConn.cpp
@@ -103,7 +103,7 @@ void IdentConn::ioParam_pvpatchAccumulateType(enum ParamsIOFlag ioFlag) {
 void IdentConn::ioParam_writeStep(enum ParamsIOFlag ioFlag) {
    if (ioFlag == PARAMS_IO_READ) {
       if (parent->parameters()->present(name, "writeStep")) {
-         parent->ioParamValue(ioFlag, name, "writeStep", &writeStep, -1.0/*default*/, false/*warnIfAbsent*/);
+         parent->parameters()->ioParamValue(ioFlag, name, "writeStep", &writeStep, -1.0/*default*/, false/*warnIfAbsent*/);
          if (writeStep>=0) {
             if (parent->columnId()==0) {
                pvErrorNoExit().printf("%s does not use writeStep, but the parameters file sets it to %f.\n", getDescription_c(), writeStep);

--- a/src/connections/ImprintConn.cpp
+++ b/src/connections/ImprintConn.cpp
@@ -62,7 +62,7 @@ void ImprintConn::ioParam_sharedWeights(enum ParamsIOFlag ioFlag) {
 }
 
 void ImprintConn::ioParam_imprintTimeThresh(enum ParamsIOFlag ioFlag) {
-   parent->ioParamValueRequired(ioFlag, name, "imprintTimeThresh", &imprintTimeThresh);
+   parent->parameters()->ioParamValueRequired(ioFlag, name, "imprintTimeThresh", &imprintTimeThresh);
    if (ioFlag==PARAMS_IO_READ) {
       if (imprintTimeThresh==-1) {
          imprintTimeThresh = weightUpdateTime * 100; //Default value of 100 weight updates
@@ -74,7 +74,7 @@ void ImprintConn::ioParam_imprintTimeThresh(enum ParamsIOFlag ioFlag) {
 }
 
 //void ImprintConn::ioParam_imprintChance(enum ParamsIOFlag ioFlag) {
-//   parent->ioParamValue(ioFlag, name, "imprintChance", &imprintChance, imprintChance);
+//   parent->parameters()->ioParamValue(ioFlag, name, "imprintChance", &imprintChance, imprintChance);
 //   if (ioFlag==PARAMS_IO_READ) {
 //      if (imprintTimeThresh==-1) {
 //         imprintTimeThresh = weightUpdateTime * 100; //Default value of 100 weight updates

--- a/src/connections/MomentumConn.cpp
+++ b/src/connections/MomentumConn.cpp
@@ -86,7 +86,7 @@ void MomentumConn::ioParam_momentumTau(enum ParamsIOFlag ioFlag){
          defaultVal = .9;
       }
       
-      parent->ioParamValue(ioFlag, name, "momentumTau", &momentumTau, defaultVal);
+      parent->parameters()->ioParamValue(ioFlag, name, "momentumTau", &momentumTau, defaultVal);
    }
 }
 
@@ -99,7 +99,7 @@ void MomentumConn::ioParam_momentumTau(enum ParamsIOFlag ioFlag){
  */
 void MomentumConn::ioParam_momentumMethod(enum ParamsIOFlag ioFlag){
    if(plasticityFlag){
-      parent->ioParamStringRequired(ioFlag, name, "momentumMethod", &momentumMethod);
+      parent->parameters()->ioParamStringRequired(ioFlag, name, "momentumMethod", &momentumMethod);
       if(strcmp(momentumMethod, "simple") != 0 &&
          strcmp(momentumMethod, "viscosity") != 0 &&
          strcmp(momentumMethod, "alex")){
@@ -110,7 +110,7 @@ void MomentumConn::ioParam_momentumMethod(enum ParamsIOFlag ioFlag){
 
 void MomentumConn::ioParam_momentumDecay(enum ParamsIOFlag ioFlag){
    if(plasticityFlag){
-      parent->ioParamValue(ioFlag, name, "momentumDecay", &momentumDecay, momentumDecay);
+      parent->parameters()->ioParamValue(ioFlag, name, "momentumDecay", &momentumDecay, momentumDecay);
       if(momentumDecay < 0 || momentumDecay > 1){
          pvError() << "MomentumConn " << name << ": momentumDecay must be between 0 and 1 inclusive\n";
       }
@@ -120,7 +120,7 @@ void MomentumConn::ioParam_momentumDecay(enum ParamsIOFlag ioFlag){
 void MomentumConn::ioParam_batchPeriod(enum ParamsIOFlag ioFlag) {
    assert(!parent->parameters()->presentAndNotBeenRead(name, "plasticityFlag"));
    if(plasticityFlag){
-      parent->ioParamValue(ioFlag, name, "batchPeriod", &timeBatchPeriod, timeBatchPeriod);
+      parent->parameters()->ioParamValue(ioFlag, name, "batchPeriod", &timeBatchPeriod, timeBatchPeriod);
    }
 }
 

--- a/src/connections/PoolingConn.cpp
+++ b/src/connections/PoolingConn.cpp
@@ -73,7 +73,7 @@ void PoolingConn::ioParam_weightInitType(enum ParamsIOFlag ioFlag) {
 void PoolingConn::ioParam_pvpatchAccumulateType(enum ParamsIOFlag ioFlag) {
    PVParams * params = parent->parameters();
 
-   parent->ioParamStringRequired(ioFlag, name, "pvpatchAccumulateType", &pvpatchAccumulateTypeString);
+   parent->parameters()->ioParamStringRequired(ioFlag, name, "pvpatchAccumulateType", &pvpatchAccumulateTypeString);
    if (ioFlag==PARAMS_IO_READ) {
       poolingType = parseAccumulateTypeString(pvpatchAccumulateTypeString);
       if (poolingType==UNDEFINED) {
@@ -120,12 +120,12 @@ void PoolingConn::unsetAccumulateType() {
 }
 
 void PoolingConn::ioParam_needPostIndexLayer(enum ParamsIOFlag ioFlag){
-   parent->ioParamValue(ioFlag, name, "needPostIndexLayer", &needPostIndexLayer, needPostIndexLayer);
+   parent->parameters()->ioParamValue(ioFlag, name, "needPostIndexLayer", &needPostIndexLayer, needPostIndexLayer);
 }
 
 void PoolingConn::ioParam_postIndexLayerName(enum ParamsIOFlag ioFlag) {
    if(needPostIndexLayer){
-      parent->ioParamStringRequired(ioFlag, name, "postIndexLayerName", &postIndexLayerName);
+      parent->parameters()->ioParamStringRequired(ioFlag, name, "postIndexLayerName", &postIndexLayerName);
    }
 }
 

--- a/src/connections/RescaleConn.cpp
+++ b/src/connections/RescaleConn.cpp
@@ -34,7 +34,7 @@ int RescaleConn::ioParamsFillGroup(enum ParamsIOFlag ioFlag) {
 }
 
 void RescaleConn::ioParam_scale(enum ParamsIOFlag ioFlag) {
-   parent->ioParamValue(ioFlag, name, "scale", &scale, scale/*default*/, true /*warn if absent*/);
+   parent->parameters()->ioParamValue(ioFlag, name, "scale", &scale, scale/*default*/, true /*warn if absent*/);
 }
 
 int RescaleConn::deliverPresynapticPerspective(PVLayerCube const * activity, int arborID) {

--- a/src/connections/TransposeConn.cpp
+++ b/src/connections/TransposeConn.cpp
@@ -174,7 +174,7 @@ void TransposeConn::ioParam_normalizeMethod(enum ParamsIOFlag ioFlag) {
 }
 
 void TransposeConn::ioParam_originalConnName(enum ParamsIOFlag ioFlag) {
-   parent->ioParamStringRequired(ioFlag, name, "originalConnName", &originalConnName);
+   parent->parameters()->ioParamStringRequired(ioFlag, name, "originalConnName", &originalConnName);
 }
 
 int TransposeConn::communicateInitInfo() {

--- a/src/connections/TransposePoolingConn.cpp
+++ b/src/connections/TransposePoolingConn.cpp
@@ -230,7 +230,7 @@ void TransposePoolingConn::ioParam_normalizeMethod(enum ParamsIOFlag ioFlag) {
 }
 
 void TransposePoolingConn::ioParam_originalConnName(enum ParamsIOFlag ioFlag) {
-   parent->ioParamStringRequired(ioFlag, name, "originalConnName", &mOriginalConnName);
+   parent->parameters()->ioParamStringRequired(ioFlag, name, "originalConnName", &mOriginalConnName);
 }
 
 int TransposePoolingConn::communicateInitInfo() {

--- a/src/io/PVParams.cpp
+++ b/src/io/PVParams.cpp
@@ -1848,32 +1848,6 @@ void PVParams::handleUnnecessaryParameter(const char * group_name, const char * 
    }
 }
 
-template <typename T>
-void PVParams::handleUnnecessaryParameter(const char * group_name, const char * param_name, T correct_value) {
-   int status = PV_SUCCESS;
-   if (present(group_name, param_name)) {
-      if (worldRank==0) {
-         const char * class_name = groupKeywordFromName(group_name);
-         pvWarn().printf("%s \"%s\" does not use parameter %s, but it is present in the parameters file.\n",
-               class_name, group_name, param_name);
-      }
-      T params_value = (T) value(group_name, param_name); // marks param as read so that presentAndNotBeenRead doesn't trip up
-      if (params_value != correct_value) {
-         status = PV_FAILURE;
-         if (worldRank==0) {
-            pvErrorNoExit() << "   Value " << params_value << " is inconsistent with correct value " << correct_value << std::endl;
-         }
-      }
-   }
-   MPI_Barrier(icComm->globalCommunicator());
-   if (status != PV_SUCCESS) exit(EXIT_FAILURE);
-}
-// Declare the instantiations of allocateBuffer that occur in other .cpp files; otherwise you may get linker errors.
-template void PVParams::handleUnnecessaryParameter<bool>(const char * group_name, const char * param_name, bool correct_value);
-template void PVParams::handleUnnecessaryParameter<int>(const char * group_name, const char * param_name, int correct_value);
-template void PVParams::handleUnnecessaryParameter<float>(const char * group_name, const char * param_name, float correct_value);
-template void PVParams::handleUnnecessaryParameter<double>(const char * group_name, const char * param_name, double correct_value);
-
 void PVParams::handleUnnecessaryStringParameter(const char * group_name, const char * param_name) {
    int status = PV_SUCCESS;
    const char * class_name = groupKeywordFromName(group_name);

--- a/src/io/PVParams.hpp
+++ b/src/io/PVParams.hpp
@@ -367,6 +367,27 @@ private:
 };
 
 template <typename T>
+void PVParams::handleUnnecessaryParameter(const char * group_name, const char * param_name, T correct_value) {
+   int status = PV_SUCCESS;
+   if (present(group_name, param_name)) {
+      if (worldRank==0) {
+         const char * class_name = groupKeywordFromName(group_name);
+         pvWarn().printf("%s \"%s\" does not use parameter %s, but it is present in the parameters file.\n",
+               class_name, group_name, param_name);
+      }
+      T params_value = (T) value(group_name, param_name); // marks param as read so that presentAndNotBeenRead doesn't trip up
+      if (params_value != correct_value) {
+         status = PV_FAILURE;
+         if (worldRank==0) {
+            pvErrorNoExit() << "   Value " << params_value << " is inconsistent with correct value " << correct_value << std::endl;
+         }
+      }
+   }
+   MPI_Barrier(icComm->globalCommunicator());
+   if (status != PV_SUCCESS) exit(EXIT_FAILURE);
+}
+
+template <typename T>
 void PVParams::ioParamValueRequired(enum ParamsIOFlag ioFlag, const char * groupName, const char * paramName, T * paramValue) {
    switch(ioFlag) {
    case PARAMS_IO_READ:

--- a/src/io/PVParams.hpp
+++ b/src/io/PVParams.hpp
@@ -36,7 +36,6 @@ public:
    const float * valuePtr() { hasBeenReadFlag = true; return &paramValue; }
    const double * valueDblPtr() { hasBeenReadFlag = true; return &paramDblValue; }
    bool hasBeenRead()       { return hasBeenReadFlag; }
-   int outputParam(FILE * fp, int indentation);
    void clearHasBeenRead()    { hasBeenReadFlag = false; }
    void setValue(double v)  { paramValue = (float) v; paramDblValue = v;}
    Parameter* copyParameter() {return new Parameter(paramName, paramDblValue);}
@@ -61,7 +60,6 @@ public:
    void resetArraySize(){arraySize = 0;}
    bool hasBeenRead() { return hasBeenReadFlag; }
    void clearHasBeenRead() { hasBeenReadFlag = false; }
-   int outputString(FILE * fp, int indentation);
    double peek(int index)   { return valuesDbl[index]; }
    ParameterArray* copyParameterArray();
 
@@ -83,7 +81,6 @@ public:
    const char * getName()      { return paramName; }
    const char * getValue()     { hasBeenReadFlag = true; return paramValue; }
    bool hasBeenRead()          { return hasBeenReadFlag; }
-   int outputString(FILE * fp, int indentation);
    void clearHasBeenRead()     { hasBeenReadFlag = false; }
    void setValue(const char * s) { free(paramValue); paramValue = s?strdup(s):NULL;}
    ParameterString* copyParameterString() {return new ParameterString(paramName, paramValue);}
@@ -103,7 +100,6 @@ public:
    Parameter * pop();
    Parameter * peek(int index)   { return parameters[index]; }
    int size()                    { return count; }
-   int outputStack(FILE * fp, int indentation);
 
 private:
    int count;
@@ -116,7 +112,6 @@ public:
    ParameterArrayStack(int initialCount);
    virtual ~ParameterArrayStack();
    int push(ParameterArray * array);
-   int outputStack(FILE * fp, int indentation);
    int size() {return count;}
    ParameterArray * peek(int index) {return index>=0 && index<count ? parameterArrays[index] : NULL; }
 
@@ -137,7 +132,6 @@ public:
    ParameterString * peek(int index)    { return index>=0 && index<count ? parameterStrings[index] : NULL; }
    int size()                           { return count; }
    const char * lookup(const char * targetname);
-   int outputStack(FILE * fp, int indentation);
 
 private:
    int count;
@@ -164,7 +158,6 @@ public:
    int warnUnread();
    bool hasBeenRead(const char * paramName);
    int clearHasBeenReadFlags();
-   int outputGroup(FILE * fp);
    int pushNumerical(Parameter * param);
    int pushString(ParameterString * param);
    int setValue(const char * param_name, double value);
@@ -272,7 +265,6 @@ public:
     * are not equal.
     */
    void handleUnnecessaryStringParameter(const char * group_name, const char * param_name, const char * correctValue, bool case_insensitive_flag=false);
-   int outputParams(FILE *);
 
    void setPrintLuaStream(PV_Stream * printLuaStream) { mPrintLuaStream = printLuaStream; }
    void setPrintParamsStream(PV_Stream * printParamsStream) { mPrintParamsStream = printParamsStream; }

--- a/src/layers/ANNErrorLayer.cpp
+++ b/src/layers/ANNErrorLayer.cpp
@@ -69,7 +69,7 @@ int ANNErrorLayer::ioParamsFillGroup(enum ParamsIOFlag ioFlag) {
 }
 
 void ANNErrorLayer::ioParam_errScale(enum ParamsIOFlag ioFlag) {
-   parent->ioParamValue(ioFlag, name, "errScale", &errScale, errScale, true/*warnIfAbsent*/);
+   parent->parameters()->ioParamValue(ioFlag, name, "errScale", &errScale, errScale, true/*warnIfAbsent*/);
 }
 
 int ANNErrorLayer::setVertices() {

--- a/src/layers/ANNLayer.cpp
+++ b/src/layers/ANNLayer.cpp
@@ -103,7 +103,7 @@ int ANNLayer::ioParamsFillGroup(enum ParamsIOFlag ioFlag) {
 void ANNLayer::ioParam_verticesV(enum ParamsIOFlag ioFlag) {
    pvAssert(verticesListInParams);
    int numVerticesTmp = numVertices;
-   this->getParent()->ioParamArray(ioFlag, this->getName(), "verticesV", &verticesV, &numVerticesTmp);
+   this->getParent()->parameters()->ioParamArray(ioFlag, this->getName(), "verticesV", &verticesV, &numVerticesTmp);
    if (ioFlag==PARAMS_IO_READ) {
       if (numVerticesTmp==0) {
          if (this->getParent()->columnId()==0) {
@@ -129,7 +129,7 @@ void ANNLayer::ioParam_verticesV(enum ParamsIOFlag ioFlag) {
 void ANNLayer::ioParam_verticesA(enum ParamsIOFlag ioFlag) {
    pvAssert(verticesListInParams);
    int numVerticesA;
-   this->getParent()->ioParamArray(ioFlag, this->getName(), "verticesA", &verticesA, &numVerticesA);
+   this->getParent()->parameters()->ioParamArray(ioFlag, this->getName(), "verticesA", &verticesA, &numVerticesA);
    if (ioFlag==PARAMS_IO_READ) {
       if (numVerticesA==0) {
          if (this->getParent()->columnId()==0) {
@@ -154,45 +154,45 @@ void ANNLayer::ioParam_verticesA(enum ParamsIOFlag ioFlag) {
 
 void ANNLayer::ioParam_slopeNegInf(enum ParamsIOFlag ioFlag) {
    pvAssert(verticesListInParams);
-   parent->ioParamValue(ioFlag, name, "slopeNegInf", &slopeNegInf, slopeNegInf/*default*/, true/*warnIfAbsent*/);
+   parent->parameters()->ioParamValue(ioFlag, name, "slopeNegInf", &slopeNegInf, slopeNegInf/*default*/, true/*warnIfAbsent*/);
 }
 
 void ANNLayer::ioParam_slopePosInf(enum ParamsIOFlag ioFlag) {
    pvAssert(verticesListInParams);
-   parent->ioParamValue(ioFlag, name, "slopePosInf", &slopePosInf, slopePosInf/*default*/, true/*warnIfAbsent*/);
+   parent->parameters()->ioParamValue(ioFlag, name, "slopePosInf", &slopePosInf, slopePosInf/*default*/, true/*warnIfAbsent*/);
 }
 
 void ANNLayer::ioParam_VThresh(enum ParamsIOFlag ioFlag) {
    pvAssert(!verticesListInParams);
-   parent->ioParamValue(ioFlag, name, "VThresh", &VThresh, VThresh);
+   parent->parameters()->ioParamValue(ioFlag, name, "VThresh", &VThresh, VThresh);
 }
 
 void ANNLayer::ioParam_AMin(enum ParamsIOFlag ioFlag) {
    pvAssert(!verticesListInParams);
    pvAssert(!parent->parameters()->presentAndNotBeenRead(name, "VThresh"));
-   parent->ioParamValue(ioFlag, name, "AMin", &AMin, VThresh); // defaults to the value of VThresh, which was read earlier.
+   parent->parameters()->ioParamValue(ioFlag, name, "AMin", &AMin, VThresh); // defaults to the value of VThresh, which was read earlier.
 }
 
 void ANNLayer::ioParam_AMax(enum ParamsIOFlag ioFlag) {
    pvAssert(!verticesListInParams);
-   parent->ioParamValue(ioFlag, name, "AMax", &AMax, AMax);
+   parent->parameters()->ioParamValue(ioFlag, name, "AMax", &AMax, AMax);
 }
 
 void ANNLayer::ioParam_AShift(enum ParamsIOFlag ioFlag) {
    pvAssert(!verticesListInParams);
-   parent->ioParamValue(ioFlag, name, "AShift", &AShift, AShift);
+   parent->parameters()->ioParamValue(ioFlag, name, "AShift", &AShift, AShift);
 }
 
 void ANNLayer::ioParam_VWidth(enum ParamsIOFlag ioFlag) {
    pvAssert(!verticesListInParams);
-   parent->ioParamValue(ioFlag, name, "VWidth", &VWidth, VWidth);
+   parent->parameters()->ioParamValue(ioFlag, name, "VWidth", &VWidth, VWidth);
 }
 
 // clearGSynInterval parameter was made obsolete Sep 21, 2016.
 void ANNLayer::ioParam_clearGSynInterval(enum ParamsIOFlag ioFlag) {
    if (ioFlag==PARAMS_IO_READ && parent->parameters()->present(name, "clearGSynInterval")) {
       double clearGSynInterval;
-      parent->ioParamValueRequired(ioFlag, name, "clearGSynInterval", &clearGSynInterval);
+      parent->parameters()->ioParamValueRequired(ioFlag, name, "clearGSynInterval", &clearGSynInterval);
       if (clearGSynInterval) {
          if (parent->getCommunicator()->commRank()==0) {
             pvErrorNoExit() << getDescription() << ": the clearGSynInterval parameter is obsolete.  Value 0 specified in params file will be ignored.\n";

--- a/src/layers/BackgroundLayer.cpp
+++ b/src/layers/BackgroundLayer.cpp
@@ -85,7 +85,7 @@ int BackgroundLayer::allocateV() {
 }
 
 void BackgroundLayer::ioParam_repFeatureNum(enum ParamsIOFlag ioFlag) {
-   parent->ioParamValue(ioFlag, name, "repFeatureNum", &repFeatureNum, repFeatureNum);
+   parent->parameters()->ioParamValue(ioFlag, name, "repFeatureNum", &repFeatureNum, repFeatureNum);
    if(repFeatureNum <= 0){
       pvError() << "BackgroundLayer " << name << ": repFeatureNum must an integer greater or equal to 1 (1 feature means no replication)\n";
    }

--- a/src/layers/BinningLayer.cpp
+++ b/src/layers/BinningLayer.cpp
@@ -44,7 +44,7 @@ int BinningLayer::ioParamsFillGroup(enum ParamsIOFlag ioFlag) {
 }
 
 void BinningLayer::ioParam_originalLayerName(enum ParamsIOFlag ioFlag) {
-   parent->ioParamStringRequired(ioFlag, name, "originalLayerName", &originalLayerName);
+   parent->parameters()->ioParamStringRequired(ioFlag, name, "originalLayerName", &originalLayerName);
    assert(originalLayerName);
    if (ioFlag==PARAMS_IO_READ && originalLayerName[0]=='\0') {
       if (parent->columnId()==0) {
@@ -57,8 +57,8 @@ void BinningLayer::ioParam_originalLayerName(enum ParamsIOFlag ioFlag) {
 }
 
 void BinningLayer::ioParam_binMaxMin(enum ParamsIOFlag ioFlag) {
-   parent->ioParamValue(ioFlag, name, "binMax", &binMax, binMax);
-   parent->ioParamValue(ioFlag, name, "binMin", &binMin, binMin);
+   parent->parameters()->ioParamValue(ioFlag, name, "binMax", &binMax, binMax);
+   parent->parameters()->ioParamValue(ioFlag, name, "binMin", &binMin, binMin);
    if(ioFlag == PARAMS_IO_READ && binMax <= binMin){
       if (parent->columnId()==0) {
          pvErrorNoExit().printf("%s: binMax (%f) must be greater than binMin (%f).\n",
@@ -70,23 +70,23 @@ void BinningLayer::ioParam_binMaxMin(enum ParamsIOFlag ioFlag) {
 }
 
 void BinningLayer::ioParam_binSigma(enum ParamsIOFlag ioFlag) {
-   parent->ioParamValue(ioFlag, name, "binSigma", &binSigma, binSigma);
+   parent->parameters()->ioParamValue(ioFlag, name, "binSigma", &binSigma, binSigma);
 }
 
 void BinningLayer::ioParam_delay(enum ParamsIOFlag ioFlag) {
-   parent->ioParamValue(ioFlag, name, "delay", &delay, delay);
+   parent->parameters()->ioParamValue(ioFlag, name, "delay", &delay, delay);
 }
 
 void BinningLayer::ioParam_zeroNeg(enum ParamsIOFlag ioFlag) {
-   parent->ioParamValue(ioFlag, name, "zeroNeg", &zeroNeg, zeroNeg);
+   parent->parameters()->ioParamValue(ioFlag, name, "zeroNeg", &zeroNeg, zeroNeg);
 }
 
 void BinningLayer::ioParam_zeroDCR(enum ParamsIOFlag ioFlag) {
-   parent->ioParamValue(ioFlag, name, "zeroDCR", &zeroDCR, zeroDCR);
+   parent->parameters()->ioParamValue(ioFlag, name, "zeroDCR", &zeroDCR, zeroDCR);
 }
 
 void BinningLayer::ioParam_normalDist(enum ParamsIOFlag ioFlag) {
-   parent->ioParamValue(ioFlag, name, "normalDist", &normalDist, normalDist);
+   parent->parameters()->ioParamValue(ioFlag, name, "normalDist", &normalDist, normalDist);
 }
 
 //TODO read params for gaussian over features

--- a/src/layers/CloneVLayer.cpp
+++ b/src/layers/CloneVLayer.cpp
@@ -38,7 +38,7 @@ int CloneVLayer::ioParamsFillGroup(enum ParamsIOFlag ioFlag) {
 }
 
 void CloneVLayer::ioParam_originalLayerName(enum ParamsIOFlag ioFlag) {
-   parent->ioParamStringRequired(ioFlag, name, "originalLayerName", &originalLayerName);
+   parent->parameters()->ioParamStringRequired(ioFlag, name, "originalLayerName", &originalLayerName);
 }
 
 void CloneVLayer::ioParam_InitVType(enum ParamsIOFlag ioFlag) {

--- a/src/layers/FilenameParsingGroundTruthLayer.cpp
+++ b/src/layers/FilenameParsingGroundTruthLayer.cpp
@@ -35,16 +35,16 @@ namespace PV {
    }
 
    void FilenameParsingGroundTruthLayer::ioParam_gtClassTrueValue(enum ParamsIOFlag ioFlag) {
-         parent->ioParamValue(ioFlag, name, "gtClassTrueValue", &mGtClassTrueValue, 1.0f, false);
+         parent->parameters()->ioParamValue(ioFlag, name, "gtClassTrueValue", &mGtClassTrueValue, 1.0f, false);
    }
 
 
    void FilenameParsingGroundTruthLayer::ioParam_gtClassFalseValue(enum ParamsIOFlag ioFlag) {
-         parent->ioParamValue(ioFlag, name, "gtClassFalseValue", &mGtClassFalseValue, -1.0f, false);
+         parent->parameters()->ioParamValue(ioFlag, name, "gtClassFalseValue", &mGtClassFalseValue, -1.0f, false);
    }
 
    void FilenameParsingGroundTruthLayer::ioParam_inputLayerName(enum ParamsIOFlag ioFlag) {
-         parent->ioParamStringRequired(ioFlag, name, "inputLayerName", &mInputLayerName);
+         parent->parameters()->ioParamStringRequired(ioFlag, name, "inputLayerName", &mInputLayerName);
    }
 
    void FilenameParsingGroundTruthLayer::ioParam_classes(enum ParamsIOFlag ioFlag) {

--- a/src/layers/GapLayer.cpp
+++ b/src/layers/GapLayer.cpp
@@ -46,7 +46,7 @@ int GapLayer::ioParamsFillGroup(enum ParamsIOFlag ioFlag) {
 }
 
 void GapLayer::ioParam_ampSpikelet(enum ParamsIOFlag ioFlag) {
-   parent->ioParamValue(ioFlag, name, "ampSpikelet", &ampSpikelet, ampSpikelet);
+   parent->parameters()->ioParamValue(ioFlag, name, "ampSpikelet", &ampSpikelet, ampSpikelet);
 }
 
 int GapLayer::communicateInitInfo() {

--- a/src/layers/HyPerLCALayer.cpp
+++ b/src/layers/HyPerLCALayer.cpp
@@ -85,18 +85,18 @@ int HyPerLCALayer::ioParamsFillGroup(enum ParamsIOFlag ioFlag) {
 }
 
 void HyPerLCALayer::ioParam_timeConstantTau(enum ParamsIOFlag ioFlag) {
-   parent->ioParamValue(ioFlag, name, "timeConstantTau", &timeConstantTau, timeConstantTau, true/*warnIfAbsent*/);
+   parent->parameters()->ioParamValue(ioFlag, name, "timeConstantTau", &timeConstantTau, timeConstantTau, true/*warnIfAbsent*/);
 }
 
 void HyPerLCALayer::ioParam_selfInteract(enum ParamsIOFlag ioFlag) {
-   parent->ioParamValue(ioFlag, name, "selfInteract", &selfInteract, selfInteract);
+   parent->parameters()->ioParamValue(ioFlag, name, "selfInteract", &selfInteract, selfInteract);
    if (ioFlag==PARAMS_IO_READ && parent->columnId() == 0) {
       pvInfo() << getDescription() << ": selfInteract flag is " << (selfInteract ? "true" : "false") << std::endl;
    }   
 }
 
 void HyPerLCALayer::ioParam_adaptiveTimeScaleProbe(enum ParamsIOFlag ioFlag) {
-   parent->ioParamString(ioFlag, name, "adaptiveTimeScaleProbe", &mAdaptiveTimeScaleProbeName, nullptr/*default*/, true/*warn if absent*/);
+   parent->parameters()->ioParamString(ioFlag, name, "adaptiveTimeScaleProbe", &mAdaptiveTimeScaleProbeName, nullptr/*default*/, true/*warn if absent*/);
 }
 
 int HyPerLCALayer::requireChannel(int channelNeeded, int * numChannelsResult) {

--- a/src/layers/HyPerLayer.cpp
+++ b/src/layers/HyPerLayer.cpp
@@ -609,7 +609,7 @@ int HyPerLayer::ioParamsFillGroup(enum ParamsIOFlag ioFlag) {
 }
 
 void HyPerLayer::ioParam_dataType(enum ParamsIOFlag ioFlag) {
-   this->getParent()->ioParamString(ioFlag, this->getName(), "dataType", &dataTypeString, NULL, false/*warnIfAbsent*/);
+   this->getParent()->parameters()->ioParamString(ioFlag, this->getName(), "dataType", &dataTypeString, NULL, false/*warnIfAbsent*/);
    if(dataTypeString == NULL){
       //Default value
       dataType = PV_FLOAT;
@@ -628,10 +628,10 @@ void HyPerLayer::ioParam_dataType(enum ParamsIOFlag ioFlag) {
 
 void HyPerLayer::ioParam_updateGpu(enum ParamsIOFlag ioFlag) {
 #ifdef PV_USE_CUDA
-   parent->ioParamValue(ioFlag, name, "updateGpu", &updateGpu, updateGpu, true/*warnIfAbsent*/);
+   parent->parameters()->ioParamValue(ioFlag, name, "updateGpu", &updateGpu, updateGpu, true/*warnIfAbsent*/);
 #else //PV_USE_CUDA
    bool updateGpu = false;
-   parent->ioParamValue(ioFlag, name, "updateGpu", &updateGpu, updateGpu, false/*warnIfAbsent*/);
+   parent->parameters()->ioParamValue(ioFlag, name, "updateGpu", &updateGpu, updateGpu, false/*warnIfAbsent*/);
    if (ioFlag==PARAMS_IO_READ && updateGpu) {
       if (parent->columnId()==0) {
          pvErrorNoExit().printf("%s: updateGpu is set to true, but PetaVision was compiled without GPU acceleration.\n",
@@ -644,39 +644,39 @@ void HyPerLayer::ioParam_updateGpu(enum ParamsIOFlag ioFlag) {
 }
 
 void HyPerLayer::ioParam_nxScale(enum ParamsIOFlag ioFlag) {
-   parent->ioParamValue(ioFlag, name, "nxScale", &nxScale, nxScale);
+   parent->parameters()->ioParamValue(ioFlag, name, "nxScale", &nxScale, nxScale);
 }
 
 void HyPerLayer::ioParam_nyScale(enum ParamsIOFlag ioFlag) {
-   parent->ioParamValue(ioFlag, name, "nyScale", &nyScale, nyScale);
+   parent->parameters()->ioParamValue(ioFlag, name, "nyScale", &nyScale, nyScale);
 }
 
 void HyPerLayer::ioParam_nf(enum ParamsIOFlag ioFlag) {
-   parent->ioParamValue(ioFlag, name, "nf", &numFeatures, numFeatures);
+   parent->parameters()->ioParamValue(ioFlag, name, "nf", &numFeatures, numFeatures);
 }
 
 void HyPerLayer::ioParam_phase(enum ParamsIOFlag ioFlag) {
-   parent->ioParamValue(ioFlag, name, "phase", &phase, phase);
+   parent->parameters()->ioParamValue(ioFlag, name, "phase", &phase, phase);
    if (ioFlag == PARAMS_IO_READ && phase<0) {
       if (parent->columnId()==0) pvError().printf("%s: phase must be >= 0 (given value was %d).\n", getDescription_c(), phase);
    }
 }
 
 void HyPerLayer::ioParam_mirrorBCflag(enum ParamsIOFlag ioFlag) {
-   parent->ioParamValue(ioFlag, name, "mirrorBCflag", &mirrorBCflag, mirrorBCflag);
+   parent->parameters()->ioParamValue(ioFlag, name, "mirrorBCflag", &mirrorBCflag, mirrorBCflag);
 }
 
 void HyPerLayer::ioParam_valueBC(enum ParamsIOFlag ioFlag) {
    assert(!parent->parameters()->presentAndNotBeenRead(name, "mirrorBCflag"));
    if (!mirrorBCflag) {
-      parent->ioParamValue(ioFlag, name, "valueBC", &valueBC, (pvdata_t) 0);
+      parent->parameters()->ioParamValue(ioFlag, name, "valueBC", &valueBC, (pvdata_t) 0);
    }
 }
 
 void HyPerLayer::ioParam_initializeFromCheckpointFlag(enum ParamsIOFlag ioFlag) {
    assert(parent->getInitializeFromCheckpointDir());
    if (parent->getInitializeFromCheckpointDir() && parent->getInitializeFromCheckpointDir()[0]) {
-      parent->ioParamValue(ioFlag, name, "initializeFromCheckpointFlag", &initializeFromCheckpointFlag, parent->getDefaultInitializeFromCheckpointFlag(), true/*warnIfAbsent*/);
+      parent->parameters()->ioParamValue(ioFlag, name, "initializeFromCheckpointFlag", &initializeFromCheckpointFlag, parent->getDefaultInitializeFromCheckpointFlag(), true/*warnIfAbsent*/);
    }
 }
 
@@ -694,7 +694,7 @@ void HyPerLayer::ioParam_InitVType(enum ParamsIOFlag ioFlag) {
 }
 
 void HyPerLayer::ioParam_triggerLayerName(enum ParamsIOFlag ioFlag) {
-   parent->ioParamString(ioFlag, name, "triggerLayerName", &triggerLayerName, NULL, false/*warnIfAbsent*/);
+   parent->parameters()->ioParamString(ioFlag, name, "triggerLayerName", &triggerLayerName, NULL, false/*warnIfAbsent*/);
    if (ioFlag==PARAMS_IO_READ) {
       if (triggerLayerName && !strcmp(name, triggerLayerName)) {
          if (parent->columnId()==0) {
@@ -717,7 +717,7 @@ void HyPerLayer::ioParam_triggerFlag(enum ParamsIOFlag ioFlag) {
    pvAssert(!parent->parameters()->presentAndNotBeenRead(name, "triggerLayerName"));
    if (ioFlag == PARAMS_IO_READ && parent->parameters()->present(name, "triggerFlag")) {
       bool flagFromParams = false;
-      parent->ioParamValue(ioFlag, name, "triggerFlag", &flagFromParams, flagFromParams);
+      parent->parameters()->ioParamValue(ioFlag, name, "triggerFlag", &flagFromParams, flagFromParams);
       if (parent->columnId()==0) {
          pvWarn(triggerFlagMessage);
          triggerFlagMessage.printf("%s: triggerFlag has been deprecated.\n", getDescription_c());
@@ -744,7 +744,7 @@ void HyPerLayer::ioParam_triggerFlag(enum ParamsIOFlag ioFlag) {
 void HyPerLayer::ioParam_triggerOffset(enum ParamsIOFlag ioFlag) {
    assert(!parent->parameters()->presentAndNotBeenRead(name, "triggerLayerName"));
    if (triggerFlag) {
-      parent->ioParamValue(ioFlag, name, "triggerOffset", &triggerOffset, triggerOffset);
+      parent->parameters()->ioParamValue(ioFlag, name, "triggerOffset", &triggerOffset, triggerOffset);
       if(triggerOffset < 0){
          if (parent->columnId()==0) {
             pvError().printf("%s: TriggerOffset (%f) must be positive\n", getDescription_c(), triggerOffset);
@@ -755,7 +755,7 @@ void HyPerLayer::ioParam_triggerOffset(enum ParamsIOFlag ioFlag) {
 void HyPerLayer::ioParam_triggerBehavior(enum ParamsIOFlag ioFlag) {
    assert(!parent->parameters()->presentAndNotBeenRead(name, "triggerLayerName"));
    if (triggerFlag) {
-      parent->ioParamString(ioFlag, name, "triggerBehavior", &triggerBehavior, "updateOnlyOnTrigger", true/*warnIfAbsent*/);
+      parent->parameters()->ioParamString(ioFlag, name, "triggerBehavior", &triggerBehavior, "updateOnlyOnTrigger", true/*warnIfAbsent*/);
       if (triggerBehavior==NULL || !strcmp(triggerBehavior, "")) {
          free(triggerBehavior);
          triggerBehavior = strdup("updateOnlyOnTrigger");
@@ -787,20 +787,20 @@ void HyPerLayer::ioParam_triggerResetLayerName(enum ParamsIOFlag ioFlag) {
    if (triggerFlag) {
       assert(!parent->parameters()->presentAndNotBeenRead(name, "triggerBehavior"));
       if (!strcmp(triggerBehavior, "resetStateOnTrigger")) {
-         parent->ioParamStringRequired(ioFlag, name, "triggerResetLayerName", &triggerResetLayerName);
+         parent->parameters()->ioParamStringRequired(ioFlag, name, "triggerResetLayerName", &triggerResetLayerName);
       }
    }
 }
 
 void HyPerLayer::ioParam_writeStep(enum ParamsIOFlag ioFlag) {
-   parent->ioParamValue(ioFlag, name, "writeStep", &writeStep, parent->getDeltaTime());
+   parent->parameters()->ioParamValue(ioFlag, name, "writeStep", &writeStep, parent->getDeltaTime());
 }
 
 void HyPerLayer::ioParam_initialWriteTime(enum ParamsIOFlag ioFlag) {
    assert(!parent->parameters()->presentAndNotBeenRead(name, "writeStep"));
    if (writeStep>=0.0) {
       double start_time = parent->getStartTime();
-      parent->ioParamValue(ioFlag, name, "initialWriteTime", &initialWriteTime, start_time);
+      parent->parameters()->ioParamValue(ioFlag, name, "initialWriteTime", &initialWriteTime, start_time);
       if (ioFlag == PARAMS_IO_READ && writeStep > 0.0 && initialWriteTime < start_time) {
          double storeInitialWriteTime = initialWriteTime;
          while (initialWriteTime < start_time) {
@@ -818,7 +818,7 @@ void HyPerLayer::ioParam_initialWriteTime(enum ParamsIOFlag ioFlag) {
 
 void HyPerLayer::ioParam_sparseLayer(enum ParamsIOFlag ioFlag) {
    if (ioFlag==PARAMS_IO_READ && !parent->parameters()->present(name, "sparseLayer") && parent->parameters()->present(name, "writeSparseActivity")){
-      parent->ioParamValue(ioFlag, name, "writeSparseActivity", &sparseLayer, false);
+      parent->parameters()->ioParamValue(ioFlag, name, "writeSparseActivity", &sparseLayer, false);
       if (parent->columnId()==0) {
          pvWarn().printf("writeSparseActivity is deprecated.  Use sparseLayer instead.\n");
       }
@@ -826,7 +826,7 @@ void HyPerLayer::ioParam_sparseLayer(enum ParamsIOFlag ioFlag) {
    }
    // writeSparseActivity was deprecated Nov 4, 2014
    // When support for writeSparseActivity is removed entirely, remove the above if-statement and keep the ioParamValue call below.
-   parent->ioParamValue(ioFlag, name, "sparseLayer", &sparseLayer, false);
+   parent->parameters()->ioParamValue(ioFlag, name, "sparseLayer", &sparseLayer, false);
 }
 
 void HyPerLayer::ioParam_writeSparseValues(enum ParamsIOFlag ioFlag) {
@@ -838,7 +838,7 @@ void HyPerLayer::ioParam_writeSparseValues(enum ParamsIOFlag ioFlag) {
       assert(!parent->parameters()->presentAndNotBeenRead(name, "sparseLayer"));
    }
    if (sparseLayer)
-      parent->ioParamValue(ioFlag, name, "writeSparseValues", &writeSparseValues, true/*default value*/);
+      parent->parameters()->ioParamValue(ioFlag, name, "writeSparseValues", &writeSparseValues, true/*default value*/);
 }
 
 int HyPerLayer::respond(std::shared_ptr<BaseMessage const> message) {

--- a/src/layers/ISTALayer.cpp
+++ b/src/layers/ISTALayer.cpp
@@ -86,19 +86,19 @@ int ISTALayer::ioParamsFillGroup(enum ParamsIOFlag ioFlag) {
 }
 
 void ISTALayer::ioParam_timeConstantTau(enum ParamsIOFlag ioFlag) {
-   parent->ioParamValue(ioFlag, name, "timeConstantTau", &timeConstantTau, timeConstantTau, true/*warnIfAbsent*/);
+   parent->parameters()->ioParamValue(ioFlag, name, "timeConstantTau", &timeConstantTau, timeConstantTau, true/*warnIfAbsent*/);
 }
 
 
 void ISTALayer::ioParam_selfInteract(enum ParamsIOFlag ioFlag) {
-   parent->ioParamValue(ioFlag, name, "selfInteract", &selfInteract, selfInteract);
+   parent->parameters()->ioParamValue(ioFlag, name, "selfInteract", &selfInteract, selfInteract);
    if (parent->columnId() == 0) {
      pvInfo() << "selfInteract = " << selfInteract << std::endl;
    }   
 }
 
 void ISTALayer::ioParam_adaptiveTimeScaleProbe(enum ParamsIOFlag ioFlag) {
-   parent->ioParamString(ioFlag, name, "adaptiveTimeScaleProbe", &mAdaptiveTimeScaleProbeName, nullptr/*default*/, true/*warn if absent*/);
+   parent->parameters()->ioParamString(ioFlag, name, "adaptiveTimeScaleProbe", &mAdaptiveTimeScaleProbeName, nullptr/*default*/, true/*warn if absent*/);
 }
 
 int ISTALayer::requireChannel(int channelNeeded, int * numChannelsResult) {

--- a/src/layers/InitV.cpp
+++ b/src/layers/InitV.cpp
@@ -42,7 +42,7 @@ InitV::~InitV() {
 }
 
 void InitV::ioParamGroup_ConstantV(enum ParamsIOFlag ioFlag){
-   parent->ioParamValue(ioFlag, groupName, "valueV", &constantValue, (pvdata_t) V_REST);
+   parent->parameters()->ioParamValue(ioFlag, groupName, "valueV", &constantValue, (pvdata_t) V_REST);
 }
 
 void InitV::ioParamGroup_ZeroV(enum ParamsIOFlag ioFlag){
@@ -50,17 +50,17 @@ void InitV::ioParamGroup_ZeroV(enum ParamsIOFlag ioFlag){
 }
 
 void InitV::ioParamGroup_UniformRandomV(enum ParamsIOFlag ioFlag){
-   parent->ioParamValue(ioFlag, groupName, "minV", &minV, 0.0f);
-   parent->ioParamValue(ioFlag, groupName, "maxV", &maxV, minV + 1.0f);
+   parent->parameters()->ioParamValue(ioFlag, groupName, "minV", &minV, 0.0f);
+   parent->parameters()->ioParamValue(ioFlag, groupName, "maxV", &maxV, minV + 1.0f);
 }
 
 void InitV::ioParamGroup_GaussianRandomV(enum ParamsIOFlag ioFlag){
-   parent->ioParamValue(ioFlag, groupName, "meanV", &meanV, 0.0f);
-   parent->ioParamValue(ioFlag, groupName, "sigmaV", &sigmaV, 1.0f);
+   parent->parameters()->ioParamValue(ioFlag, groupName, "meanV", &meanV, 0.0f);
+   parent->parameters()->ioParamValue(ioFlag, groupName, "sigmaV", &sigmaV, 1.0f);
 }
 
 void InitV::ioParamGroup_InitVFromFile(enum ParamsIOFlag ioFlag){
-   parent->ioParamString(ioFlag, groupName, "Vfilename", &filename, NULL, true/*warnIfAbsent*/);
+   parent->parameters()->ioParamString(ioFlag, groupName, "Vfilename", &filename, NULL, true/*warnIfAbsent*/);
    if( filename == NULL ) {
       initVTypeCode = UndefinedInitV;
       pvErrorNoExit().printf("InitV::initialize, group \"%s\": for InitVFromFile, string parameter \"Vfilename\" must be defined.  Exiting\n", groupName);
@@ -72,7 +72,7 @@ void InitV::ioParamGroup_InitVFromFile(enum ParamsIOFlag ioFlag){
 int InitV::ioParamsFillGroup(enum ParamsIOFlag ioFlag) {
    int status = PV_SUCCESS;
    printErrors = parent->getCommunicator()->commRank()==0;
-   parent->ioParamString(ioFlag, groupName, "InitVType", &initVTypeString, "ConstantV", true/*warnIfAbsent*/);
+   parent->parameters()->ioParamString(ioFlag, groupName, "InitVType", &initVTypeString, "ConstantV", true/*warnIfAbsent*/);
    if( !strcmp(initVTypeString, "ConstantV") ) {
       initVTypeCode = ConstantV;
       ioParamGroup_ConstantV(ioFlag);

--- a/src/layers/InputLayer.cpp
+++ b/src/layers/InputLayer.cpp
@@ -472,7 +472,7 @@ namespace PV {
       if (ioFlag == PARAMS_IO_WRITE) {
          tempString = strdup(mInputPath.c_str());
       }
-      parent->ioParamStringRequired(ioFlag, name, "inputPath", &tempString);
+      parent->parameters()->ioParamStringRequired(ioFlag, name, "inputPath", &tempString);
       if (ioFlag == PARAMS_IO_READ) { 
          mInputPath = std::string(tempString);
          // Check if the input path ends in ".txt" and enable the file list if so
@@ -488,19 +488,19 @@ namespace PV {
    }
 
    void InputLayer::ioParam_useInputBCflag(enum ParamsIOFlag ioFlag) { 
-      parent->ioParamValue(ioFlag, name, "useInputBCflag", &mUseInputBCflag, mUseInputBCflag);
+      parent->parameters()->ioParamValue(ioFlag, name, "useInputBCflag", &mUseInputBCflag, mUseInputBCflag);
    }
 
    int InputLayer::ioParam_offsets(enum ParamsIOFlag ioFlag) {
-      parent->ioParamValue(ioFlag, name, "offsetX", &mOffsetX, mOffsetX);
-      parent->ioParamValue(ioFlag, name, "offsetY", &mOffsetY, mOffsetY);
+      parent->parameters()->ioParamValue(ioFlag, name, "offsetX", &mOffsetX, mOffsetX);
+      parent->parameters()->ioParamValue(ioFlag, name, "offsetY", &mOffsetY, mOffsetY);
       return PV_SUCCESS;
    }
 
    void InputLayer::ioParam_offsetAnchor(enum ParamsIOFlag ioFlag){
       if (ioFlag==PARAMS_IO_READ) {
          char *offsetAnchor = nullptr;
-         parent->ioParamString(ioFlag, name, "offsetAnchor", &offsetAnchor, "tl");
+         parent->parameters()->ioParamString(ioFlag, name, "offsetAnchor", &offsetAnchor, "tl");
          if(checkValidAnchorString(offsetAnchor) == PV_FAILURE) {
             pvError() << "Invalid value for offsetAnchor\n";
          }
@@ -578,13 +578,13 @@ namespace PV {
                offsetAnchor[1] = 'r';
                break;
          }
-         parent->ioParamString(ioFlag, name, "offsetAnchor", &offsetAnchor, "tl");
+         parent->parameters()->ioParamString(ioFlag, name, "offsetAnchor", &offsetAnchor, "tl");
          free(offsetAnchor);
       }
    }
 
    void InputLayer::ioParam_autoResizeFlag(enum ParamsIOFlag ioFlag) {
-      parent->ioParamValue(ioFlag, name, "autoResizeFlag", &mAutoResizeFlag, mAutoResizeFlag);
+      parent->parameters()->ioParamValue(ioFlag, name, "autoResizeFlag", &mAutoResizeFlag, mAutoResizeFlag);
    }
 
    void InputLayer::ioParam_aspectRatioAdjustment(enum ParamsIOFlag ioFlag) {
@@ -601,7 +601,7 @@ namespace PV {
                   break;
             }
          }
-         parent->ioParamString(ioFlag, name, "aspectRatioAdjustment", &aspectRatioAdjustment, "crop");
+         parent->parameters()->ioParamString(ioFlag, name, "aspectRatioAdjustment", &aspectRatioAdjustment, "crop");
          if (ioFlag == PARAMS_IO_READ) {
             assert(aspectRatioAdjustment);
             for (char * c = aspectRatioAdjustment; *c; c++) { *c = tolower(*c); }
@@ -629,7 +629,7 @@ namespace PV {
       if (mAutoResizeFlag) {
          char * interpolationMethodString = nullptr;
          if (ioFlag == PARAMS_IO_READ) {
-            parent->ioParamString(ioFlag, name, "interpolationMethod", &interpolationMethodString, "bicubic", true/*warn if absent*/);
+            parent->parameters()->ioParamString(ioFlag, name, "interpolationMethod", &interpolationMethodString, "bicubic", true/*warn if absent*/);
             assert(interpolationMethodString);
             for (char * c = interpolationMethodString; *c; c++) { *c = tolower(*c); }
             if (!strncmp(interpolationMethodString, "bicubic", strlen("bicubic"))) {
@@ -657,28 +657,28 @@ namespace PV {
                interpolationMethodString = strdup("nearestNeighbor");
                break;
             }
-            parent->ioParamString(ioFlag, name, "interpolationMethod", &interpolationMethodString, "bicubic", true/*warn if absent*/);
+            parent->parameters()->ioParamString(ioFlag, name, "interpolationMethod", &interpolationMethodString, "bicubic", true/*warn if absent*/);
          }
          free(interpolationMethodString);
       }
    }
 
    void InputLayer::ioParam_inverseFlag(enum ParamsIOFlag ioFlag) {
-      parent->ioParamValue(ioFlag, name, "inverseFlag", &mInverseFlag, mInverseFlag);
+      parent->parameters()->ioParamValue(ioFlag, name, "inverseFlag", &mInverseFlag, mInverseFlag);
    }
 
    void InputLayer::ioParam_normalizeLuminanceFlag(enum ParamsIOFlag ioFlag) {
-      parent->ioParamValue(ioFlag, name, "normalizeLuminanceFlag", &mNormalizeLuminanceFlag, mNormalizeLuminanceFlag);
+      parent->parameters()->ioParamValue(ioFlag, name, "normalizeLuminanceFlag", &mNormalizeLuminanceFlag, mNormalizeLuminanceFlag);
    }
 
    void InputLayer::ioParam_normalizeStdDev(enum ParamsIOFlag ioFlag) {
       assert(!parent->parameters()->presentAndNotBeenRead(name, "normalizeLuminanceFlag"));
       if (mNormalizeLuminanceFlag) {
-        parent->ioParamValue(ioFlag, name, "normalizeStdDev", &mNormalizeStdDev, mNormalizeStdDev);
+        parent->parameters()->ioParamValue(ioFlag, name, "normalizeStdDev", &mNormalizeStdDev, mNormalizeStdDev);
       }
    }
    void InputLayer::ioParam_padValue(enum ParamsIOFlag ioFlag) {
-      parent->ioParamValue(ioFlag, name, "padValue", &mPadValue, mPadValue);
+      parent->parameters()->ioParamValue(ioFlag, name, "padValue", &mPadValue, mPadValue);
    }
   
    void InputLayer::ioParam_InitVType(enum ParamsIOFlag ioFlag) {
@@ -695,11 +695,11 @@ namespace PV {
    }
 
    void InputLayer::ioParam_displayPeriod(enum ParamsIOFlag ioFlag) {
-      parent->ioParamValue(ioFlag, name, "displayPeriod", &mDisplayPeriod, mDisplayPeriod);
+      parent->parameters()->ioParamValue(ioFlag, name, "displayPeriod", &mDisplayPeriod, mDisplayPeriod);
    }
 
    void InputLayer::ioParam_echoFramePathnameFlag(enum ParamsIOFlag ioFlag) {
-      parent->ioParamValue(ioFlag, name, "echoFramePathnameFlag", &mEchoFramePathnameFlag, false/*default value*/);
+      parent->parameters()->ioParamValue(ioFlag, name, "echoFramePathnameFlag", &mEchoFramePathnameFlag, false/*default value*/);
    }
 
    void InputLayer::ioParam_batchMethod(enum ParamsIOFlag ioFlag) {
@@ -717,7 +717,7 @@ namespace PV {
                break;
          }
       }
-      parent->ioParamString(ioFlag, name, "batchMethod", &batchMethod, "byFile");
+      parent->parameters()->ioParamString(ioFlag, name, "batchMethod", &batchMethod, "byFile");
       if (strcmp(batchMethod, "byImage") == 0 || strcmp(batchMethod, "byFile") == 0) {
          mBatchMethod = BatchIndexer::BYFILE;
       }
@@ -743,7 +743,7 @@ namespace PV {
             paramsStartFrameIndex[i] = mStartFrameIndex.at(i);
          }
       }
-      this->getParent()->ioParamArray(ioFlag, this->getName(), "start_frame_index", &paramsStartFrameIndex, &length);
+      this->getParent()->parameters()->ioParamArray(ioFlag, this->getName(), "start_frame_index", &paramsStartFrameIndex, &length);
       pvErrorIf(length > 0 && length != parent->getNBatchGlobal(),
             "%s: start_frame_index requires either 0 or nbatch values.\n", getName());
       mStartFrameIndex.clear();
@@ -771,7 +771,7 @@ namespace PV {
             return;
          }
       }
-      this->getParent()->ioParamArray(ioFlag, this->getName(), "skip_frame_index", &paramsSkipFrameIndex, &length);
+      this->getParent()->parameters()->ioParamArray(ioFlag, this->getName(), "skip_frame_index", &paramsSkipFrameIndex, &length);
       pvErrorIf(length != 0 && mBatchMethod != BatchIndexer::BYSPECIFIED,
             "%s: skip_frame_index requires batchMethod == bySpecified.\n", getName());
       pvErrorIf(mBatchMethod == BatchIndexer::BYSPECIFIED && length != parent->getNBatchGlobal(),
@@ -787,11 +787,11 @@ namespace PV {
    }
 
    void InputLayer::ioParam_writeFrameToTimestamp(enum ParamsIOFlag ioFlag) {
-      parent->ioParamValue(ioFlag, name, "writeFrameToTimestamp", &mWriteFileToTimestamp, mWriteFileToTimestamp);
+      parent->parameters()->ioParamValue(ioFlag, name, "writeFrameToTimestamp", &mWriteFileToTimestamp, mWriteFileToTimestamp);
    }
 
    void InputLayer::ioParam_resetToStartOnLoop(enum ParamsIOFlag ioFlag) {
-      parent->ioParamValue(ioFlag, name, "resetToStartOnLoop", &mResetToStartOnLoop, mResetToStartOnLoop);
+      parent->parameters()->ioParamValue(ioFlag, name, "resetToStartOnLoop", &mResetToStartOnLoop, mResetToStartOnLoop);
    }
 
    BaseInputDeprecatedError::BaseInputDeprecatedError(const char * name, HyPerCol *hc) {

--- a/src/layers/KmeansLayer.cpp
+++ b/src/layers/KmeansLayer.cpp
@@ -79,7 +79,7 @@ namespace PV
     
     void KmeansLayer::ioParam_TrainingFlag(enum ParamsIOFlag ioFlag)
     {
-        parent->ioParamValue(ioFlag, name, "training", &trainingFlag,trainingFlag);
+        parent->parameters()->ioParamValue(ioFlag, name, "training", &trainingFlag,trainingFlag);
     }
 
     int KmeansLayer::ioParamsFillGroup(enum ParamsIOFlag ioFlag)

--- a/src/layers/LCALIFLayer.cpp
+++ b/src/layers/LCALIFLayer.cpp
@@ -115,15 +115,15 @@ int LCALIFLayer::ioParamsFillGroup(enum ParamsIOFlag ioFlag) {
 }
 
 void LCALIFLayer::ioParam_tauTHR(enum ParamsIOFlag ioFlag) {
-   parent->ioParamValue(ioFlag, name, "tauTHR", &tauTHR, tauTHR);
+   parent->parameters()->ioParamValue(ioFlag, name, "tauTHR", &tauTHR, tauTHR);
 }
 
 void LCALIFLayer::ioParam_targetRate(enum ParamsIOFlag ioFlag) {
-   parent->ioParamValue(ioFlag, name, "targetRate", &targetRateHz, targetRateHz);
+   parent->parameters()->ioParamValue(ioFlag, name, "targetRate", &targetRateHz, targetRateHz);
 }
 
 void LCALIFLayer::ioParam_normalizeInput(enum ParamsIOFlag ioFlag) {
-   parent->ioParamValue(ioFlag, name, "normalizeInput", &normalizeInputFlag, normalizeInputFlag);
+   parent->parameters()->ioParamValue(ioFlag, name, "normalizeInput", &normalizeInputFlag, normalizeInputFlag);
 }
 
 void LCALIFLayer::ioParam_Vscale(enum ParamsIOFlag ioFlag) {
@@ -132,7 +132,7 @@ void LCALIFLayer::ioParam_Vscale(enum ParamsIOFlag ioFlag) {
    assert(!p->presentAndNotBeenRead(name, "Vrest"));
    float defaultDynVthScale = lParams.VthRest-lParams.Vrest;
    Vscale = defaultDynVthScale > 0 ? defaultDynVthScale : DEFAULT_DYNVTHSCALE;
-   parent->ioParamValue(ioFlag, name, "Vscale", &Vscale, Vscale);
+   parent->parameters()->ioParamValue(ioFlag, name, "Vscale", &Vscale, Vscale);
 }
 
 LCALIFLayer::~LCALIFLayer()

--- a/src/layers/LIF.cpp
+++ b/src/layers/LIF.cpp
@@ -176,24 +176,24 @@ int LIF::ioParamsFillGroup(enum ParamsIOFlag ioFlag)
    ioParam_method(ioFlag);
    return 0;
 }
-void LIF::ioParam_Vrest(enum ParamsIOFlag ioFlag) { parent->ioParamValue(ioFlag, name, "Vrest", &lParams.Vrest, (float) V_REST); }
-void LIF::ioParam_Vexc(enum ParamsIOFlag ioFlag) { parent->ioParamValue(ioFlag, name, "Vexc", &lParams.Vexc, (float) V_EXC); }
-void LIF::ioParam_Vinh(enum ParamsIOFlag ioFlag) { parent->ioParamValue(ioFlag, name, "Vinh", &lParams.Vinh, (float) V_INH); }
-void LIF::ioParam_VinhB(enum ParamsIOFlag ioFlag) { parent->ioParamValue(ioFlag, name, "VinhB", &lParams.VinhB, (float) V_INHB); }
-void LIF::ioParam_VthRest(enum ParamsIOFlag ioFlag) { parent->ioParamValue(ioFlag, name, "VthRest", &lParams.VthRest, (float) VTH_REST); }
-void LIF::ioParam_tau(enum ParamsIOFlag ioFlag) { parent->ioParamValue(ioFlag, name, "tau", &lParams.tau, (float) TAU_VMEM); }
-void LIF::ioParam_tauE(enum ParamsIOFlag ioFlag) { parent->ioParamValue(ioFlag, name, "tauE", &lParams.tauE, (float) TAU_EXC); }
-void LIF::ioParam_tauI(enum ParamsIOFlag ioFlag) { parent->ioParamValue(ioFlag, name, "tauI", &lParams.tauI, (float) TAU_INH); }
-void LIF::ioParam_tauIB(enum ParamsIOFlag ioFlag) { parent->ioParamValue(ioFlag, name, "tauIB", &lParams.tauIB, (float) TAU_INHB); }
-void LIF::ioParam_tauVth(enum ParamsIOFlag ioFlag) { parent->ioParamValue(ioFlag, name, "tauVth", &lParams.tauVth, (float) TAU_VTH); }
-void LIF::ioParam_deltaVth(enum ParamsIOFlag ioFlag) { parent->ioParamValue(ioFlag, name, "deltaVth", &lParams.deltaVth, (float) DELTA_VTH); }
-void LIF::ioParam_deltaGIB(enum ParamsIOFlag ioFlag) { parent->ioParamValue(ioFlag, name, "deltaGIB", &lParams.deltaGIB, (float) DELTA_G_INHB); }
-void LIF::ioParam_noiseAmpE(enum ParamsIOFlag ioFlag) { parent->ioParamValue(ioFlag, name, "noiseAmpE", &lParams.noiseAmpE, 0.0f); }
-void LIF::ioParam_noiseAmpI(enum ParamsIOFlag ioFlag) { parent->ioParamValue(ioFlag, name, "noiseAmpI", &lParams.noiseAmpI, 0.0f); }
-void LIF::ioParam_noiseAmpIB(enum ParamsIOFlag ioFlag) { parent->ioParamValue(ioFlag, name, "noiseAmpIB", &lParams.noiseAmpIB, 0.0f); }
+void LIF::ioParam_Vrest(enum ParamsIOFlag ioFlag) { parent->parameters()->ioParamValue(ioFlag, name, "Vrest", &lParams.Vrest, (float) V_REST); }
+void LIF::ioParam_Vexc(enum ParamsIOFlag ioFlag) { parent->parameters()->ioParamValue(ioFlag, name, "Vexc", &lParams.Vexc, (float) V_EXC); }
+void LIF::ioParam_Vinh(enum ParamsIOFlag ioFlag) { parent->parameters()->ioParamValue(ioFlag, name, "Vinh", &lParams.Vinh, (float) V_INH); }
+void LIF::ioParam_VinhB(enum ParamsIOFlag ioFlag) { parent->parameters()->ioParamValue(ioFlag, name, "VinhB", &lParams.VinhB, (float) V_INHB); }
+void LIF::ioParam_VthRest(enum ParamsIOFlag ioFlag) { parent->parameters()->ioParamValue(ioFlag, name, "VthRest", &lParams.VthRest, (float) VTH_REST); }
+void LIF::ioParam_tau(enum ParamsIOFlag ioFlag) { parent->parameters()->ioParamValue(ioFlag, name, "tau", &lParams.tau, (float) TAU_VMEM); }
+void LIF::ioParam_tauE(enum ParamsIOFlag ioFlag) { parent->parameters()->ioParamValue(ioFlag, name, "tauE", &lParams.tauE, (float) TAU_EXC); }
+void LIF::ioParam_tauI(enum ParamsIOFlag ioFlag) { parent->parameters()->ioParamValue(ioFlag, name, "tauI", &lParams.tauI, (float) TAU_INH); }
+void LIF::ioParam_tauIB(enum ParamsIOFlag ioFlag) { parent->parameters()->ioParamValue(ioFlag, name, "tauIB", &lParams.tauIB, (float) TAU_INHB); }
+void LIF::ioParam_tauVth(enum ParamsIOFlag ioFlag) { parent->parameters()->ioParamValue(ioFlag, name, "tauVth", &lParams.tauVth, (float) TAU_VTH); }
+void LIF::ioParam_deltaVth(enum ParamsIOFlag ioFlag) { parent->parameters()->ioParamValue(ioFlag, name, "deltaVth", &lParams.deltaVth, (float) DELTA_VTH); }
+void LIF::ioParam_deltaGIB(enum ParamsIOFlag ioFlag) { parent->parameters()->ioParamValue(ioFlag, name, "deltaGIB", &lParams.deltaGIB, (float) DELTA_G_INHB); }
+void LIF::ioParam_noiseAmpE(enum ParamsIOFlag ioFlag) { parent->parameters()->ioParamValue(ioFlag, name, "noiseAmpE", &lParams.noiseAmpE, 0.0f); }
+void LIF::ioParam_noiseAmpI(enum ParamsIOFlag ioFlag) { parent->parameters()->ioParamValue(ioFlag, name, "noiseAmpI", &lParams.noiseAmpI, 0.0f); }
+void LIF::ioParam_noiseAmpIB(enum ParamsIOFlag ioFlag) { parent->parameters()->ioParamValue(ioFlag, name, "noiseAmpIB", &lParams.noiseAmpIB, 0.0f); }
 
 void LIF::ioParam_noiseFreqE(enum ParamsIOFlag ioFlag) {
-   parent->ioParamValue(ioFlag, name, "noiseFreqE", &lParams.noiseFreqE, 250.0f);
+   parent->parameters()->ioParamValue(ioFlag, name, "noiseFreqE", &lParams.noiseFreqE, 250.0f);
    if (ioFlag==PARAMS_IO_READ) {
       float dt_sec = 0.001f * (float)parent->getDeltaTime();// seconds
       if (dt_sec * lParams.noiseFreqE  > 1.0f) {
@@ -203,7 +203,7 @@ void LIF::ioParam_noiseFreqE(enum ParamsIOFlag ioFlag) {
 }
 
 void LIF::ioParam_noiseFreqI(enum ParamsIOFlag ioFlag) {
-   parent->ioParamValue(ioFlag, name, "noiseFreqI", &lParams.noiseFreqI, 250.0f);
+   parent->parameters()->ioParamValue(ioFlag, name, "noiseFreqI", &lParams.noiseFreqI, 250.0f);
    if (ioFlag==PARAMS_IO_READ) {
       float dt_sec = 0.001f * (float)parent->getDeltaTime();// seconds
       if (dt_sec * lParams.noiseFreqI  > 1.0f) {
@@ -213,7 +213,7 @@ void LIF::ioParam_noiseFreqI(enum ParamsIOFlag ioFlag) {
 }
 
 void LIF::ioParam_noiseFreqIB(enum ParamsIOFlag ioFlag) {
-   parent->ioParamValue(ioFlag, name, "noiseFreqIB", &lParams.noiseFreqIB, 250.0f);
+   parent->parameters()->ioParamValue(ioFlag, name, "noiseFreqIB", &lParams.noiseFreqIB, 250.0f);
    if (ioFlag==PARAMS_IO_READ) {
       float dt_sec = 0.001f * (float)parent->getDeltaTime();// seconds
       if (dt_sec * lParams.noiseFreqIB > 1.0f) {
@@ -225,7 +225,7 @@ void LIF::ioParam_noiseFreqIB(enum ParamsIOFlag ioFlag) {
 void LIF::ioParam_method(enum ParamsIOFlag ioFlag) {
    // Read the integration method: one of 'arma' (preferred), 'beginning' (deprecated), or 'original' (deprecated).
    const char * default_method = "arma";
-   parent->ioParamString(ioFlag, name, "method", &methodString, default_method, true/*warnIfAbsent*/);
+   parent->parameters()->ioParamString(ioFlag, name, "method", &methodString, default_method, true/*warnIfAbsent*/);
    if (ioFlag != PARAMS_IO_READ) {
       return;
    }

--- a/src/layers/LabelErrorLayer.cpp
+++ b/src/layers/LabelErrorLayer.cpp
@@ -71,11 +71,11 @@ int LabelErrorLayer::ioParamsFillGroup(enum ParamsIOFlag ioFlag) {
 }
 
 void LabelErrorLayer::ioParam_errScale(enum ParamsIOFlag ioFlag) {
-   parent->ioParamValue(ioFlag, name, "errScale", &errScale, errScale);
+   parent->parameters()->ioParamValue(ioFlag, name, "errScale", &errScale, errScale);
 }
 
 void LabelErrorLayer::ioParam_isBinary(enum ParamsIOFlag ioFlag) {
-   parent->ioParamValue(ioFlag, name, "isBinary", &isBinary, isBinary);
+   parent->parameters()->ioParamValue(ioFlag, name, "isBinary", &isBinary, isBinary);
 }
 
 int LabelErrorLayer::updateState(double time, double dt)

--- a/src/layers/LeakyIntegrator.cpp
+++ b/src/layers/LeakyIntegrator.cpp
@@ -39,7 +39,7 @@ int LeakyIntegrator::ioParamsFillGroup(enum ParamsIOFlag ioFlag) {
 }
 
 void LeakyIntegrator::ioParam_integrationTime(enum ParamsIOFlag ioFlag) {
-   parent->ioParamValue(ioFlag, name, "integrationTime", &integrationTime, integrationTime);
+   parent->parameters()->ioParamValue(ioFlag, name, "integrationTime", &integrationTime, integrationTime);
 }
 
 int LeakyIntegrator::updateState(double timed, double dt) {

--- a/src/layers/MaskLayer.cpp
+++ b/src/layers/MaskLayer.cpp
@@ -50,7 +50,7 @@ int MaskLayer::ioParamsFillGroup(enum ParamsIOFlag ioFlag) {
 }
 
 void MaskLayer::ioParam_maskMethod(enum ParamsIOFlag ioFlag) {
-   parent->ioParamStringRequired(ioFlag, name, "maskMethod", &maskMethod);
+   parent->parameters()->ioParamStringRequired(ioFlag, name, "maskMethod", &maskMethod);
    //Check valid methods
    if(strcmp(maskMethod, "layer") == 0){
    }
@@ -72,14 +72,14 @@ void MaskLayer::ioParam_maskMethod(enum ParamsIOFlag ioFlag) {
 void MaskLayer::ioParam_maskLayerName(enum ParamsIOFlag ioFlag) {
    assert(!parent->parameters()->presentAndNotBeenRead(name, "maskMethod"));
    if(strcmp(maskMethod, "layer") == 0 || strcmp(maskMethod, "invertLayer") == 0){
-      parent->ioParamStringRequired(ioFlag, name, "maskLayerName", &maskLayerName);
+      parent->parameters()->ioParamStringRequired(ioFlag, name, "maskLayerName", &maskLayerName);
    }
 }
 
 void MaskLayer::ioParam_featureIdxs(enum ParamsIOFlag ioFlag) {
    assert(!parent->parameters()->presentAndNotBeenRead(name, "maskMethod"));
    if(strcmp(maskMethod, "maskFeatures") == 0 || strcmp(maskMethod, "noMaskFeatures") == 0){
-      parent->ioParamArray(ioFlag, name, "featureIdxs", &features, &numSpecifiedFeatures);
+      parent->parameters()->ioParamArray(ioFlag, name, "featureIdxs", &features, &numSpecifiedFeatures);
       if(numSpecifiedFeatures == 0){
          if (parent->columnId()==0) {
             pvErrorNoExit().printf("%s: MaskLayer must specify at least one feature for maskMethod \"%s\".\n",

--- a/src/layers/MomentumLCALayer.cpp
+++ b/src/layers/MomentumLCALayer.cpp
@@ -105,7 +105,7 @@ int MomentumLCALayer::ioParamsFillGroup(enum ParamsIOFlag ioFlag) {
 }
 
 void MomentumLCALayer::ioParam_LCAMomentumRate(enum ParamsIOFlag ioFlag) {
-   parent->ioParamValue(ioFlag, name, "LCAMomentumRate", &LCAMomentumRate, LCAMomentumRate, true/*warnIfAbsent*/);
+   parent->parameters()->ioParamValue(ioFlag, name, "LCAMomentumRate", &LCAMomentumRate, LCAMomentumRate, true/*warnIfAbsent*/);
 }
 
 #ifdef PV_USE_CUDA

--- a/src/layers/RescaleLayer.cpp
+++ b/src/layers/RescaleLayer.cpp
@@ -94,41 +94,41 @@ int RescaleLayer::ioParamsFillGroup(enum ParamsIOFlag ioFlag){
 }
 
 void RescaleLayer::ioParam_rescaleMethod(enum ParamsIOFlag ioFlag){
-   parent->ioParamStringRequired(ioFlag, name, "rescaleMethod", &rescaleMethod);
+   parent->parameters()->ioParamStringRequired(ioFlag, name, "rescaleMethod", &rescaleMethod);
 }
 
 void RescaleLayer::ioParam_targetMax(enum ParamsIOFlag ioFlag){
    assert(!parent->parameters()->presentAndNotBeenRead(name, "rescaleMethod"));
    if (strcmp(rescaleMethod, "maxmin")==0) {
-      parent->ioParamValue(ioFlag, name, "targetMax", &targetMax, targetMax);
+      parent->parameters()->ioParamValue(ioFlag, name, "targetMax", &targetMax, targetMax);
    }
 }
 
 void RescaleLayer::ioParam_targetMin(enum ParamsIOFlag ioFlag){
    assert(!parent->parameters()->presentAndNotBeenRead(name, "rescaleMethod"));
    if (strcmp(rescaleMethod, "maxmin")==0) {
-      parent->ioParamValue(ioFlag, name, "targetMin", &targetMin, targetMin);
+      parent->parameters()->ioParamValue(ioFlag, name, "targetMin", &targetMin, targetMin);
    }
 }
 
 void RescaleLayer::ioParam_targetMean(enum ParamsIOFlag ioFlag){
    assert(!parent->parameters()->presentAndNotBeenRead(name, "rescaleMethod"));
    if ((strcmp(rescaleMethod, "meanstd")==0) || (strcmp(rescaleMethod, "pointmeanstd")==0)) {
-      parent->ioParamValue(ioFlag, name, "targetMean", &targetMean, targetMean);
+      parent->parameters()->ioParamValue(ioFlag, name, "targetMean", &targetMean, targetMean);
    }
 }
 
 void RescaleLayer::ioParam_targetStd(enum ParamsIOFlag ioFlag){
    assert(!parent->parameters()->presentAndNotBeenRead(name, "rescaleMethod"));
    if ((strcmp(rescaleMethod, "meanstd")==0) || (strcmp(rescaleMethod, "pointmeanstd")==0)) {
-      parent->ioParamValue(ioFlag, name, "targetStd", &targetStd, targetStd);
+      parent->parameters()->ioParamValue(ioFlag, name, "targetStd", &targetStd, targetStd);
    }
 }
 
 void RescaleLayer::ioParam_patchSize(enum ParamsIOFlag ioFlag){
    assert(!parent->parameters()->presentAndNotBeenRead(name, "rescaleMethod"));
    if (strcmp(rescaleMethod, "l2")==0 || strcmp(rescaleMethod, "l2NoMean") == 0) {
-      parent->ioParamValue(ioFlag, name, "patchSize", &patchSize, patchSize);
+      parent->parameters()->ioParamValue(ioFlag, name, "patchSize", &patchSize, patchSize);
    }
 }
 

--- a/src/layers/Retina.cpp
+++ b/src/layers/Retina.cpp
@@ -160,7 +160,7 @@ void Retina::ioParam_InitVType(enum ParamsIOFlag ioFlag) {
 }
 
 void Retina::ioParam_spikingFlag(enum ParamsIOFlag ioFlag) {
-   parent->ioParamValue(ioFlag, name, "spikingFlag", &spikingFlag, true);
+   parent->parameters()->ioParamValue(ioFlag, name, "spikingFlag", &spikingFlag, true);
 }
 
 void Retina::ioParam_foregroundRate(enum ParamsIOFlag ioFlag) {
@@ -185,7 +185,7 @@ void Retina::ioParam_foregroundRate(enum ParamsIOFlag ioFlag) {
    }
    // noiseOnFreq and poissonEdgeProb were deprecated Jan 24, 2013 and marked obsolete Jun 27, 2016.
    // After a reasonable fade time, remove the above if-statement and keep the ioParamValue call below.
-   parent->ioParamValue(ioFlag, name, "foregroundRate", &probStimParam, 1.0f);
+   parent->parameters()->ioParamValue(ioFlag, name, "foregroundRate", &probStimParam, 1.0f);
 }
 
 void Retina::ioParam_backgroundRate(enum ParamsIOFlag ioFlag) {
@@ -211,7 +211,7 @@ void Retina::ioParam_backgroundRate(enum ParamsIOFlag ioFlag) {
    // noiseOffFreq and poissonBlankProb was deprecated Jan 24, 2013 and marked obsolete Jun 27, 2016.
    // After a reasonable fade time, remove the above if-statement and keep the ioParamValue call below
    // and the sanity check following it.
-   parent->ioParamValue(ioFlag, name, "backgroundRate", &probBaseParam, 0.0f);
+   parent->parameters()->ioParamValue(ioFlag, name, "backgroundRate", &probBaseParam, 0.0f);
    if (ioFlag==PARAMS_IO_READ) {
       assert(!parent->parameters()->presentAndNotBeenRead(name, "foregroundRate"));
       if (probBaseParam > probStimParam) {
@@ -223,33 +223,33 @@ void Retina::ioParam_backgroundRate(enum ParamsIOFlag ioFlag) {
 }
 
 void Retina::ioParam_beginStim(enum ParamsIOFlag ioFlag) {
-   parent->ioParamValue(ioFlag, name, "beginStim", &rParams.beginStim, 0.0);
+   parent->parameters()->ioParamValue(ioFlag, name, "beginStim", &rParams.beginStim, 0.0);
 }
 
 void Retina::ioParam_endStim(enum ParamsIOFlag ioFlag) {
-   parent->ioParamValue(ioFlag, name, "endStim", &rParams.endStim, (double) FLT_MAX);
+   parent->parameters()->ioParamValue(ioFlag, name, "endStim", &rParams.endStim, (double) FLT_MAX);
    if (ioFlag == PARAMS_IO_READ && rParams.endStim < 0) rParams.endStim = FLT_MAX;
 }
 
 void Retina::ioParam_burstFreq(enum ParamsIOFlag ioFlag) {
-   parent->ioParamValue(ioFlag, name, "burstFreq", &rParams.burstFreq, 1.0f);
+   parent->parameters()->ioParamValue(ioFlag, name, "burstFreq", &rParams.burstFreq, 1.0f);
 }
 
 void Retina::ioParam_burstDuration(enum ParamsIOFlag ioFlag) {
-   parent->ioParamValue(ioFlag, name, "burstDuration", &rParams.burstDuration, 1000.0f);
+   parent->parameters()->ioParamValue(ioFlag, name, "burstDuration", &rParams.burstDuration, 1000.0f);
 }
 
 void Retina::ioParam_refractoryPeriod(enum ParamsIOFlag ioFlag) {
    assert(!parent->parameters()->presentAndNotBeenRead(name, "spikingFlag"));
    if (spikingFlag){
-      parent->ioParamValue(ioFlag, name, "refractoryPeriod", &rParams.refractory_period, (float) REFRACTORY_PERIOD);
+      parent->parameters()->ioParamValue(ioFlag, name, "refractoryPeriod", &rParams.refractory_period, (float) REFRACTORY_PERIOD);
    }
 }
 
 void Retina::ioParam_absRefractoryPeriod(enum ParamsIOFlag ioFlag) {
    assert(!parent->parameters()->presentAndNotBeenRead(name, "spikingFlag"));
    if (spikingFlag){
-      parent->ioParamValue(ioFlag, name, "absRefractoryPeriod", &rParams.abs_refractory_period, (float) ABS_REFRACTORY_PERIOD);
+      parent->parameters()->ioParamValue(ioFlag, name, "absRefractoryPeriod", &rParams.abs_refractory_period, (float) ABS_REFRACTORY_PERIOD);
    }
 }
 

--- a/src/layers/RunningAverageLayer.cpp
+++ b/src/layers/RunningAverageLayer.cpp
@@ -67,7 +67,7 @@ int RunningAverageLayer::ioParamsFillGroup(enum ParamsIOFlag ioFlag){
 }
 
 void RunningAverageLayer::ioParam_numImagesToAverage(enum ParamsIOFlag ioFlag){
-   parent->ioParamValue(ioFlag, name, "numImagesToAverage", &numImagesToAverage, numImagesToAverage);
+   parent->parameters()->ioParamValue(ioFlag, name, "numImagesToAverage", &numImagesToAverage, numImagesToAverage);
 }
 
 int RunningAverageLayer::setActivity() {

--- a/src/layers/SegmentLayer.cpp
+++ b/src/layers/SegmentLayer.cpp
@@ -42,7 +42,7 @@ int SegmentLayer::ioParamsFillGroup(enum ParamsIOFlag ioFlag) {
 }
 
 void SegmentLayer::ioParam_segmentMethod(enum ParamsIOFlag ioFlag) {
-   parent->ioParamStringRequired(ioFlag, name, "segmentMethod", &segmentMethod);
+   parent->parameters()->ioParamStringRequired(ioFlag, name, "segmentMethod", &segmentMethod);
    assert(segmentMethod);
    //Check valid segment methods
    //none means the gsyn is already a segmentation. Helpful if reading segmentation from pvp
@@ -61,7 +61,7 @@ void SegmentLayer::ioParam_segmentMethod(enum ParamsIOFlag ioFlag) {
 }
 
 void SegmentLayer::ioParam_originalLayerName(enum ParamsIOFlag ioFlag) {
-   parent->ioParamStringRequired(ioFlag, name, "originalLayerName", &originalLayerName);
+   parent->parameters()->ioParamStringRequired(ioFlag, name, "originalLayerName", &originalLayerName);
    assert(originalLayerName);
    if (ioFlag==PARAMS_IO_READ && originalLayerName[0]=='\0') {
       if (parent->columnId()==0) {

--- a/src/layers/Segmentify.cpp
+++ b/src/layers/Segmentify.cpp
@@ -42,7 +42,7 @@ int Segmentify::ioParamsFillGroup(enum ParamsIOFlag ioFlag) {
 
 
 void Segmentify::ioParam_inputMethod(enum ParamsIOFlag ioFlag) {
-   parent->ioParamStringRequired(ioFlag, name, "inputMethod", &inputMethod);
+   parent->parameters()->ioParamStringRequired(ioFlag, name, "inputMethod", &inputMethod);
    if(strcmp(inputMethod, "average") == 0){
    }
    else if(strcmp(inputMethod, "sum") == 0){
@@ -60,7 +60,7 @@ void Segmentify::ioParam_inputMethod(enum ParamsIOFlag ioFlag) {
 }
 
 void Segmentify::ioParam_outputMethod(enum ParamsIOFlag ioFlag) {
-   parent->ioParamStringRequired(ioFlag, name, "outputMethod", &outputMethod);
+   parent->parameters()->ioParamStringRequired(ioFlag, name, "outputMethod", &outputMethod);
    if(strcmp(outputMethod, "centroid") == 0){
    }
    else if(strcmp(outputMethod, "fill") == 0){
@@ -76,7 +76,7 @@ void Segmentify::ioParam_outputMethod(enum ParamsIOFlag ioFlag) {
 }
 
 void Segmentify::ioParam_originalLayerName(enum ParamsIOFlag ioFlag) {
-   parent->ioParamStringRequired(ioFlag, name, "originalLayerName", &originalLayerName);
+   parent->parameters()->ioParamStringRequired(ioFlag, name, "originalLayerName", &originalLayerName);
    assert(originalLayerName);
    if (ioFlag==PARAMS_IO_READ && originalLayerName[0]=='\0') {
       if (parent->columnId()==0) {
@@ -89,7 +89,7 @@ void Segmentify::ioParam_originalLayerName(enum ParamsIOFlag ioFlag) {
 }
 
 void Segmentify::ioParam_segmentLayerName(enum ParamsIOFlag ioFlag) {
-   parent->ioParamStringRequired(ioFlag, name, "segmentLayerName", &segmentLayerName);
+   parent->parameters()->ioParamStringRequired(ioFlag, name, "segmentLayerName", &segmentLayerName);
    assert(segmentLayerName);
    if (ioFlag==PARAMS_IO_READ && segmentLayerName[0]=='\0') {
       if (parent->columnId()==0) {

--- a/src/layers/ShuffleLayer.cpp
+++ b/src/layers/ShuffleLayer.cpp
@@ -114,7 +114,7 @@ int ShuffleLayer::ioParamsFillGroup(enum ParamsIOFlag ioFlag){
 }
 
 void ShuffleLayer::ioParam_shuffleMethod(enum ParamsIOFlag ioFlag){
-   parent->ioParamString(ioFlag, name, "shuffleMethod", &shuffleMethod, "random", false/*warnIfAbsent*/);
+   parent->parameters()->ioParamString(ioFlag, name, "shuffleMethod", &shuffleMethod, "random", false/*warnIfAbsent*/);
    //ioFlag==PARAMS_IO_READ && 
    if ((strcmp(shuffleMethod, "random") == 0 || strcmp(shuffleMethod, "rejection") == 0)){
    }
@@ -126,21 +126,21 @@ void ShuffleLayer::ioParam_shuffleMethod(enum ParamsIOFlag ioFlag){
 void ShuffleLayer::ioParam_readFreqFromFile(enum ParamsIOFlag ioFlag) {
    assert(!parent->parameters()->presentAndNotBeenRead(name, "shuffleMethod"));
    if (strcmp(shuffleMethod, "rejection") == 0){
-      parent->ioParamValue(ioFlag, name, "readFreqFromFile", &readFreqFromFile, readFreqFromFile);
+      parent->parameters()->ioParamValue(ioFlag, name, "readFreqFromFile", &readFreqFromFile, readFreqFromFile);
    }
 }
 
 void ShuffleLayer::ioParam_freqFilename(enum ParamsIOFlag ioFlag) {
    assert(!parent->parameters()->presentAndNotBeenRead(name, "readFreqFromFile"));
    if (readFreqFromFile){
-      parent->ioParamString(ioFlag, name, "freqFilename", &freqFilename, freqFilename);
+      parent->parameters()->ioParamString(ioFlag, name, "freqFilename", &freqFilename, freqFilename);
    }
 }
 
 void ShuffleLayer::ioParam_freqCollectTime(enum ParamsIOFlag ioFlag) {
    assert(!parent->parameters()->presentAndNotBeenRead(name, "readFreqFromFile"));
    if (!readFreqFromFile){
-      parent->ioParamValue(ioFlag, name, "freqCollectTime", &freqCollectTime, freqCollectTime);
+      parent->parameters()->ioParamValue(ioFlag, name, "freqCollectTime", &freqCollectTime, freqCollectTime);
    }
 }
 

--- a/src/layers/SigmoidLayer.cpp
+++ b/src/layers/SigmoidLayer.cpp
@@ -65,19 +65,19 @@ int SigmoidLayer::ioParamsFillGroup(enum ParamsIOFlag ioFlag) {
 }
 
 void SigmoidLayer::ioParam_Vrest(enum ParamsIOFlag ioFlag) {
-   parent->ioParamValue(ioFlag, name, "Vrest", &V0, (float) V_REST);
+   parent->parameters()->ioParamValue(ioFlag, name, "Vrest", &V0, (float) V_REST);
 }
 void SigmoidLayer::ioParam_VthRest(enum ParamsIOFlag ioFlag) {
-   parent->ioParamValue(ioFlag, name, "VthRest", &Vth, (float) VTH_REST);
+   parent->parameters()->ioParamValue(ioFlag, name, "VthRest", &Vth, (float) VTH_REST);
 }
 void SigmoidLayer::ioParam_InverseFlag(enum ParamsIOFlag ioFlag) {
-   parent->ioParamValue(ioFlag, name, "InverseFlag", &InverseFlag, (bool) INVERSEFLAG);
+   parent->parameters()->ioParamValue(ioFlag, name, "InverseFlag", &InverseFlag, (bool) INVERSEFLAG);
 }
 void SigmoidLayer::ioParam_SigmoidFlag(enum ParamsIOFlag ioFlag) {
-   parent->ioParamValue(ioFlag, name, "SigmoidFlag", &SigmoidFlag, (bool) SIGMOIDFLAG);
+   parent->parameters()->ioParamValue(ioFlag, name, "SigmoidFlag", &SigmoidFlag, (bool) SIGMOIDFLAG);
 }
 void SigmoidLayer::ioParam_SigmoidAlpha(enum ParamsIOFlag ioFlag) {
-   parent->ioParamValue(ioFlag, name, "SigmoidAlpha", &SigmoidAlpha, (float) SIGMOIDALPHA);
+   parent->parameters()->ioParamValue(ioFlag, name, "SigmoidAlpha", &SigmoidAlpha, (float) SIGMOIDALPHA);
 }
 
 int SigmoidLayer::communicateInitInfo() {

--- a/src/layers/WTALayer.cpp
+++ b/src/layers/WTALayer.cpp
@@ -88,7 +88,7 @@ int WTALayer::ioParamsFillGroup(enum ParamsIOFlag ioFlag) {
    return status;
 }
 void WTALayer::ioParam_originalLayerName(enum ParamsIOFlag ioFlag) {
-   parent->ioParamStringRequired(ioFlag, name, "originalLayerName", &originalLayerName);
+   parent->parameters()->ioParamStringRequired(ioFlag, name, "originalLayerName", &originalLayerName);
    assert(originalLayerName);
    if (ioFlag==PARAMS_IO_READ && originalLayerName[0]=='\0') {
       if (parent->columnId()==0) {
@@ -101,8 +101,8 @@ void WTALayer::ioParam_originalLayerName(enum ParamsIOFlag ioFlag) {
 }
 
 void WTALayer::ioParam_binMaxMin(enum ParamsIOFlag ioFlag) {
-   parent->ioParamValue(ioFlag, name, "binMax", &binMax, binMax);
-   parent->ioParamValue(ioFlag, name, "binMin", &binMin, binMin);
+   parent->parameters()->ioParamValue(ioFlag, name, "binMax", &binMax, binMax);
+   parent->parameters()->ioParamValue(ioFlag, name, "binMin", &binMin, binMin);
    if(ioFlag == PARAMS_IO_READ && binMax <= binMin){
       if (parent->columnId()==0) {
          pvErrorNoExit().printf("%s: binMax (%f) must be greater than binMin (%f).\n",

--- a/src/normalizers/NormalizeBase.cpp
+++ b/src/normalizers/NormalizeBase.cpp
@@ -62,19 +62,19 @@ int NormalizeBase::ioParamsFillGroup(enum ParamsIOFlag ioFlag) {
 }
 
 void NormalizeBase::ioParam_strength(enum ParamsIOFlag ioFlag) {
-   parent->ioParamValue(ioFlag, name, "strength", &strength, strength/*default*/, true/*warn if absent*/);
+   parent->parameters()->ioParamValue(ioFlag, name, "strength", &strength, strength/*default*/, true/*warn if absent*/);
 }
 
 void NormalizeBase::ioParam_normalizeArborsIndividually(enum ParamsIOFlag ioFlag) {
-   parent->ioParamValue(ioFlag, name, "normalizeArborsIndividually", &normalizeArborsIndividually, false/*default*/, true/*warnIfAbsent*/);
+   parent->parameters()->ioParamValue(ioFlag, name, "normalizeArborsIndividually", &normalizeArborsIndividually, false/*default*/, true/*warnIfAbsent*/);
 }
 
 void NormalizeBase::ioParam_normalizeOnInitialize(enum ParamsIOFlag ioFlag) {
-   parent->ioParamValue(ioFlag, name, "normalizeOnInitialize", &normalizeOnInitialize, normalizeOnInitialize);
+   parent->parameters()->ioParamValue(ioFlag, name, "normalizeOnInitialize", &normalizeOnInitialize, normalizeOnInitialize);
 }
 
 void NormalizeBase::ioParam_normalizeOnWeightUpdate(enum ParamsIOFlag ioFlag) {
-   parent->ioParamValue(ioFlag, name, "normalizeOnWeightUpdate", &normalizeOnWeightUpdate, normalizeOnWeightUpdate);
+   parent->parameters()->ioParamValue(ioFlag, name, "normalizeOnWeightUpdate", &normalizeOnWeightUpdate, normalizeOnWeightUpdate);
 }
 
 int NormalizeBase::communicateInitInfo() {

--- a/src/normalizers/NormalizeContrastZeroMean.cpp
+++ b/src/normalizers/NormalizeContrastZeroMean.cpp
@@ -33,7 +33,7 @@ int NormalizeContrastZeroMean::ioParamsFillGroup(enum ParamsIOFlag ioFlag) {
 }
 
 void NormalizeContrastZeroMean::ioParam_minSumTolerated(enum ParamsIOFlag ioFlag) {
-   parent->ioParamValue(ioFlag, name, "minSumTolerated", &minSumTolerated, 0.0f, true/*warnIfAbsent*/);
+   parent->parameters()->ioParamValue(ioFlag, name, "minSumTolerated", &minSumTolerated, 0.0f, true/*warnIfAbsent*/);
 }
 
 void NormalizeContrastZeroMean::ioParam_normalizeFromPostPerspective(enum ParamsIOFlag ioFlag) {

--- a/src/normalizers/NormalizeGap.cpp
+++ b/src/normalizers/NormalizeGap.cpp
@@ -45,7 +45,7 @@ void NormalizeGap::ioParam_normalizeFromPostPerspective(enum ParamsIOFlag ioFlag
          pvWarn().printf("%s \"%s\": normalizeFromPostPerspective default is true for GapConns with normalizeMethod of normalizeSum, but the default for this parameter may change to false in a future release, to be consistent with other normalizerMethods.\n", parent->parameters()->groupKeywordFromName(name), name);
       }
    }
-   parent->ioParamValue(ioFlag, name, "normalizeFromPostPerspective", &normalizeFromPostPerspective, true/*default*/, true/*warnIfAbsent*/);
+   parent->parameters()->ioParamValue(ioFlag, name, "normalizeFromPostPerspective", &normalizeFromPostPerspective, true/*default*/, true/*warnIfAbsent*/);
 }
 
 } /* namespace PV */

--- a/src/normalizers/NormalizeGroup.cpp
+++ b/src/normalizers/NormalizeGroup.cpp
@@ -43,7 +43,7 @@ void NormalizeGroup::ioParam_normalizeOnInitialize(enum ParamsIOFlag ioFlag) {}
 void NormalizeGroup::ioParam_normalizeOnWeightUpdate(enum ParamsIOFlag ioFlag) {}
 
 void NormalizeGroup::ioParam_normalizeGroupName(enum ParamsIOFlag ioFlag) {
-   parent->ioParamStringRequired(ioFlag, name, "normalizeGroupName", &normalizeGroupName);
+   parent->parameters()->ioParamStringRequired(ioFlag, name, "normalizeGroupName", &normalizeGroupName);
 }
 
 int NormalizeGroup::communicateInitInfo() {

--- a/src/normalizers/NormalizeL2.cpp
+++ b/src/normalizers/NormalizeL2.cpp
@@ -33,7 +33,7 @@ int NormalizeL2::ioParamsFillGroup(enum ParamsIOFlag ioFlag) {
 }
 
 void NormalizeL2::ioParam_minL2NormTolerated(enum ParamsIOFlag ioFlag) {
-   parent->ioParamValue(ioFlag, name, "minL2NormTolerated", &minL2NormTolerated, 0.0f, true/*warnIfAbsent*/);
+   parent->parameters()->ioParamValue(ioFlag, name, "minL2NormTolerated", &minL2NormTolerated, 0.0f, true/*warnIfAbsent*/);
 }
 
 int NormalizeL2::normalizeWeights() {

--- a/src/normalizers/NormalizeMax.cpp
+++ b/src/normalizers/NormalizeMax.cpp
@@ -34,7 +34,7 @@ int NormalizeMax::ioParamsFillGroup(enum ParamsIOFlag ioFlag) {
 }
 
 void NormalizeMax::ioParam_minMaxTolerated(enum ParamsIOFlag ioFlag) {
-   parent->ioParamValue(ioFlag, name, "minMaxTolerated", &minMaxTolerated, 0.0f, true/*warnIfAbsent*/);
+   parent->parameters()->ioParamValue(ioFlag, name, "minMaxTolerated", &minMaxTolerated, 0.0f, true/*warnIfAbsent*/);
 }
 
 int NormalizeMax::normalizeWeights() {

--- a/src/normalizers/NormalizeMultiply.cpp
+++ b/src/normalizers/NormalizeMultiply.cpp
@@ -43,19 +43,19 @@ int NormalizeMultiply::ioParamsFillGroup(enum ParamsIOFlag ioFlag) {
 }
 
 void NormalizeMultiply::ioParam_rMinX(enum ParamsIOFlag ioFlag) {
-   parent->ioParamValue(ioFlag, name, "rMinX", &rMinX, rMinX);
+   parent->parameters()->ioParamValue(ioFlag, name, "rMinX", &rMinX, rMinX);
 }
 
 void NormalizeMultiply::ioParam_rMinY(enum ParamsIOFlag ioFlag) {
-   parent->ioParamValue(ioFlag, name, "rMinY", &rMinY, rMinY);
+   parent->parameters()->ioParamValue(ioFlag, name, "rMinY", &rMinY, rMinY);
 }
 
 void NormalizeMultiply::ioParam_nonnegativeConstraintFlag(enum ParamsIOFlag ioFlag) {
-   parent->ioParamValue(ioFlag, name, "nonnegativeConstraintFlag", &nonnegativeConstraintFlag, nonnegativeConstraintFlag);
+   parent->parameters()->ioParamValue(ioFlag, name, "nonnegativeConstraintFlag", &nonnegativeConstraintFlag, nonnegativeConstraintFlag);
 }
 
 void NormalizeMultiply::ioParam_normalize_cutoff(enum ParamsIOFlag ioFlag) {
-   parent->ioParamValue(ioFlag, name, "normalize_cutoff", &normalize_cutoff, normalize_cutoff);
+   parent->parameters()->ioParamValue(ioFlag, name, "normalize_cutoff", &normalize_cutoff, normalize_cutoff);
 }
 
 void NormalizeMultiply::ioParam_normalizeFromPostPerspective(enum ParamsIOFlag ioFlag) {
@@ -66,7 +66,7 @@ void NormalizeMultiply::ioParam_normalizeFromPostPerspective(enum ParamsIOFlag i
       normalizeFromPostPerspective = parent->parameters()->value(name, "normalizeTotalToPost");
       return;
    }
-   parent->ioParamValue(ioFlag, name, "normalizeFromPostPerspective", &normalizeFromPostPerspective, false/*default value*/, true/*warnIfAbsent*/);
+   parent->parameters()->ioParamValue(ioFlag, name, "normalizeFromPostPerspective", &normalizeFromPostPerspective, false/*default value*/, true/*warnIfAbsent*/);
 }
 
 int NormalizeMultiply::normalizeWeights() {

--- a/src/normalizers/NormalizeSum.cpp
+++ b/src/normalizers/NormalizeSum.cpp
@@ -34,7 +34,7 @@ int NormalizeSum::ioParamsFillGroup(enum ParamsIOFlag ioFlag) {
 }
 
 void NormalizeSum::ioParam_minSumTolerated(enum ParamsIOFlag ioFlag) {
-   parent->ioParamValue(ioFlag, name, "minSumTolerated", &minSumTolerated, 0.0f, true/*warnIfAbsent*/);
+   parent->parameters()->ioParamValue(ioFlag, name, "minSumTolerated", &minSumTolerated, 0.0f, true/*warnIfAbsent*/);
 }
 
 int NormalizeSum::normalizeWeights() {

--- a/src/probes/AbstractNormProbe.cpp
+++ b/src/probes/AbstractNormProbe.cpp
@@ -51,7 +51,7 @@ int AbstractNormProbe::ioParamsFillGroup(enum ParamsIOFlag ioFlag) {
 }
    
 void AbstractNormProbe::ioParam_maskLayerName(enum ParamsIOFlag ioFlag) {
-   parent->ioParamString(ioFlag, name, "maskLayerName", &maskLayerName, NULL, false/*warnIfAbsent*/);
+   parent->parameters()->ioParamString(ioFlag, name, "maskLayerName", &maskLayerName, NULL, false/*warnIfAbsent*/);
 }
 
 int AbstractNormProbe::communicateInitInfo() {

--- a/src/probes/AdaptiveTimeScaleProbe.cpp
+++ b/src/probes/AdaptiveTimeScaleProbe.cpp
@@ -39,15 +39,15 @@ int AdaptiveTimeScaleProbe::ioParamsFillGroup(enum ParamsIOFlag ioFlag) {
 }
 
 void AdaptiveTimeScaleProbe::ioParam_targetName(enum ParamsIOFlag ioFlag) {
-   parent->ioParamStringRequired(ioFlag, name, "targetName", &targetName);
+   parent->parameters()->ioParamStringRequired(ioFlag, name, "targetName", &targetName);
 }
 
 void AdaptiveTimeScaleProbe::ioParam_baseMax(enum ParamsIOFlag ioFlag) {
-   parent->ioParamValue(ioFlag, name, "baseMax", &mBaseMax, mBaseMax);
+   parent->parameters()->ioParamValue(ioFlag, name, "baseMax", &mBaseMax, mBaseMax);
 }
 
 void AdaptiveTimeScaleProbe::ioParam_baseMin(enum ParamsIOFlag ioFlag) {
-   parent->ioParamValue(ioFlag, name, "baseMin", &mBaseMin, mBaseMin);
+   parent->parameters()->ioParamValue(ioFlag, name, "baseMin", &mBaseMin, mBaseMin);
 }
 
 void AdaptiveTimeScaleProbe::ioParam_dtMinToleratedTimeScale(enum ParamsIOFlag ioFlag) {
@@ -61,21 +61,21 @@ void AdaptiveTimeScaleProbe::ioParam_dtMinToleratedTimeScale(enum ParamsIOFlag i
 }
 
 void AdaptiveTimeScaleProbe::ioParam_tauFactor(enum ParamsIOFlag ioFlag) {
-   parent->ioParamValue(ioFlag, name, "tauFactor", &tauFactor, tauFactor);
+   parent->parameters()->ioParamValue(ioFlag, name, "tauFactor", &tauFactor, tauFactor);
 }
 
 void AdaptiveTimeScaleProbe::ioParam_growthFactor(enum ParamsIOFlag ioFlag) {
-   parent->ioParamValue(ioFlag, name, "growthFactor", &mGrowthFactor, mGrowthFactor);
+   parent->parameters()->ioParamValue(ioFlag, name, "growthFactor", &mGrowthFactor, mGrowthFactor);
 }
 
 void AdaptiveTimeScaleProbe::ioParam_writeTimeScales(enum ParamsIOFlag ioFlag) {
-   parent->ioParamValue(ioFlag, name, "writeTimeScales", &mWriteTimeScales, mWriteTimeScales);
+   parent->parameters()->ioParamValue(ioFlag, name, "writeTimeScales", &mWriteTimeScales, mWriteTimeScales);
 }
 
 void AdaptiveTimeScaleProbe::ioParam_writeTimeScaleFieldnames(enum ParamsIOFlag ioFlag) {
    pvAssert(!parent->parameters()->presentAndNotBeenRead(name, "writeTimeScales"));
    if (mWriteTimeScales) {
-     parent->ioParamValue(ioFlag, name, "writeTimeScaleFieldnames", &mWriteTimeScaleFieldnames, mWriteTimeScaleFieldnames);
+     parent->parameters()->ioParamValue(ioFlag, name, "writeTimeScaleFieldnames", &mWriteTimeScaleFieldnames, mWriteTimeScaleFieldnames);
    }
 }
 

--- a/src/probes/BaseConnectionProbe.cpp
+++ b/src/probes/BaseConnectionProbe.cpp
@@ -33,7 +33,7 @@ int BaseConnectionProbe::initialize(const char * probeName, HyPerCol * hc) {
 }
 
 void BaseConnectionProbe::ioParam_targetName(enum ParamsIOFlag ioFlag) {
-   parent->ioParamString(ioFlag, name, "targetConnection", &targetName, NULL, false);
+   parent->parameters()->ioParamString(ioFlag, name, "targetConnection", &targetName, NULL, false);
    if(targetName == NULL){
       BaseProbe::ioParam_targetName(ioFlag);
    }

--- a/src/probes/BaseProbe.cpp
+++ b/src/probes/BaseProbe.cpp
@@ -90,40 +90,40 @@ int BaseProbe::ioParamsFillGroup(enum ParamsIOFlag ioFlag) {
 }
 
 void BaseProbe::ioParam_targetName(enum ParamsIOFlag ioFlag) {
-   parent->ioParamStringRequired(ioFlag, name, "targetName", &targetName);
+   parent->parameters()->ioParamStringRequired(ioFlag, name, "targetName", &targetName);
 }
 
 void BaseProbe::ioParam_message(enum ParamsIOFlag ioFlag) {
-   parent->ioParamString(ioFlag, name, "message", &msgparams, NULL, false/*warnIfAbsent*/);
+   parent->parameters()->ioParamString(ioFlag, name, "message", &msgparams, NULL, false/*warnIfAbsent*/);
    if (ioFlag == PARAMS_IO_READ) {
       initMessage(msgparams);
    }
 }
 
 void BaseProbe::ioParam_energyProbe(enum ParamsIOFlag ioFlag) {
-   parent->ioParamString(ioFlag, name, "energyProbe", &energyProbe, NULL, false/*warnIfAbsent*/);
+   parent->parameters()->ioParamString(ioFlag, name, "energyProbe", &energyProbe, NULL, false/*warnIfAbsent*/);
 }
 
 void BaseProbe::ioParam_coefficient(enum ParamsIOFlag ioFlag) {
    assert(!parent->parameters()->presentAndNotBeenRead(name, "energyProbe"));
    if (energyProbe && energyProbe[0]) {
-      parent->ioParamValue(ioFlag, name, "coefficient", &coefficient, coefficient, true/*warnIfAbsent*/);
+      parent->parameters()->ioParamValue(ioFlag, name, "coefficient", &coefficient, coefficient, true/*warnIfAbsent*/);
    }
 }
 
 void BaseProbe::ioParam_textOutputFlag(enum ParamsIOFlag ioFlag) {
-   parent->ioParamValue(ioFlag, name, "textOutputFlag", &textOutputFlag, textOutputFlag);
+   parent->parameters()->ioParamValue(ioFlag, name, "textOutputFlag", &textOutputFlag, textOutputFlag);
 }
 
 void BaseProbe::ioParam_probeOutputFile(enum ParamsIOFlag ioFlag) {
    assert(!parent->parameters()->presentAndNotBeenRead(name, "textOutputFlag"));
    if (textOutputFlag) {
-      parent->ioParamString(ioFlag, name, "probeOutputFile", &probeOutputFilename, NULL, false/*warnIfAbsent*/);
+      parent->parameters()->ioParamString(ioFlag, name, "probeOutputFile", &probeOutputFilename, NULL, false/*warnIfAbsent*/);
    }
 }
 
 void BaseProbe::ioParam_triggerLayerName(enum ParamsIOFlag ioFlag) {
-   parent->ioParamString(ioFlag, name, "triggerLayerName", &triggerLayerName, NULL, false/*warnIfAbsent*/);
+   parent->parameters()->ioParamString(ioFlag, name, "triggerLayerName", &triggerLayerName, NULL, false/*warnIfAbsent*/);
    if (ioFlag==PARAMS_IO_READ) {
       triggerFlag = (triggerLayerName!=NULL && triggerLayerName[0]!='\0');
    }
@@ -138,7 +138,7 @@ void BaseProbe::ioParam_triggerFlag(enum ParamsIOFlag ioFlag) {
    assert(!parent->parameters()->presentAndNotBeenRead(name, "triggerLayerName"));
    if (ioFlag == PARAMS_IO_READ && parent->parameters()->present(name, "triggerFlag")) {
       bool flagFromParams = false;
-      parent->ioParamValue(ioFlag, name, "triggerFlag", &flagFromParams, flagFromParams);
+      parent->parameters()->ioParamValue(ioFlag, name, "triggerFlag", &flagFromParams, flagFromParams);
       if (parent->columnId()==0) {
          pvWarn(triggerFlagDeprecated);
          triggerFlagDeprecated.printf("%s: triggerFlag has been deprecated.\n", getDescription_c());
@@ -159,7 +159,7 @@ void BaseProbe::ioParam_triggerFlag(enum ParamsIOFlag ioFlag) {
 void BaseProbe::ioParam_triggerOffset(enum ParamsIOFlag ioFlag) {
    assert(!parent->parameters()->presentAndNotBeenRead(name, "triggerFlag"));
    if (triggerFlag) {
-      parent->ioParamValue(ioFlag, name, "triggerOffset", &triggerOffset, triggerOffset);
+      parent->parameters()->ioParamValue(ioFlag, name, "triggerOffset", &triggerOffset, triggerOffset);
       if(triggerOffset < 0){
          pvError().printf("%s \"%s\" error in rank %d process: TriggerOffset (%f) must be positive\n", parent->parameters()->groupKeywordFromName(name), name, parent->columnId(), triggerOffset);
       }

--- a/src/probes/FirmThresholdCostFnProbe.cpp
+++ b/src/probes/FirmThresholdCostFnProbe.cpp
@@ -42,11 +42,11 @@ int FirmThresholdCostFnProbe::ioParamsFillGroup(enum ParamsIOFlag ioFlag) {
 }
 
 void FirmThresholdCostFnProbe::ioParam_VThresh(enum ParamsIOFlag ioFlag) {
-   getParent()->ioParamValue(ioFlag, name, "VThresh", &VThresh, VThresh/*default*/, false/*warnIfAbsent*/);
+   getParent()->parameters()->ioParamValue(ioFlag, name, "VThresh", &VThresh, VThresh/*default*/, false/*warnIfAbsent*/);
 }
 
 void FirmThresholdCostFnProbe::ioParam_VWidth(enum ParamsIOFlag ioFlag) {
-   parent->ioParamValue(ioFlag, name, "VWidth", &VWidth, VWidth/*default*/, false/*warnIfAbsent*/);
+   parent->parameters()->ioParamValue(ioFlag, name, "VWidth", &VWidth, VWidth/*default*/, false/*warnIfAbsent*/);
 }
 
 int FirmThresholdCostFnProbe::setNormDescription() {
@@ -66,8 +66,8 @@ int FirmThresholdCostFnProbe::communicateInitInfo() {
    }
    else {
       // Reread VThresh and VWidth commands, this time warning if they are not absent.
-      parent->ioParamValue(PARAMS_IO_READ, name, "VThresh", &VThresh, VThresh/*default*/, true/*warnIfAbsent*/);
-      parent->ioParamValue(PARAMS_IO_READ, name, "VThresh", &VThresh, VThresh/*default*/, true/*warnIfAbsent*/);
+      parent->parameters()->ioParamValue(PARAMS_IO_READ, name, "VThresh", &VThresh, VThresh/*default*/, true/*warnIfAbsent*/);
+      parent->parameters()->ioParamValue(PARAMS_IO_READ, name, "VThresh", &VThresh, VThresh/*default*/, true/*warnIfAbsent*/);
    }
    return PV_SUCCESS;
 }

--- a/src/probes/KernelProbe.cpp
+++ b/src/probes/KernelProbe.cpp
@@ -44,23 +44,23 @@ int KernelProbe::ioParamsFillGroup(enum ParamsIOFlag ioFlag) {
 }
 
 void KernelProbe::ioParam_kernelIndex(enum ParamsIOFlag ioFlag) {
-   parent->ioParamValue(ioFlag, name, "kernelIndex", &kernelIndex, 0);
+   parent->parameters()->ioParamValue(ioFlag, name, "kernelIndex", &kernelIndex, 0);
 }
 
 void KernelProbe::ioParam_arborId(enum ParamsIOFlag ioFlag) {
-   parent->ioParamValue(ioFlag, name, "arborId", &arborID, 0);
+   parent->parameters()->ioParamValue(ioFlag, name, "arborId", &arborID, 0);
 }
 
 void KernelProbe::ioParam_outputWeights(enum ParamsIOFlag ioFlag) {
-   parent->ioParamValue(ioFlag, name, "outputWeights", &outputWeights, true/*default value*/);
+   parent->parameters()->ioParamValue(ioFlag, name, "outputWeights", &outputWeights, true/*default value*/);
 }
 
 void KernelProbe::ioParam_outputPlasticIncr(enum ParamsIOFlag ioFlag) {
-   parent->ioParamValue(ioFlag, name, "outputPlasticIncr", &outputPlasticIncr, false/*default value*/);
+   parent->parameters()->ioParamValue(ioFlag, name, "outputPlasticIncr", &outputPlasticIncr, false/*default value*/);
 }
 
 void KernelProbe::ioParam_outputPatchIndices(enum ParamsIOFlag ioFlag) {
-   parent->ioParamValue(ioFlag, name, "outputPatchIndices", &outputPatchIndices, false/*default value*/);
+   parent->parameters()->ioParamValue(ioFlag, name, "outputPatchIndices", &outputPatchIndices, false/*default value*/);
 }
 
 int KernelProbe::initNumValues() {

--- a/src/probes/L0NormProbe.cpp
+++ b/src/probes/L0NormProbe.cpp
@@ -34,7 +34,7 @@ int L0NormProbe::ioParamsFillGroup(enum ParamsIOFlag ioFlag) {
 }
 
 void L0NormProbe::ioParam_nnzThreshold(enum ParamsIOFlag ioFlag) {
-    getParent()->ioParamValue(ioFlag, getName(), "nnzThreshold", &nnzThreshold, (pvadata_t) 0);
+    getParent()->parameters()->ioParamValue(ioFlag, getName(), "nnzThreshold", &nnzThreshold, (pvadata_t) 0);
 }
 
 double L0NormProbe::getValueInternal(double timevalue, int index) {

--- a/src/probes/L2NormProbe.cpp
+++ b/src/probes/L2NormProbe.cpp
@@ -39,7 +39,7 @@ int L2NormProbe::ioParamsFillGroup(enum ParamsIOFlag ioFlag) {
 }
 
 void L2NormProbe::ioParam_exponent(enum ParamsIOFlag ioFlag) {
-   parent->ioParamValue(ioFlag, name, "exponent", &exponent, 1.0/*default*/, true/*warnIfAbsent*/);
+   parent->parameters()->ioParamValue(ioFlag, name, "exponent", &exponent, 1.0/*default*/, true/*warnIfAbsent*/);
 }
 
 int L2NormProbe::setNormDescription() {

--- a/src/probes/LayerProbe.cpp
+++ b/src/probes/LayerProbe.cpp
@@ -46,7 +46,7 @@ int LayerProbe::initialize(const char * probeName, HyPerCol * hc)
 
 void LayerProbe::ioParam_targetName(enum ParamsIOFlag ioFlag) {
    //targetLayer is a legacy parameter, so here, it's not required
-   parent->ioParamString(ioFlag, name, "targetLayer", &targetName, NULL/*default*/, false/*warnIfAbsent*/);
+   parent->parameters()->ioParamString(ioFlag, name, "targetLayer", &targetName, NULL/*default*/, false/*warnIfAbsent*/);
    //But if it isn't defined, targetName must be, which BaseProbe checks for
    if(targetName == NULL){
       BaseProbe::ioParam_targetName(ioFlag);

--- a/src/probes/PointLIFProbe.cpp
+++ b/src/probes/PointLIFProbe.cpp
@@ -52,7 +52,7 @@ int PointLIFProbe::ioParamsFillGroup(enum ParamsIOFlag ioFlag) {
 
 void PointLIFProbe::ioParam_writeStep(enum ParamsIOFlag ioFlag) {
    writeStep = getParent()->getDeltaTime();  // Marian, don't change this default behavior
-   getParent()->ioParamValue(ioFlag, getName(), "writeStep", &writeStep, writeStep, true/*warnIfAbsent*/);
+   getParent()->parameters()->ioParamValue(ioFlag, getName(), "writeStep", &writeStep, writeStep, true/*warnIfAbsent*/);
 }
 
 int PointLIFProbe::initNumValues() {

--- a/src/probes/PointProbe.cpp
+++ b/src/probes/PointProbe.cpp
@@ -54,19 +54,19 @@ int PointProbe::ioParamsFillGroup(enum ParamsIOFlag ioFlag) {
 }
 
 void PointProbe::ioParam_xLoc(enum ParamsIOFlag ioFlag) {
-   getParent()->ioParamValueRequired(ioFlag, getName(), "xLoc", &xLoc);
+   getParent()->parameters()->ioParamValueRequired(ioFlag, getName(), "xLoc", &xLoc);
 }
 
 void PointProbe::ioParam_yLoc(enum ParamsIOFlag ioFlag) {
-   getParent()->ioParamValueRequired(ioFlag, getName(), "yLoc", &yLoc);
+   getParent()->parameters()->ioParamValueRequired(ioFlag, getName(), "yLoc", &yLoc);
 }
 
 void PointProbe::ioParam_fLoc(enum ParamsIOFlag ioFlag) {
-   getParent()->ioParamValueRequired(ioFlag, getName(), "fLoc", &fLoc);
+   getParent()->parameters()->ioParamValueRequired(ioFlag, getName(), "fLoc", &fLoc);
 }
 
 void PointProbe::ioParam_batchLoc(enum ParamsIOFlag ioFlag) {
-   getParent()->ioParamValueRequired(ioFlag, getName(), "batchLoc", &batchLoc);
+   getParent()->parameters()->ioParamValueRequired(ioFlag, getName(), "batchLoc", &batchLoc);
 }
 
 int PointProbe::initNumValues() {

--- a/src/probes/QuotientColProbe.cpp
+++ b/src/probes/QuotientColProbe.cpp
@@ -58,15 +58,15 @@ int QuotientColProbe::ioParamsFillGroup(enum ParamsIOFlag ioFlag) {
 }
 
 void QuotientColProbe::ioParam_valueDescription(enum ParamsIOFlag ioFlag) {
-   parent->ioParamString(ioFlag, name, "valueDescription", &valueDescription, "value", true/*warnIfAbsent*/);
+   parent->parameters()->ioParamString(ioFlag, name, "valueDescription", &valueDescription, "value", true/*warnIfAbsent*/);
 }
 
 void QuotientColProbe::ioParam_numerator(enum ParamsIOFlag ioFlag) {
-   parent->ioParamStringRequired(ioFlag, name, "numerator", &numerator);
+   parent->parameters()->ioParamStringRequired(ioFlag, name, "numerator", &numerator);
 }
 
 void QuotientColProbe::ioParam_denominator(enum ParamsIOFlag ioFlag) {
-   parent->ioParamStringRequired(ioFlag, name, "denominator", &denominator);
+   parent->parameters()->ioParamStringRequired(ioFlag, name, "denominator", &denominator);
 }
 
 int QuotientColProbe::communicateInitInfo() {

--- a/src/probes/RequireAllZeroActivityProbe.cpp
+++ b/src/probes/RequireAllZeroActivityProbe.cpp
@@ -39,13 +39,13 @@ void RequireAllZeroActivityProbe::ioParam_buffer(enum ParamsIOFlag ioFlag) {
 }
 
 void RequireAllZeroActivityProbe::ioParam_exitOnFailure(enum ParamsIOFlag ioFlag) {
-   parent->ioParamValue(ioFlag, name, "exitOnFailure", &exitOnFailure, exitOnFailure);
+   parent->parameters()->ioParamValue(ioFlag, name, "exitOnFailure", &exitOnFailure, exitOnFailure);
 }
 
 void RequireAllZeroActivityProbe::ioParam_immediateExitOnFailure(enum ParamsIOFlag ioFlag) {
    pvAssert(!parent->parameters()->presentAndNotBeenRead(name, "exitOnFailure"));
    if (exitOnFailure) {
-      parent->ioParamValue(ioFlag, name, "immediateExitOnFailure", &immediateExitOnFailure, immediateExitOnFailure);
+      parent->parameters()->ioParamValue(ioFlag, name, "immediateExitOnFailure", &immediateExitOnFailure, immediateExitOnFailure);
    }
    else {
       immediateExitOnFailure = false;

--- a/src/probes/StatsProbe.cpp
+++ b/src/probes/StatsProbe.cpp
@@ -157,7 +157,7 @@ void StatsProbe::ioParam_buffer(enum ParamsIOFlag ioFlag) {
          buffer = strdup("Activity");
       }
    }
-   getParent()->ioParamString(ioFlag, getName(), "buffer", &buffer, "Activity", true/*warnIfAbsent*/);
+   getParent()->parameters()->ioParamString(ioFlag, getName(), "buffer", &buffer, "Activity", true/*warnIfAbsent*/);
    if (ioFlag == PARAMS_IO_READ) {
       assert(buffer);
       size_t len = strlen(buffer);
@@ -185,7 +185,7 @@ void StatsProbe::ioParam_buffer(enum ParamsIOFlag ioFlag) {
 }
 
 void StatsProbe::ioParam_nnzThreshold(enum ParamsIOFlag ioFlag) {
-    getParent()->ioParamValue(ioFlag, getName(), "nnzThreshold", &nnzThreshold, 0.0f);
+    getParent()->parameters()->ioParamValue(ioFlag, getName(), "nnzThreshold", &nnzThreshold, 0.0f);
 }
 
 int StatsProbe::initNumValues() {

--- a/src/weightinit/InitCocircWeightsParams.cpp
+++ b/src/weightinit/InitCocircWeightsParams.cpp
@@ -80,25 +80,25 @@ int InitCocircWeightsParams::ioParamsFillGroup(enum ParamsIOFlag ioFlag) {
 }
 
 void InitCocircWeightsParams::ioParam_sigmaCocirc(enum ParamsIOFlag ioFlag) {
-   parent->ioParamValue(ioFlag, name, "sigmaCocirc", &sigma_cocirc, sigma_cocirc);
+   parent->parameters()->ioParamValue(ioFlag, name, "sigmaCocirc", &sigma_cocirc, sigma_cocirc);
 }
 
 void InitCocircWeightsParams::ioParam_sigmaKurve(enum ParamsIOFlag ioFlag) {
-   parent->ioParamValue(ioFlag, name, "sigmaKurve", &sigma_kurve, sigma_kurve);
+   parent->parameters()->ioParamValue(ioFlag, name, "sigmaKurve", &sigma_kurve, sigma_kurve);
 }
 
 // void InitCocircWeightsParams::ioParam_sigmaChord(enum ParamsIOFlag ioFlag) {
-//    parent->ioParamValue(ioFlag, name, "sigmaChord", &sigma_chord, sigma_chord);
+//    parent->parameters()->ioParamValue(ioFlag, name, "sigmaChord", &sigma_chord, sigma_chord);
 // }
 
 void InitCocircWeightsParams::ioParam_cocircSelf(enum ParamsIOFlag ioFlag) {
-   parent->ioParamValue(ioFlag, name, "cocircSelf", &cocirc_self, cocirc_self);
+   parent->parameters()->ioParamValue(ioFlag, name, "cocircSelf", &cocirc_self, cocirc_self);
 }
 
 void InitCocircWeightsParams::ioParam_deltaRadiusCurvature(enum ParamsIOFlag ioFlag) {
    // from pv_common.h
    // // DK (1.0/(6*(NK-1)))   /*1/(sqrt(DX*DX+DY*DY)*(NK-1))*/         //  change in curvature
-   parent->ioParamValue(ioFlag, name, "deltaRadiusCurvature", &delta_radius_curvature, delta_radius_curvature);
+   parent->parameters()->ioParamValue(ioFlag, name, "deltaRadiusCurvature", &delta_radius_curvature, delta_radius_curvature);
 }
 
 void InitCocircWeightsParams::ioParam_numOrientationsPre(enum ParamsIOFlag ioFlag) {
@@ -115,7 +115,7 @@ void InitCocircWeightsParams::ioParam_numOrientationsPre(enum ParamsIOFlag ioFla
       MPI_Barrier(parent->getCommunicator()->communicator());
       exit(EXIT_FAILURE);
    }
-   parent->ioParamValue(ioFlag, name, paramname, &numOrientationsPre, pre->getLayerLoc()->nf);
+   parent->parameters()->ioParamValue(ioFlag, name, paramname, &numOrientationsPre, pre->getLayerLoc()->nf);
 }
 
 void InitCocircWeightsParams::ioParam_numOrientationsPost(enum ParamsIOFlag ioFlag) {
@@ -132,7 +132,7 @@ void InitCocircWeightsParams::ioParam_numOrientationsPost(enum ParamsIOFlag ioFl
       MPI_Barrier(parent->getCommunicator()->communicator());
       exit(EXIT_FAILURE);
    }
-   parent->ioParamValue(ioFlag, name, paramname, &numOrientationsPost, post->getLayerLoc()->nf);
+   parent->parameters()->ioParamValue(ioFlag, name, paramname, &numOrientationsPost, post->getLayerLoc()->nf);
 }
 
 void InitCocircWeightsParams::calcOtherParams(int patchIndex) {

--- a/src/weightinit/InitGauss2DWeightsParams.cpp
+++ b/src/weightinit/InitGauss2DWeightsParams.cpp
@@ -74,15 +74,15 @@ int InitGauss2DWeightsParams::ioParamsFillGroup(enum ParamsIOFlag ioFlag) {
 }
 
 void InitGauss2DWeightsParams::ioParam_aspect(enum ParamsIOFlag ioFlag) {
-   parent->ioParamValue(ioFlag, name, "aspect", &aspect, aspect);
+   parent->parameters()->ioParamValue(ioFlag, name, "aspect", &aspect, aspect);
 }
 
 void InitGauss2DWeightsParams::ioParam_sigma(enum ParamsIOFlag ioFlag) {
-   parent->ioParamValue(ioFlag, name, "sigma", &sigma, sigma);
+   parent->parameters()->ioParamValue(ioFlag, name, "sigma", &sigma, sigma);
 }
 
 void InitGauss2DWeightsParams::ioParam_rMax(enum ParamsIOFlag ioFlag) {
-   parent->ioParamValue(ioFlag, name, "rMax", &rMax, rMax);
+   parent->parameters()->ioParamValue(ioFlag, name, "rMax", &rMax, rMax);
    if (ioFlag==PARAMS_IO_READ) {
       double rMaxd = (double) rMax;
       r2Max = rMaxd*rMaxd;
@@ -90,7 +90,7 @@ void InitGauss2DWeightsParams::ioParam_rMax(enum ParamsIOFlag ioFlag) {
 }
 
 void InitGauss2DWeightsParams::ioParam_rMin(enum ParamsIOFlag ioFlag) {
-   parent->ioParamValue(ioFlag, name, "rMin", &rMin, rMin);
+   parent->parameters()->ioParamValue(ioFlag, name, "rMin", &rMin, rMin);
    if (ioFlag==PARAMS_IO_READ) {
       double rMind = (double) rMin;
       r2Min = rMind*rMind;
@@ -98,49 +98,49 @@ void InitGauss2DWeightsParams::ioParam_rMin(enum ParamsIOFlag ioFlag) {
 }
 
 void InitGauss2DWeightsParams::ioParam_strength(enum ParamsIOFlag ioFlag) {
-   parent->ioParamValue(ioFlag, name, "strength", &strength, strength/*default value*/, true/*warnIfAbsent*/);
+   parent->parameters()->ioParamValue(ioFlag, name, "strength", &strength, strength/*default value*/, true/*warnIfAbsent*/);
 }
 
 void InitGauss2DWeightsParams::ioParam_numOrientationsPost(enum ParamsIOFlag ioFlag) {
    if (post->getLayerLoc()->nf > 1) {
-      parent->ioParamValue(ioFlag, name, "numOrientationsPost", &numOrientationsPost, this->post->getLayerLoc()->nf);
+      parent->parameters()->ioParamValue(ioFlag, name, "numOrientationsPost", &numOrientationsPost, this->post->getLayerLoc()->nf);
    }
 }
 
 void InitGauss2DWeightsParams::ioParam_numOrientationsPre(enum ParamsIOFlag ioFlag) {
    if (pre->getLayerLoc()->nf > 1) {
-      parent->ioParamValue(ioFlag, name, "numOrientationsPre", &numOrientationsPre, this->pre->getLayerLoc()->nf);
+      parent->parameters()->ioParamValue(ioFlag, name, "numOrientationsPre", &numOrientationsPre, this->pre->getLayerLoc()->nf);
    }
 }
 
 void InitGauss2DWeightsParams::ioParam_deltaThetaMax(enum ParamsIOFlag ioFlag) {
-   parent->ioParamValue(ioFlag, name, "deltaThetaMax", &deltaThetaMax, getDeltaThetaMax());
+   parent->parameters()->ioParamValue(ioFlag, name, "deltaThetaMax", &deltaThetaMax, getDeltaThetaMax());
 }
 
 void InitGauss2DWeightsParams::ioParam_thetaMax(enum ParamsIOFlag ioFlag) {
-   parent->ioParamValue(ioFlag, name, "thetaMax", &thetaMax, getThetaMax());
+   parent->parameters()->ioParamValue(ioFlag, name, "thetaMax", &thetaMax, getThetaMax());
 }
 
 void InitGauss2DWeightsParams::ioParam_numFlanks(enum ParamsIOFlag ioFlag) {
-   parent->ioParamValue(ioFlag, name, "numFlanks", &numFlanks, numFlanks);
+   parent->parameters()->ioParamValue(ioFlag, name, "numFlanks", &numFlanks, numFlanks);
 }
 
 void InitGauss2DWeightsParams::ioParam_flankShift(enum ParamsIOFlag ioFlag) {
-   parent->ioParamValue(ioFlag, name, "flankShift", &shift, shift);
+   parent->parameters()->ioParamValue(ioFlag, name, "flankShift", &shift, shift);
 }
 
 void InitGauss2DWeightsParams::ioParam_rotate(enum ParamsIOFlag ioFlag) {
-   parent->ioParamValue(ioFlag, name, "rotate", &rotate, rotate);
+   parent->parameters()->ioParamValue(ioFlag, name, "rotate", &rotate, rotate);
 }
 
 void InitGauss2DWeightsParams::ioParam_bowtieFlag(enum ParamsIOFlag ioFlag) {
-   parent->ioParamValue(ioFlag, name, "bowtieFlag", &bowtieFlag, bowtieFlag);
+   parent->parameters()->ioParamValue(ioFlag, name, "bowtieFlag", &bowtieFlag, bowtieFlag);
 }
 
 void InitGauss2DWeightsParams::ioParam_bowtieAngle(enum ParamsIOFlag ioFlag) {
    assert(!parent->parameters()->presentAndNotBeenRead(name, "bowtieFlag"));
    if (bowtieFlag) {
-      parent->ioParamValue(ioFlag, name, "bowtieAngle", &bowtieAngle, bowtieAngle);
+      parent->parameters()->ioParamValue(ioFlag, name, "bowtieAngle", &bowtieAngle, bowtieAngle);
    }
 }
 

--- a/src/weightinit/InitGaussianRandomWeightsParams.cpp
+++ b/src/weightinit/InitGaussianRandomWeightsParams.cpp
@@ -43,11 +43,11 @@ int InitGaussianRandomWeightsParams::ioParamsFillGroup(enum ParamsIOFlag ioFlag)
 }
 
 void InitGaussianRandomWeightsParams::ioParam_wGaussMean(enum ParamsIOFlag ioFlag) {
-   parent->ioParamValue(ioFlag, name, "wGaussMean", &wGaussMean, wGaussMean);
+   parent->parameters()->ioParamValue(ioFlag, name, "wGaussMean", &wGaussMean, wGaussMean);
 }
 
 void InitGaussianRandomWeightsParams::ioParam_wGaussStdev(enum ParamsIOFlag ioFlag) {
-   parent->ioParamValue(ioFlag, name, "wGaussStdev", &wGaussStdev, wGaussStdev);
+   parent->parameters()->ioParamValue(ioFlag, name, "wGaussStdev", &wGaussStdev, wGaussStdev);
 }
 
 } /* namespace PV */

--- a/src/weightinit/InitOneToOneWeightsParams.cpp
+++ b/src/weightinit/InitOneToOneWeightsParams.cpp
@@ -40,7 +40,7 @@ int InitOneToOneWeightsParams::ioParamsFillGroup(enum ParamsIOFlag ioFlag) {
 }
 
 void InitOneToOneWeightsParams::ioParam_weightInit(enum ParamsIOFlag ioFlag) {
-   parent->ioParamValue(ioFlag, getName(), "weightInit", &initWeight, initWeight);
+   parent->parameters()->ioParamValue(ioFlag, getName(), "weightInit", &initWeight, initWeight);
 }
 
 void InitOneToOneWeightsParams::calcOtherParams(int patchIndex) {

--- a/src/weightinit/InitOneToOneWeightsWithDelaysParams.cpp
+++ b/src/weightinit/InitOneToOneWeightsWithDelaysParams.cpp
@@ -40,7 +40,7 @@ int InitOneToOneWeightsWithDelaysParams::ioParamsFillGroup(enum ParamsIOFlag ioF
 }
 
 void InitOneToOneWeightsWithDelaysParams::ioParam_weightInit(enum ParamsIOFlag ioFlag) {
-   parent->ioParamValue(ioFlag, getName(), "weightInit", &initWeight, initWeight);
+   parent->parameters()->ioParamValue(ioFlag, getName(), "weightInit", &initWeight, initWeight);
 }
 
 void InitOneToOneWeightsWithDelaysParams::calcOtherParams(int patchIndex) {

--- a/src/weightinit/InitSpreadOverArborsWeightsParams.cpp
+++ b/src/weightinit/InitSpreadOverArborsWeightsParams.cpp
@@ -44,7 +44,7 @@ int InitSpreadOverArborsWeightsParams::ioParamsFillGroup(enum ParamsIOFlag ioFla
 }
 
 void InitSpreadOverArborsWeightsParams::ioParam_weightInit(enum ParamsIOFlag ioFlag) {
-   parent->ioParamValue(ioFlag, name, "weightInit", &initWeight, initWeight);
+   parent->parameters()->ioParamValue(ioFlag, name, "weightInit", &initWeight, initWeight);
 }
 
 void InitSpreadOverArborsWeightsParams::calcOtherParams(int patchIndex) {

--- a/src/weightinit/InitUniformRandomWeightsParams.cpp
+++ b/src/weightinit/InitUniformRandomWeightsParams.cpp
@@ -45,15 +45,15 @@ int InitUniformRandomWeightsParams::ioParamsFillGroup(enum ParamsIOFlag ioFlag) 
 }
 
 void InitUniformRandomWeightsParams::ioParam_wMinInit(enum ParamsIOFlag ioFlag) {
-   parent->ioParamValue(ioFlag, name, "wMinInit", &wMin, wMin);
+   parent->parameters()->ioParamValue(ioFlag, name, "wMinInit", &wMin, wMin);
 }
 
 void InitUniformRandomWeightsParams::ioParam_wMaxInit(enum ParamsIOFlag ioFlag) {
-   parent->ioParamValue(ioFlag, name, "wMaxInit", &wMax, wMax);
+   parent->parameters()->ioParamValue(ioFlag, name, "wMaxInit", &wMax, wMax);
 }
 
 void InitUniformRandomWeightsParams::ioParam_sparseFraction(enum ParamsIOFlag ioFlag) {
-   parent->ioParamValue(ioFlag, name, "sparseFraction", &sparseFraction, sparseFraction);
+   parent->parameters()->ioParamValue(ioFlag, name, "sparseFraction", &sparseFraction, sparseFraction);
 }
 
 

--- a/src/weightinit/InitUniformWeightsParams.cpp
+++ b/src/weightinit/InitUniformWeightsParams.cpp
@@ -43,11 +43,11 @@ int InitUniformWeightsParams::ioParamsFillGroup(enum ParamsIOFlag ioFlag) {
 }
 
 void InitUniformWeightsParams::ioParam_weightInit(enum ParamsIOFlag ioFlag) {
-   parent->ioParamValue(ioFlag, name, "weightInit", &initWeight, initWeight);
+   parent->parameters()->ioParamValue(ioFlag, name, "weightInit", &initWeight, initWeight);
 }
 
 void InitUniformWeightsParams::ioParam_connectOnlySameFeatures(enum ParamsIOFlag ioFlag) {
-   parent->ioParamValue(ioFlag, name, "connectOnlySameFeatures", &connectOnlySameFeatures, connectOnlySameFeatures);
+   parent->parameters()->ioParamValue(ioFlag, name, "connectOnlySameFeatures", &connectOnlySameFeatures, connectOnlySameFeatures);
 }
 
 

--- a/src/weightinit/InitWeights.cpp
+++ b/src/weightinit/InitWeights.cpp
@@ -62,7 +62,7 @@ int InitWeights::setDescription() {
 
 int InitWeights::ioParamsFillGroup(enum ParamsIOFlag ioFlag) {
    // Read/write any params from the params file, typically
-   // parent->ioParamValue(ioFlag, name, "param_name", &param, default_value);
+   // parent->parameters()->ioParamValue(ioFlag, name, "param_name", &param, default_value);
 
    if (ioFlag==PARAMS_IO_READ) {
       weightParams = createNewWeightParams();

--- a/src/weightinit/InitWeightsParams.cpp
+++ b/src/weightinit/InitWeightsParams.cpp
@@ -92,7 +92,7 @@ int InitWeightsParams::initialize(char const * name, HyPerCol * hc) {
 
 int InitWeightsParams::ioParamsFillGroup(enum ParamsIOFlag ioFlag) {
    // Read/write any params from the params file, typically
-   // parent->ioParamValue(ioFlag, name, "param_name", &param, default_value);
+   // parent->parameters()->ioParamValue(ioFlag, name, "param_name", &param, default_value);
    parentConn = dynamic_cast<HyPerConn *>(parent->getConnFromName(name));
    ioParam_initWeightsFile(ioFlag);
    ioParam_useListOfArborFiles(ioFlag);
@@ -102,20 +102,20 @@ int InitWeightsParams::ioParamsFillGroup(enum ParamsIOFlag ioFlag) {
 }
 
 void InitWeightsParams::ioParam_initWeightsFile(enum ParamsIOFlag ioFlag) {
-   parent->ioParamString(ioFlag, name, "initWeightsFile", &filename, NULL, false/*warnIfAbsent*/);
+   parent->parameters()->ioParamString(ioFlag, name, "initWeightsFile", &filename, NULL, false/*warnIfAbsent*/);
 }
 
 void InitWeightsParams::ioParam_useListOfArborFiles(enum ParamsIOFlag ioFlag) {
    assert(!parent->parameters()->presentAndNotBeenRead(name, "initWeightsFile"));
    if (filename!=NULL) {
-      parent->ioParamValue(ioFlag, name, "useListOfArborFiles", &useListOfArborFiles, false/*default*/, true/*warnIfAbsent*/);
+      parent->parameters()->ioParamValue(ioFlag, name, "useListOfArborFiles", &useListOfArborFiles, false/*default*/, true/*warnIfAbsent*/);
    }
 }
 
 void InitWeightsParams::ioParam_combineWeightFiles(enum ParamsIOFlag ioFlag) {
    assert(!parent->parameters()->presentAndNotBeenRead(name, "initWeightsFile"));
    if (filename!=NULL) {
-      parent->ioParamValue(ioFlag, name, "combineWeightFiles", &combineWeightFiles, false/*default*/, true/*warnIfAbsent*/);
+      parent->parameters()->ioParamValue(ioFlag, name, "combineWeightFiles", &combineWeightFiles, false/*default*/, true/*warnIfAbsent*/);
    }
 }
 
@@ -125,7 +125,7 @@ void InitWeightsParams::ioParam_numWeightFiles(enum ParamsIOFlag ioFlag) {
       assert(!parent->parameters()->presentAndNotBeenRead(name, "combineWeightFiles"));
       if (combineWeightFiles) {
          int max_weight_files = 1;  // arbitrary limit...
-         parent->ioParamValue(ioFlag, name, "numWeightFiles", &numWeightFiles, max_weight_files, true/*warnIfAbsent*/);
+         parent->parameters()->ioParamValue(ioFlag, name, "numWeightFiles", &numWeightFiles, max_weight_files, true/*warnIfAbsent*/);
       }
    }
 }

--- a/tests/BatchSweepTest/src/BatchSweepTestProbe.cpp
+++ b/tests/BatchSweepTest/src/BatchSweepTestProbe.cpp
@@ -34,14 +34,14 @@ void BatchSweepTestProbe::ioParam_buffer(enum ParamsIOFlag ioFlag) {
 }
 
 void BatchSweepTestProbe::ioParam_expectedSum(enum ParamsIOFlag ioFlag) {
-   getParent()->ioParamValue(ioFlag, getName(), "expectedSum", &expectedSum, 0.0);
+   getParent()->parameters()->ioParamValue(ioFlag, getName(), "expectedSum", &expectedSum, 0.0);
 }
 void BatchSweepTestProbe::ioParam_expectedMin(enum ParamsIOFlag ioFlag) {
-   getParent()->ioParamValue(ioFlag, getName(), "expectedMin", &expectedMin, 0.0f);
+   getParent()->parameters()->ioParamValue(ioFlag, getName(), "expectedMin", &expectedMin, 0.0f);
 }
 
 void BatchSweepTestProbe::ioParam_expectedMax(enum ParamsIOFlag ioFlag) {
-   getParent()->ioParamValue(ioFlag, getName(), "expectedMax", &expectedMax, 0.0f);
+   getParent()->parameters()->ioParamValue(ioFlag, getName(), "expectedMax", &expectedMax, 0.0f);
 }
 
 int BatchSweepTestProbe::outputState(double timed) {

--- a/tests/GroupNormalizationTest/src/AllConstantValueProbe.cpp
+++ b/tests/GroupNormalizationTest/src/AllConstantValueProbe.cpp
@@ -32,7 +32,7 @@ int AllConstantValueProbe::ioParamsFillGroup(enum ParamsIOFlag ioFlag) {
 }
 
 void AllConstantValueProbe::ioParam_correctValue(enum ParamsIOFlag ioFlag) {
-   getParent()->ioParamValue(ioFlag, getName(), "correctValue", &correctValue, correctValue/*default*/);
+   getParent()->parameters()->ioParamValue(ioFlag, getName(), "correctValue", &correctValue, correctValue/*default*/);
 }
 
 int AllConstantValueProbe::outputState(double timed) {

--- a/tests/InitWeightsTest/src/HyPerConnDebugInitWeights.cpp
+++ b/tests/InitWeightsTest/src/HyPerConnDebugInitWeights.cpp
@@ -46,7 +46,7 @@ void HyPerConnDebugInitWeights::ioParam_channelCode(enum ParamsIOFlag ioFlag) {
 }
 
 void HyPerConnDebugInitWeights::ioParam_copiedConn(enum ParamsIOFlag ioFlag) {
-   parent->ioParamStringRequired(ioFlag, name, "copiedConn", &otherConnName);
+   parent->parameters()->ioParamStringRequired(ioFlag, name, "copiedConn", &otherConnName);
 }
 
 int HyPerConnDebugInitWeights::initialize_base() {

--- a/tests/InitWeightsTest/src/InitGaborWeightsParams.cpp
+++ b/tests/InitWeightsTest/src/InitGaborWeightsParams.cpp
@@ -58,15 +58,15 @@ int InitGaborWeightsParams::ioParamsFillGroup(enum ParamsIOFlag ioFlag) {
 }
 
 void InitGaborWeightsParams::ioParam_lambda(enum ParamsIOFlag ioFlag) {
-   parent->ioParamValue(ioFlag, name, "lambda", &lambda, lambda);
+   parent->parameters()->ioParamValue(ioFlag, name, "lambda", &lambda, lambda);
 }
 
 void InitGaborWeightsParams::ioParam_phi(enum ParamsIOFlag ioFlag) {
-   parent->ioParamValue(ioFlag, name, "phi", &phi, phi);
+   parent->parameters()->ioParamValue(ioFlag, name, "phi", &phi, phi);
 }
 
 void InitGaborWeightsParams::ioParam_invert(enum ParamsIOFlag ioFlag) {
-   parent->ioParamValue(ioFlag, name, "invert", &invert, invert);
+   parent->parameters()->ioParamValue(ioFlag, name, "invert", &invert, invert);
 }
 
 void InitGaborWeightsParams::calcOtherParams(int patchIndex) {

--- a/tests/InitWeightsTest/src/KernelConnDebugInitWeights.cpp
+++ b/tests/InitWeightsTest/src/KernelConnDebugInitWeights.cpp
@@ -59,7 +59,7 @@ void KernelConnDebugInitWeights::ioParam_sharedWeights(enum ParamsIOFlag ioFlag)
 }
 
 void KernelConnDebugInitWeights::ioParam_copiedConn(enum ParamsIOFlag ioFlag) {
-   parent->ioParamStringRequired(ioFlag, name, "copiedConn", &otherConnName);
+   parent->parameters()->ioParamStringRequired(ioFlag, name, "copiedConn", &otherConnName);
 }
 
 int KernelConnDebugInitWeights::communicateInitInfo() {

--- a/tests/LIFTest/src/LIFTestProbe.cpp
+++ b/tests/LIFTest/src/LIFTestProbe.cpp
@@ -72,11 +72,11 @@ int LIFTestProbe::ioParamsFillGroup(enum ParamsIOFlag ioFlag) {
 }
 
 void LIFTestProbe::ioParam_endingTime(enum ParamsIOFlag ioFlag) {
-   getParent()->ioParamValue(ioFlag, getName(), "endingTime", &endingTime, LIFTESTPROBE_DEFAULTENDINGTIME);
+   getParent()->parameters()->ioParamValue(ioFlag, getName(), "endingTime", &endingTime, LIFTESTPROBE_DEFAULTENDINGTIME);
 }
 
 void LIFTestProbe::ioParam_tolerance(enum ParamsIOFlag ioFlag) {
-   getParent()->ioParamValue(ioFlag, getName(), "tolerance", &tolerance, LIFTESTPROBE_DEFAULTTOLERANCE);
+   getParent()->parameters()->ioParamValue(ioFlag, getName(), "tolerance", &tolerance, LIFTESTPROBE_DEFAULTTOLERANCE);
 }
 
 LIFTestProbe::~LIFTestProbe() {

--- a/tests/LayerPhaseTest/src/LayerPhaseTestProbe.cpp
+++ b/tests/LayerPhaseTest/src/LayerPhaseTestProbe.cpp
@@ -34,11 +34,11 @@ void LayerPhaseTestProbe::ioParam_buffer(enum ParamsIOFlag ioFlag) {
 }
 
 void LayerPhaseTestProbe::ioParam_equilibriumValue(enum ParamsIOFlag ioFlag) {
-   getParent()->ioParamValue(ioFlag, getName(), "equilibriumValue", &equilibriumValue, 0.0f, true);
+   getParent()->parameters()->ioParamValue(ioFlag, getName(), "equilibriumValue", &equilibriumValue, 0.0f, true);
 }
 
 void LayerPhaseTestProbe::ioParam_equilibriumTime(enum ParamsIOFlag ioFlag) {
-   getParent()->ioParamValue(ioFlag, getName(), "equilibriumTime", &equilibriumTime, 0.0, true);
+   getParent()->parameters()->ioParamValue(ioFlag, getName(), "equilibriumTime", &equilibriumTime, 0.0, true);
 }
 
 int LayerPhaseTestProbe::outputState(double timed)

--- a/tests/MaskLayerTest/src/MaskTestLayer.cpp
+++ b/tests/MaskLayerTest/src/MaskTestLayer.cpp
@@ -19,7 +19,7 @@ int MaskTestLayer::ioParamsFillGroup(enum ParamsIOFlag ioFlag) {
 }
 
 void MaskTestLayer::ioParam_maskMethod(enum ParamsIOFlag ioFlag) {
-   parent->ioParamStringRequired(ioFlag, name, "maskMethod", &maskMethod);
+   parent->parameters()->ioParamStringRequired(ioFlag, name, "maskMethod", &maskMethod);
    //Check valid methods
    if(strcmp(maskMethod, "layer") == 0){
    }

--- a/tests/MomentumTest/src/MomentumConnTestProbe.cpp
+++ b/tests/MomentumTest/src/MomentumConnTestProbe.cpp
@@ -33,7 +33,7 @@ int MomentumConnTestProbe::ioParamsFillGroup(enum ParamsIOFlag ioFlag) {
 }
 
 void MomentumConnTestProbe::ioParam_isViscosity(enum ParamsIOFlag ioFlag) {
-   parent->ioParamValue(ioFlag, name, "isViscosity", &isViscosity, 0 /*default value*/);
+   parent->parameters()->ioParamValue(ioFlag, name, "isViscosity", &isViscosity, 0 /*default value*/);
 }
 
 /**

--- a/tests/NormalizeSubclassSystemTest/src/NormalizeL3.cpp
+++ b/tests/NormalizeSubclassSystemTest/src/NormalizeL3.cpp
@@ -32,7 +32,7 @@ int NormalizeL3::ioParamsFillGroup(enum ParamsIOFlag ioFlag) {
 }
 
 void NormalizeL3::ioParam_minL3NormTolerated(enum ParamsIOFlag ioFlag) {
-   parent->ioParamValue(ioFlag, name, "minL3NormTolerated", &minL3NormTolerated, minL3NormTolerated, true/*warnIfAbsent*/);
+   parent->parameters()->ioParamValue(ioFlag, name, "minL3NormTolerated", &minL3NormTolerated, minL3NormTolerated, true/*warnIfAbsent*/);
 }
 int NormalizeL3::normalizeWeights() {
    int status = PV_SUCCESS;

--- a/tests/ParameterSweepTest/src/ParameterSweepTestProbe.cpp
+++ b/tests/ParameterSweepTest/src/ParameterSweepTestProbe.cpp
@@ -34,14 +34,14 @@ void ParameterSweepTestProbe::ioParam_buffer(enum ParamsIOFlag ioFlag) {
 }
 
 void ParameterSweepTestProbe::ioParam_expectedSum(enum ParamsIOFlag ioFlag) {
-   getParent()->ioParamValue(ioFlag, getName(), "expectedSum", &expectedSum, 0.0);
+   getParent()->parameters()->ioParamValue(ioFlag, getName(), "expectedSum", &expectedSum, 0.0);
 }
 void ParameterSweepTestProbe::ioParam_expectedMin(enum ParamsIOFlag ioFlag) {
-   getParent()->ioParamValue(ioFlag, getName(), "expectedMin", &expectedMin, 0.0f);
+   getParent()->parameters()->ioParamValue(ioFlag, getName(), "expectedMin", &expectedMin, 0.0f);
 }
 
 void ParameterSweepTestProbe::ioParam_expectedMax(enum ParamsIOFlag ioFlag) {
-   getParent()->ioParamValue(ioFlag, getName(), "expectedMax", &expectedMax, 0.0f);
+   getParent()->parameters()->ioParamValue(ioFlag, getName(), "expectedMax", &expectedMax, 0.0f);
 }
 
 int ParameterSweepTestProbe::outputState(double timed) {

--- a/tests/ReceiveFromPostTest/src/ReceiveFromPostProbe.cpp
+++ b/tests/ReceiveFromPostTest/src/ReceiveFromPostProbe.cpp
@@ -37,7 +37,7 @@ void ReceiveFromPostProbe::ioParam_buffer(enum ParamsIOFlag ioFlag) {
 }
 
 void ReceiveFromPostProbe::ioParam_tolerance(enum ParamsIOFlag ioFlag) {
-   getParent()->ioParamValue(ioFlag, getName(), "tolerance", &tolerance, tolerance);
+   getParent()->parameters()->ioParamValue(ioFlag, getName(), "tolerance", &tolerance, tolerance);
 }
 
 int ReceiveFromPostProbe::outputState(double timed){

--- a/tests/ShrunkenPatchTest/src/ShrunkenPatchTestProbe.cpp
+++ b/tests/ShrunkenPatchTest/src/ShrunkenPatchTestProbe.cpp
@@ -46,12 +46,12 @@ void ShrunkenPatchTestProbe::ioParam_buffer(enum ParamsIOFlag ioFlag) {
 }
 
 void ShrunkenPatchTestProbe::ioParam_nxpShrunken(enum ParamsIOFlag ioFlag) {
-   getParent()->ioParamValueRequired(ioFlag, getName(), "nxpShrunken", &nxpShrunken);
+   getParent()->parameters()->ioParamValueRequired(ioFlag, getName(), "nxpShrunken", &nxpShrunken);
    return;
 }
 
 void ShrunkenPatchTestProbe::ioParam_nypShrunken(enum ParamsIOFlag ioFlag) {
-   getParent()->ioParamValueRequired(ioFlag, getName(), "nypShrunken", &nypShrunken);
+   getParent()->parameters()->ioParamValueRequired(ioFlag, getName(), "nypShrunken", &nypShrunken);
    return;
 }
 

--- a/tests/test_constant_input/src/TestImage.cpp
+++ b/tests/test_constant_input/src/TestImage.cpp
@@ -41,7 +41,7 @@ void TestImage::ioParam_InitVType(enum ParamsIOFlag ioFlag) {
 }
 
 void TestImage::ioParam_constantVal(enum ParamsIOFlag ioFlag) {
-   parent->ioParamValue(ioFlag, name, "constantVal", &val, (pvdata_t) 1);
+   parent->parameters()->ioParamValue(ioFlag, name, "constantVal", &val, (pvdata_t) 1);
 }
 
 int TestImage::allocateV() {


### PR DESCRIPTION
This pull request moves several methods related to input/output of parameters from HyPerCol to PVParams.  The rationale is that BaseObjects should not need to refer to the HyPerCol, or be aware of the details of the class that contains it.  Instead, they will receive a reference to the PVParams object directly.

The pull request also deletes blocks of code from HyPerCol that have been marked obsolete. Finally, it deletes the PVParams::outputParams method and the output methods that it calls; these methods were not being used and were redundant with writeParam and related methods.
