### PR TITLE
CheckpointEntry class hierarchy

### DIFF
--- a/demos/HeatMapLocalization/src/LocalizationProbe.cpp
+++ b/demos/HeatMapLocalization/src/LocalizationProbe.cpp
@@ -406,13 +406,13 @@ int LocalizationProbe::communicateInitInfo() {
    }
 
    // If drawing montages, create montage directory and label files.
-   // Under MPI, all process must call HyPerCol::ensureDirExists() even though
+   // Under MPI, all process must call ensureDirExists() even though
    // only the root process interacts with the filesystem.
    if (drawMontage) {
       featurefieldwidth = (int) ceilf(log10f((float) (nf+1)));
 
       // Make the heat map montage directory if it doesn't already exist
-      status = parent->ensureDirExists(heatMapMontageDir);
+      status = ensureDirExists(parent->getCommunicator(), heatMapMontageDir);
       if (status!=PV_SUCCESS) {
          pvError().printf("Error: Unable to make heat map montage directory \"%s\": %s\n", heatMapMontageDir, strerror(errno));
       }
@@ -420,9 +420,8 @@ int LocalizationProbe::communicateInitInfo() {
       // Make the labels directory in heatMapMontageDir if it doesn't already exist
       std::stringstream labelsdirss("");
       labelsdirss << heatMapMontageDir << "/labels";
-      // It seems ensureDirExists(labelsdirss.str().c_str()) should work, but it didn't
       char * labelsDir = strdup(labelsdirss.str().c_str());
-      status = parent->ensureDirExists(labelsDir);
+      status = ensureDirExists(parent->getCommunicator(), labelsDir);
       if (status!=PV_SUCCESS) {
          pvError().printf("Error: Unable to make heat map montage labels directory: %s\n", strerror(errno));
       }

--- a/src/columns/Communicator.hpp
+++ b/src/columns/Communicator.hpp
@@ -8,11 +8,11 @@
 #include <cstdio>
 #include <vector>
 #include "PV_Arguments.hpp"
-#include "../include/pv_arch.h"
-#include "../include/pv_types.h"
-#include "../utils/Timer.hpp"
+#include "include/pv_arch.h"
+#include "include/pv_types.h"
+#include "utils/Timer.hpp"
 
-#include "../arch/mpi/mpi.h"
+#include "arch/mpi/mpi.h"
 
 #define COMMNAME_MAXLENGTH 16
 

--- a/src/columns/HyPerCol.cpp
+++ b/src/columns/HyPerCol.cpp
@@ -187,18 +187,7 @@ int HyPerCol::initialize(const char * name, PV_Init* initObj)
    char * working_dir = expandLeadingTilde(mPVInitObj->getWorkingDir());
    mWarmStart = mPVInitObj->getRestartFlag();
 
-#ifdef PVP_DEBUG
-   if (mPVInitObj->getRequireReturnFlag()) {
-      if( rank == 0 ) {
-         fflush(stdout);
-         printf("Hit enter to begin! ");
-         fflush(stdout);
-         int charhit = -1;
-         while(charhit != '\n') { charhit = getc(stdin); }
-      }
-      MPI_Barrier(mCommunicator->globalCommunicator());
-   }
-#endif // PVP_DEBUG
+   // Sep 27, 2016: handling --require-return has been moved to the Communicator constructor.
 
    mName = strdup(name);
    mRunTimer = new Timer(mName, "column", "run    ");

--- a/src/columns/HyPerCol.cpp
+++ b/src/columns/HyPerCol.cpp
@@ -949,103 +949,7 @@ void HyPerCol::ioParam_errorOnNotANumber(enum ParamsIOFlag ioFlag) {
 }
 
 // Sep 26, 2016: HyPerCol methods for parameter input/output have been moved to PVParams.
-
-int HyPerCol::checkDirExists(const char * dirname, struct stat * pathstat) {
-   // check if the given directory name exists for the rank zero process
-   // the return value is zero if a successful stat(2) call and the error
-   // if unsuccessful.  pathstat contains the result of the buffer from the stat call.
-   // The rank zero process is the only one that calls stat(); it then Bcasts the
-   // result to the rest of the processes.
-   pvAssert(pathstat);
-
-   int rank = columnId();
-   int status;
-   int errorcode;
-   if( rank == 0 ) {
-      char * expandedDirName = expandLeadingTilde(dirname);
-      status = stat(dirname, pathstat);
-      free(expandedDirName);
-      if( status ) errorcode = errno;
-   }
-#ifdef PV_USE_MPI
-   MPI_Bcast(&status, 1, MPI_INT, 0, getCommunicator()->communicator());
-   if( status ) {
-      MPI_Bcast(&errorcode, 1, MPI_INT, 0, getCommunicator()->communicator());
-   }
-   MPI_Bcast(pathstat, sizeof(struct stat), MPI_CHAR, 0, getCommunicator()->communicator());
-#endif // PV_USE_MPI
-   return status ? errorcode : 0;
-}
-
-
-static inline int makeDirectory(const char *dir) {
-   mode_t dirmode = S_IRWXU | S_IRWXG | S_IRWXO;
-   char tmp[PV_PATH_MAX];
-   char *p = nullptr;
-   int status = 0;
-
-   int num_chars_needed = snprintf(tmp,sizeof(tmp),"%s",dir);
-   pvErrorIf(num_chars_needed > PV_PATH_MAX, "Path \"%s\" is too long.",dir);
-
-   int len = strlen(tmp);
-   if(tmp[len - 1] == '/')
-      tmp[len - 1] = 0;
-
-   for(p = tmp + 1; *p; p++)
-      if(*p == '/') {
-         *p = 0;
-         status |= mkdir(tmp, dirmode);
-         if(status != 0 && errno != EEXIST){
-            return status;
-         }
-         *p = '/';
-      }
-   status |= mkdir(tmp, dirmode);
-   if(errno == EEXIST){
-      status = 0;
-   }
-   return status;
-}
-
-int HyPerCol::ensureDirExists(const char * dirname) {
-   // see if path exists, and try to create it if it doesn't.
-   // Since only rank 0 process should be reading and writing, only rank 0 does the mkdir call
-   int rank = columnId();
-   struct stat pathstat;
-   int resultcode = checkDirExists(dirname, &pathstat);
-   if( resultcode == 0 ) { // mOutputPath exists; now check if it's a directory.
-      pvErrorIf(!(pathstat.st_mode & S_IFDIR ) && rank == 0, "Path \"%s\" exists but is not a directory\n", dirname);
-   }
-   else if( resultcode == ENOENT /* No such file or directory */ ) {
-      if( rank == 0 ) {
-         pvInfo().printf("Directory \"%s\" does not exist; attempting to create\n", dirname);
-
-         //Try up to 5 times until it works
-         int const numAttempts = 5;
-         for(int attemptNum = 0; attemptNum < numAttempts; attemptNum++){
-            int mkdirstatus = makeDirectory(dirname);
-            if( mkdirstatus != 0 ) {
-               if(attemptNum == numAttempts - 1){
-                  pvError().printf("Directory \"%s\" could not be created: %s; Exiting\n", dirname, strerror(errno));
-               }
-               else{
-                  getOutputStream().flush();
-                  pvWarn().printf("Directory \"%s\" could not be created: %s; Retrying %d out of %d\n", dirname, strerror(errno), attemptNum + 1, numAttempts);
-                  sleep(1);
-               }
-            }
-            else { break; }
-         }
-      }
-   }
-   else {
-      if( rank == 0 ) {
-         pvErrorNoExit().printf("Error checking status of directory \"%s\": %s\n", dirname, strerror(resultcode)); 
-      }
-      exit(EXIT_FAILURE);
-   }
-   return PV_SUCCESS;
-}
+// Sep 27, 2016: ensureDirExists has been moved to fileio.cpp.
 
 int HyPerCol::addLayer(HyPerLayer * layer)
 {
@@ -1596,7 +1500,7 @@ int HyPerCol::checkpointWrite(const char * cpDir) {
       }
    }
 
-   ensureDirExists(cpDir);
+   ensureDirExists(getCommunicator(), cpDir);
    for( int l=0; l<mLayers.size(); l++ ) {
       mLayers.at(l)->checkpointWrite(cpDir);
    }
@@ -1731,7 +1635,7 @@ int HyPerCol::outputParams(char const * path) {
       pvError().printf("HyPerCol::outputParams unable to allocate memory: %s\n", strerror(errno));
    }
    char * containingdir = dirname(tmp);
-   status = ensureDirExists(containingdir); // must be called by all processes, even though only rank 0 creates the directory
+   status = ensureDirExists(getCommunicator(), containingdir); // must be called by all processes, even though only rank 0 creates the directory
    if (status != PV_SUCCESS) {
       pvErrorNoExit().printf("HyPerCol::outputParams unable to create directory \"%s\"\n", containingdir);
    }

--- a/src/columns/HyPerCol.hpp
+++ b/src/columns/HyPerCol.hpp
@@ -329,7 +329,6 @@ public:
    int addNormalizer(NormalizeBase* normalizer);
    int addLayer(HyPerLayer* l);
    int advanceTime(double time);
-   int ensureDirExists(const char* dirname);
    int exitRunLoop(bool exitOnFinish);
    int insertProbe(ColProbe* p);
    int outputState(double time);

--- a/src/columns/PV_Init.cpp
+++ b/src/columns/PV_Init.cpp
@@ -188,57 +188,7 @@ int PV_Init::registerKeyword(char const * keyword, ObjectCreateFn creator) {
    return status;
 }
 
-#ifdef OBSOLETE // Marked obsolete Jul 19, 2016.  Use hc=createHyPerCol(pv_init_ptr) instead of hc=pv_init_ptr->build().
-HyPerCol * PV_Init::build() {
-   HyPerCol * hc = new HyPerCol("column", this);
-   if( hc == NULL ) {
-      pvErrorNoExit().printf("Unable to create HyPerCol\n");
-      return NULL;
-   }
-   PVParams * hcparams = hc->parameters();
-   int numGroups = hcparams->numberOfGroups();
-
-   // Make sure first group defines a column
-   if( strcmp(hcparams->groupKeywordFromIndex(0), "HyPerCol") ) {
-      pvErrorNoExit().printf("First group in the params file did not define a HyPerCol.\n");
-      delete hc;
-      return NULL;
-   }
-
-   for (int k=0; k<numGroups; k++) {
-      const char * kw = hcparams->groupKeywordFromIndex(k);
-      const char * name = hcparams->groupNameFromIndex(k);
-      if (!strcmp(kw, "HyPerCol")) {
-         if (k==0) { continue; }
-         else {
-            if (hc->columnId()==0) {
-               pvErrorNoExit().printf("Group %d in params file (\"%s\") is a HyPerCol; the HyPerCol must be the first group.\n",
-                       k+1, name);
-            }
-            delete hc;
-            return NULL;
-         }
-      }
-      else {
-         BaseObject * addedObject = factory->create(kw, name, hc);
-         if (addedObject==NULL) {
-            if (hc->globalRank()==0) {
-               pvErrorNoExit().printf("Unable to create %s \"%s\".\n", kw, name);
-            }
-            delete hc;
-            return NULL;
-         }
-      }
-   }
-
-   if( hc->numberOfLayers() == 0 ) {
-      pvErrorNoExit().printf("HyPerCol \"%s\" does not have any layers.\n", hc->getName());
-      delete hc;
-      return NULL;
-   }
-   return hc;
-}
-#endif // OBSOLETE // Marked obsolete Jul 19, 2016.  Use hc=createHyPerCol(pv_init_ptr) instead of hc=pv_init_ptr->build().
+// PV_Init::build() was marked obsolete Jul 19, 2016 and deleted Sep 27, 2016. Use hc=createHyPerCol(pv_init_ptr) instead of hc=pv_init_ptr->build().
 
 int PV_Init::commFinalize()
 {

--- a/src/columns/PV_Init.hpp
+++ b/src/columns/PV_Init.hpp
@@ -82,11 +82,6 @@ public:
    char const * getProgramName() const { return arguments->getProgramName(); }
 
    /**
-    * Returns true if the require-return flag was set; false otherwise.
-    */
-   bool getRequireReturnFlag() const { return arguments->getRequireReturnFlag(); }
-
-   /**
     * Returns the output path string.
     */
    char const * getOutputPath() const { return arguments->getOutputPath(); }
@@ -319,13 +314,6 @@ public:
     * The function should return a pointer of type BaseObject, created with the new operator.
     */
    int registerKeyword(char const * keyword, ObjectCreateFn creator);
-
-   /**
-    * The method to create an object (layer, connection, weight initializer, weight normalizer,
-    * or probe) based on keyword and name, and add it to the given HyPerLayer.
-    */
-   BaseObject * create(char const * keyword, char const * name, HyPerCol * hc) const;
-
 
    /**
     * Obsolete.  Use createHyPerCol defined in HyPerCol.cpp instead.

--- a/src/include/pv_arch.h
+++ b/src/include/pv_arch.h
@@ -18,9 +18,6 @@
 /* maximum length of a path */
 #define PV_PATH_MAX 256 // 127  // imageNet uses long folder names
 
-/* Define to enable behavior convenient for parallel debugging */
-#define PVP_DEBUG
-
 /* define if using pthreads */
 #undef PV_USE_PTHREADS
 

--- a/src/io/CMakeLists.txt
+++ b/src/io/CMakeLists.txt
@@ -1,4 +1,5 @@
 set (PVLibSrcCpp ${PVLibSrcCpp}
+   ${SUBDIR}/CheckpointEntry.cpp
    ${SUBDIR}/fileio.cpp
    ${SUBDIR}/FileStream.cpp
    ${SUBDIR}/imageio.cpp
@@ -7,6 +8,7 @@ set (PVLibSrcCpp ${PVLibSrcCpp}
 )
 
 set (PVLibSrcHpp ${PVLibSrcHpp}
+   ${SUBDIR}/CheckpointEntry.hpp
    ${SUBDIR}/fileio.hpp
    ${SUBDIR}/FileStream.hpp
    ${SUBDIR}/imageio.hpp

--- a/src/io/CheckpointEntry.cpp
+++ b/src/io/CheckpointEntry.cpp
@@ -1,0 +1,35 @@
+/*
+ * CheckpointEntry.cpp
+ *
+ *  Created on Sep 27, 2016
+ *      Author: Pete Schultz
+ */
+
+#include "CheckpointEntry.hpp"
+#include <cerrno>
+#include <cstring>
+#include <sys/stat.h>
+
+namespace PV {
+
+std::string CheckpointEntry::generatePath(std::string const& checkpointDirectory, std::string const& extension) const {
+   std::string path(checkpointDirectory);
+   path.append("/").append(getName()).append(".").append(extension);
+   return path;
+}
+
+void CheckpointEntry::deleteFile(std::string const& checkpointDirectory, std::string const& extension) const {
+   if (getCommunicator()->commRank()==0) {
+      std::string path = generatePath(checkpointDirectory, extension);
+      struct stat pathStat;
+      int statstatus = stat(path.c_str(), &pathStat);
+      if (statstatus == 0) {
+         int unlinkstatus = unlink(path.c_str());
+         if (unlinkstatus != 0) {
+            pvError().printf("Failure deleting \"%s\": %s\n", path.c_str(), strerror(errno));
+         }
+      }
+   }
+}
+
+}

--- a/src/io/CheckpointEntry.hpp
+++ b/src/io/CheckpointEntry.hpp
@@ -1,0 +1,105 @@
+/*
+ * CheckpointEntry.hpp
+ *
+ *  Created on Sep 27, 2016
+ *      Author: Pete Schultz
+ */
+
+#ifndef CHECKPOINTENTRY_HPP_
+#define CHECKPOINTENTRY_HPP_
+
+#include "columns/Communicator.hpp"
+#include <string>
+
+namespace PV {
+
+class CheckpointEntry {
+   public:
+      CheckpointEntry(std::string const& name, bool verifyingWritesFlag, Communicator * communicator) :
+            mName(name), mVerifyingWritesFlag(verifyingWritesFlag), mCommunicator(communicator) {}
+      CheckpointEntry(std::string const& objName, std::string const& dataName, bool verifyingWritesFlag, Communicator * communicator) {
+         std::string key(objName);
+         if (!(objName.empty() || dataName.empty())) { key.append("_"); }
+         key.append(dataName);
+         mVerifyingWritesFlag = verifyingWritesFlag;
+         mCommunicator = communicator;
+      }
+      virtual void write(std::string const& checkpointDirectory, double simTime) const {return;}
+      virtual void read(std::string const& checkpointDirectory, double * simTimePtr) const {return;}
+      virtual void remove(std::string const& checkpointDirectory) const {return;}
+      std::string const& getName() const { return mName; }
+   protected:
+      std::string generatePath(std::string const& checkpointDirectory, std::string const& extension) const;
+      void deleteFile(std::string const& checkpointDirectory, std::string const& extension) const;
+      bool isVerifyingWrites() const { return mVerifyingWritesFlag; }
+      Communicator * getCommunicator() const { return mCommunicator; }
+
+// data members
+private:
+   std::string mName;
+   bool mVerifyingWritesFlag;
+   Communicator * mCommunicator;
+};
+
+template <typename T>
+class CheckpointEntryData : public CheckpointEntry {
+public:
+   CheckpointEntryData(std::string const& name, bool verifyingWritesFlag, Communicator * communicator,
+         T * dataPtr, size_t numValues, bool broadcastingFlag) :
+         CheckpointEntry(name, verifyingWritesFlag, communicator),
+         mDataPointer(dataPtr), mNumValues(numValues), mBroadcastingFlag(broadcastingFlag) {}
+   CheckpointEntryData(std::string const& objName, bool verifyingWritesFlag, Communicator * communicator,
+         std::string const& dataName, T * dataPtr, size_t numValues, bool broadcastingFlag) :
+         CheckpointEntry(objName, dataName, verifyingWritesFlag, communicator),
+         mDataPointer(dataPtr), mNumValues(numValues), mBroadcastingFlag(broadcastingFlag) {}
+   virtual void write(std::string const& checkpointDirectory, double simTime) const override;
+   virtual void read(std::string const& checkpointDirectory, double * simTimePtr) const override;
+   virtual void remove(std::string const& checkpointDirectory) const override;
+
+private:
+   void broadcast();
+
+private:
+   T * mDataPointer;
+   size_t mNumValues;
+   bool mBroadcastingFlag;
+};
+
+template <typename T>
+class CheckpointEntryPvp : public CheckpointEntry {
+public:
+   CheckpointEntryPvp(std::string const& name, bool verifyingWritesFlag, Communicator * communicator,
+         T * dataPtr, size_t dataSize, int dataType, PVLayerLoc const * layerLoc, bool extended) :
+         CheckpointEntry(name, verifyingWritesFlag, communicator),
+         mDataPointer(dataPtr), mDataSize(dataSize), mDataType(dataType), mLayerLoc(layerLoc), mExtended(extended) {}
+   CheckpointEntryPvp(std::string const& objName, std::string const& dataName,
+         T * dataPtr, size_t dataSize, int dataType, PVLayerLoc const * layerLoc, bool extended) :
+         CheckpointEntry(objName, dataName),
+         mDataPointer(dataPtr), mDataSize(dataSize), mDataType(dataType), mLayerLoc(layerLoc), mExtended(extended) {}
+   virtual void write(std::string const& checkpointDirectory, double simTime) const override;
+   virtual void read(std::string const& checkpointDirectory, double * simTimePtr) const override;
+   virtual void remove(std::string const& checkpointDirectory) const override;
+private:
+   T * mDataPointer;
+   size_t mDataSize;
+   int mDataType;
+   PVLayerLoc const * mLayerLoc = nullptr;
+   bool mExtended = false;
+};
+
+namespace TextOutput {
+
+template <typename T>
+void print(T const * dataPointer, size_t numValues, std::ostream& stream) {
+   for (size_t n=0; n<numValues; n++) {
+      stream << dataPointer[n] << "\n";
+   }
+} // end print()
+
+} // end namespace TextOutput
+    
+} // end namespace PV
+
+#include "CheckpointEntry.tpp"
+
+#endif // CHECKPOINTENTRY_HPP_

--- a/src/io/CheckpointEntry.tpp
+++ b/src/io/CheckpointEntry.tpp
@@ -1,0 +1,112 @@
+/*
+ * CheckpointEntry.tpp
+ *
+ *  Created on Sep 27, 2016
+ *      Author: Pete Schultz
+ *  template implementations for CheckpointEntry class hierarchy.
+ *  Note that the .hpp includes this .tpp file at the end;
+ *  the .tpp file does not include the .hpp file.
+ */
+
+#include "io/fileio.hpp"
+#include "utils/PVLog.hpp"
+#include "utils/PVAssert.hpp"
+
+namespace PV {
+
+template <typename T>
+void CheckpointEntryData<T>::write(std::string const& checkpointDirectory, double simTime) const {
+   if (getCommunicator()->commRank()==0) {
+      std::string path = generatePath(checkpointDirectory, "bin");
+      PV_Stream * pvstream = PV_fopen(path.c_str(), "w", isVerifyingWrites());
+      int numRead = PV_fwrite(mDataPointer, sizeof(T), mNumValues, pvstream);
+      if (numRead != mNumValues) {
+         pvError() << "CheckpointEntryData::write: unable to write to \"" << path << "\".\n";
+      }
+      PV_fclose(pvstream);
+      path = generatePath(checkpointDirectory, "txt");
+      FileStream txtStream(path.c_str(), std::ios_base::out, isVerifyingWrites());
+      TextOutput::print(mDataPointer, mNumValues, txtStream.outStream());
+   }
+}
+
+template <typename T>
+void CheckpointEntryData<T>::read(std::string const& checkpointDirectory, double * simTimePtr) const {
+   if (getCommunicator()->commRank()==0) {
+      std::string path = generatePath(checkpointDirectory, "bin");
+      PV_Stream * pvstream = PV_fopen(path.c_str(), "r", false/*reading doesn't use verifyWrites, but PV_fopen constructor still uses it.*/);
+      int numRead = PV_fread(mDataPointer, sizeof(T), mNumValues, pvstream);
+      if (numRead != mNumValues) {
+         pvError() << "CheckpointData::read: unable to read from \"" << path << "\".\n";         
+      }
+      PV_fclose(pvstream);
+   }
+   if(mBroadcastingFlag) {
+      MPI_Bcast(mDataPointer, mNumValues*sizeof(T), MPI_CHAR, 0, getCommunicator()->communicator()); // TODO: Pack all MPI_Bcasts into a single broadcast.
+   }
+}
+
+template <typename T>
+void CheckpointEntryData<T>::remove(std::string const& checkpointDirectory) const {
+   deleteFile(checkpointDirectory, "bin");
+   deleteFile(checkpointDirectory, "txt");
+}
+
+template <typename T>
+void CheckpointEntryPvp<T>::write(std::string const& checkpointDirectory, double simTime) const {
+   PV_Stream * pvstream = nullptr;
+   if (getCommunicator()->commRank()==0) {
+      std::string path = generatePath(checkpointDirectory, "pvp");
+      pvstream = PV_fopen(path.c_str(), "w", isVerifyingWrites());
+      int * params = pvp_set_nonspiking_act_params(getCommunicator(), simTime, mLayerLoc, mDataType, 1/*numbands*/);
+      pvAssert(params && params[1]==NUM_BIN_PARAMS);
+      int status = pvp_write_header(pvstream, getCommunicator(), params, params[1]);
+      pvErrorIf(status!=PV_SUCCESS, "CheckpointEntryPvp::write unable to write header to to \"%s\"\n", path.c_str());
+      free(params);
+   }
+   for (int b=0; b<mLayerLoc->nbatch; b++) {
+      int nxExt = mLayerLoc->nx + mLayerLoc->halo.lt + mLayerLoc->halo.rt;
+      int nyExt = mLayerLoc->ny + mLayerLoc->halo.dn + mLayerLoc->halo.up;
+      T * batchElementStart = &mDataPointer[b*nxExt*nyExt*mLayerLoc->nf];
+      if (pvstream) { PV_fwrite(&simTime, sizeof(double), (size_t) 1, pvstream); }
+      gatherActivity(pvstream, getCommunicator(), 0/*rootproc*/, batchElementStart, mLayerLoc, mExtended);
+   }
+   if (getCommunicator()->commRank()==0) {
+      PV_fclose(pvstream);
+   }
+}
+
+template <typename T>
+void CheckpointEntryPvp<T>::read(std::string const& checkpointDirectory, double * simTimePtr) const {
+   std::string path = generatePath(checkpointDirectory, "pvp");
+   PV_Stream * pvstream = pvp_open_read_file(path.c_str(), getCommunicator());
+   int rank = getCommunicator()->commRank();
+   pvAssert( (pvstream != nullptr && rank == 0) || (pvstream == nullptr && rank != 0) );
+   int numParams = NUM_BIN_PARAMS;
+   int params[NUM_BIN_PARAMS];
+   int status = pvp_read_header(pvstream, getCommunicator(), params, &numParams);
+   if (status != PV_SUCCESS) {
+      read_header_err(path.c_str(), getCommunicator(), numParams, params);
+   }
+   MPI_Datatype * exchangeDatatypes = getCommunicator()->newDatatypes(mLayerLoc);
+   std::vector<MPI_Request> req{};
+   for (int b=0; b<mLayerLoc->nbatch; b++) {
+      int nxExt = mLayerLoc->nx + mLayerLoc->halo.lt + mLayerLoc->halo.rt;
+      int nyExt = mLayerLoc->ny + mLayerLoc->halo.dn + mLayerLoc->halo.up;
+      T * batchElementStart = &mDataPointer[b*nxExt*nyExt*mLayerLoc->nf];
+      if (pvstream) { PV_fread(simTimePtr, sizeof(double), (size_t) 1, pvstream); }
+      scatterActivity(pvstream, getCommunicator(), 0/*rootproc*/, batchElementStart, mLayerLoc, mExtended);
+      getCommunicator()->exchange(batchElementStart, exchangeDatatypes, mLayerLoc, req);
+      // TODO: scattering should be aware of interprocess overlap region so that exchange call isn't necessary.
+      getCommunicator()->wait(req);
+   }
+   getCommunicator()->freeDatatypes(exchangeDatatypes);
+   MPI_Bcast(simTimePtr, 1, MPI_DOUBLE, 0, getCommunicator()->communicator());
+}
+
+template <typename T>
+void CheckpointEntryPvp<T>::remove(std::string const& checkpointDirectory) const {
+   deleteFile(checkpointDirectory, "pvp");
+}
+
+}

--- a/src/io/fileio.cpp
+++ b/src/io/fileio.cpp
@@ -418,6 +418,100 @@ int PV_fclose(PV_Stream * pvstream) {
    return status;
 }
 
+int checkDirExists(Communicator * comm, char const * dirname, struct stat * pathstat) {
+   // check if the given directory name exists for the rank zero process
+   // the return value is zero if a successful stat(2) call and the error
+   // if unsuccessful.  pathstat contains the result of the buffer from the stat call.
+   // The rank zero process is the only one that calls stat(); it then Bcasts the
+   // result to the rest of the processes.
+   pvErrorIf(pathstat==nullptr, "checkDirExists called with pathstat null.\n");
+
+   int rank = comm->commRank();
+   int status;
+   int errorcode;
+   if( rank == 0 ) {
+      char * expandedDirName = expandLeadingTilde(dirname);
+      status = stat(dirname, pathstat);
+      free(expandedDirName);
+      if( status ) errorcode = errno;
+   }
+#ifdef PV_USE_MPI
+   MPI_Bcast(&status, 1, MPI_INT, 0, comm->communicator());
+   if( status ) {
+      MPI_Bcast(&errorcode, 1, MPI_INT, 0, comm->communicator());
+   }
+   MPI_Bcast(pathstat, sizeof(struct stat), MPI_CHAR, 0, comm->communicator());
+#endif // PV_USE_MPI
+   return status ? errorcode : 0;
+}
+
+static inline int makeDirectory(char const *dir) {
+   mode_t dirmode = S_IRWXU | S_IRWXG | S_IRWXO;
+   int status = 0;
+
+   char * workingDir = strdup(dir);
+   pvErrorIf(workingDir==nullptr, "makeDirectory: unable to duplicate path \"%s\".",dir);
+
+   int len = strlen(workingDir);
+   if(workingDir[len - 1] == '/')
+      workingDir[len - 1] = '\0';
+
+   for(char * p = workingDir + 1; *p; p++)
+      if(*p == '/') {
+         *p = '\0';
+         status |= mkdir(workingDir, dirmode);
+         if(status != 0 && errno != EEXIST){
+            return status;
+         }
+         *p = '/';
+      }
+   status |= mkdir(workingDir, dirmode);
+   if(errno == EEXIST){
+      status = 0;
+   }
+   return status;
+}
+
+int ensureDirExists(Communicator * comm, char const * dirname) {
+   // see if path exists, and try to create it if it doesn't.
+   // Since only rank 0 process should be reading and writing, only rank 0 does the mkdir call
+   int rank = comm->commRank();
+   struct stat pathstat;
+   int resultcode = checkDirExists(comm, dirname, &pathstat);
+   if( resultcode == 0 ) { // mOutputPath exists; now check if it's a directory.
+      pvErrorIf(!(pathstat.st_mode & S_IFDIR ) && rank == 0, "Path \"%s\" exists but is not a directory\n", dirname);
+   }
+   else if( resultcode == ENOENT /* No such file or directory */ ) {
+      if( rank == 0 ) {
+         pvInfo().printf("Directory \"%s\" does not exist; attempting to create\n", dirname);
+
+         //Try up to 5 times until it works
+         int const numAttempts = 5;
+         for(int attemptNum = 0; attemptNum < numAttempts; attemptNum++){
+            int mkdirstatus = makeDirectory(dirname);
+            if( mkdirstatus != 0 ) {
+               if(attemptNum == numAttempts - 1){
+                  pvError().printf("Directory \"%s\" could not be created: %s; Exiting\n", dirname, strerror(errno));
+               }
+               else{
+                  getOutputStream().flush();
+                  pvWarn().printf("Directory \"%s\" could not be created: %s; Retrying %d out of %d\n", dirname, strerror(errno), attemptNum + 1, numAttempts);
+                  sleep(1);
+               }
+            }
+            else { break; }
+         }
+      }
+   }
+   else {
+      if( rank == 0 ) {
+         pvErrorNoExit().printf("Error checking status of directory \"%s\": %s\n", dirname, strerror(resultcode)); 
+      }
+      exit(EXIT_FAILURE);
+   }
+   return PV_SUCCESS;
+}
+
 /**
  * Gets the number of patches for the given PVLayerLoc, in a non-shared weight context.
  * The return value is the number of patches for the global column (i.e. not a particular MPI process)

--- a/src/io/fileio.hpp
+++ b/src/io/fileio.hpp
@@ -42,6 +42,7 @@ int PV_fseek(PV_Stream * pvstream, long int offset, int whence);
 size_t PV_fwrite(const void * RESTRICT ptr, size_t size, size_t nitems, PV_Stream * RESTRICT pvstream);
 size_t PV_fread(void * RESTRICT ptr, size_t size, size_t nitems, PV_Stream * RESTRICT pvstream);
 int PV_fclose(PV_Stream * pvstream);
+int ensureDirExists(Communicator * comm, char const * dirname);
 
 PV_Stream * pvp_open_read_file(const char * filename, Communicator * comm);
 

--- a/src/layers/InputLayer.cpp
+++ b/src/layers/InputLayer.cpp
@@ -22,7 +22,7 @@ namespace PV {
       int status = HyPerLayer::initialize(name, hc);
       if (mWriteFileToTimestamp) {
          std::string timestampFilename = std::string(parent->getOutputPath()) + std::string("/timestamps/");
-         parent->ensureDirExists(timestampFilename.c_str());
+         ensureDirExists(parent->getCommunicator(), timestampFilename.c_str());
          timestampFilename += name + std::string(".txt");
          if (getParent()->getCommunicator()->commRank() == 0) {
              //If checkpoint read is set, append, otherwise, clobber

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -25,6 +25,7 @@ endif("${PV_SYSTEM_TEST_THREADS}" MATCHES "^([0-9]+|)$")
 # Unit tests for individual classes happen first. If these fail, the rest of the results are unreliable.
 add_subdirectory(BatchIndexerTest)
 add_subdirectory(BufferTest)
+add_subdirectory(CheckpointEntryTest)
 add_subdirectory(ImageTest)
 
 # System tests that involve starting up a full instance of PetaVision happen next.

--- a/tests/CheckpointEntryTest/CMakeLists.txt
+++ b/tests/CheckpointEntryTest/CMakeLists.txt
@@ -1,0 +1,18 @@
+set(SRC_CPP
+  src/main.cpp
+  src/testDataNoBroadcast.cpp
+  src/testDataWithBroadcast.cpp
+  src/testPvpExtended.cpp
+  src/testPvpRestricted.cpp
+  src/testPvpBatch.cpp
+)
+
+set(SRC_HPP
+  src/testDataNoBroadcast.hpp
+  src/testDataWithBroadcast.hpp
+  src/testPvpExtended.hpp
+  src/testPvpRestricted.hpp
+  src/testPvpBatch.hpp
+)
+
+pv_add_test(NO_PARAMS SRCFILES ${SRC_CPP} ${SRC_HPP} ${SRC_C} ${SRC_H})

--- a/tests/CheckpointEntryTest/src/main.cpp
+++ b/tests/CheckpointEntryTest/src/main.cpp
@@ -1,0 +1,41 @@
+#include "testDataNoBroadcast.hpp"
+#include "testDataWithBroadcast.hpp"
+#include "testPvpRestricted.hpp"
+#include "testPvpExtended.hpp"
+#include "testPvpBatch.hpp"
+
+#include "columns/Communicator.hpp"
+#include "columns/PV_Arguments.hpp"
+#include "io/fileio.hpp"
+#include "utils/PVLog.hpp"
+
+void testDataWithBroadcast(PV::Communicator * comm);
+void testPvpRestricted(PV::Communicator * comm);
+
+int main(int argc, char * argv[]) {
+   PV::PV_Arguments pvArguments{argc, argv, false/*do not allow unrecognized arguments*/};
+   MPI_Init(&argc, &argv);
+   PV::Communicator * comm = new PV::Communicator(&pvArguments);
+
+   std::string directory("checkpoints");
+   ensureDirExists(comm, directory.c_str()); // Must be called by all processes, because it broadcasts the result of the stat() call.
+   if (comm->commRank()==0) {
+      std::string rmcommand("rm -rf "); rmcommand.append(directory).append("/*");
+      pvInfo() << "Cleaning output directory with \"" << rmcommand << "\".\n";
+      int rmstatus = system(rmcommand.c_str());
+      pvErrorIf(rmstatus, "Error executing \"%s\": status code was %d\n", rmcommand.c_str(), WEXITSTATUS(rmstatus));
+   }
+   if (comm->numCommBatches()>1) {
+      directory.append("/batchsweep_").append(std::to_string(comm->commBatch()));
+      ensureDirExists(comm, directory.c_str());
+   }
+
+   testDataNoBroadcast(comm, directory);
+   testDataWithBroadcast(comm, directory);
+   testPvpRestricted(comm, directory);
+   testPvpExtended(comm, directory);
+   testPvpBatch(comm, directory);
+
+   delete comm;
+   MPI_Finalize();
+}

--- a/tests/CheckpointEntryTest/src/testDataNoBroadcast.cpp
+++ b/tests/CheckpointEntryTest/src/testDataNoBroadcast.cpp
@@ -1,0 +1,41 @@
+#include "testDataNoBroadcast.hpp"
+#include "io/CheckpointEntry.hpp"
+#include "utils/PVLog.hpp"
+
+void testDataNoBroadcast(PV::Communicator * comm, std::string const& directory) {
+   int const vectorLength = 32;
+   std::vector<float> checkpointData(vectorLength, 0);
+   int const rank = comm->commRank();
+   if (rank==0) {
+      for (int i=0; i<vectorLength; i++) {
+         checkpointData.at(i) = (float) i;
+      }
+   }
+   PV::CheckpointEntryData<float> checkpointEntryNoBroadcast{"checkpointEntryNoBroadcast", false/*not verifying writes*/, comm,
+         checkpointData.data(), checkpointData.size(), false/*no broadcast*/};
+   checkpointEntryNoBroadcast.write(directory, 0.0/*simTime, not used*/);
+
+   // Data has now been checkpointed. Copy it to compare after CheckpointEntry::read,
+   // and change the vector to make sure that checkpointRead is really modifying the data.
+   std::vector<float> dataCopy = checkpointData;
+   for (auto& x : checkpointData) { x = 5.0f; }
+
+   // Then read it back from checkpoint.
+   double dummyTime = 0.0; // in checkpointWrite API, but not used by CheckpointEntryData.
+   checkpointEntryNoBroadcast.read(directory, &dummyTime);
+
+   // The root process should have the original data; any nonroot processes should still have all 5.0.
+   if (rank==0) {
+      for (int i=0; i<vectorLength; i++) {
+         pvErrorIf(checkpointData.at(i)!=dataCopy.at(i), "testDataNoBroadcast failed: data at index %d is %f, but should be %f.\n",
+               i, (double) checkpointData.at(i), (double) dataCopy.at(i));
+      }
+   }
+   else {
+      for (int i=0; i<vectorLength; i++) {
+         pvErrorIf(checkpointData.at(i) != 5.0f, "testDataNoBroadcast failed for rank %d process: data at index %d is %f, but should be %f.\n",
+               rank, i, (double) checkpointData.at(i), (double) 5.0f);
+      }
+   }
+   pvInfo() << "testDataNoBroadcast passed.\n";
+}

--- a/tests/CheckpointEntryTest/src/testDataNoBroadcast.hpp
+++ b/tests/CheckpointEntryTest/src/testDataNoBroadcast.hpp
@@ -1,0 +1,9 @@
+#ifndef TESTDATANOBROADCAST_HPP_
+#define TESTDATANOBROADCAST_HPP_
+
+#include "columns/Communicator.hpp"
+#include <string>
+
+void testDataNoBroadcast(PV::Communicator * comm, std::string const& directory);
+
+#endif // TESTDATANOBROADCAST_HPP_

--- a/tests/CheckpointEntryTest/src/testDataWithBroadcast.cpp
+++ b/tests/CheckpointEntryTest/src/testDataWithBroadcast.cpp
@@ -1,0 +1,38 @@
+#include "testDataWithBroadcast.hpp"
+#include "io/CheckpointEntry.hpp"
+#include "utils/PVLog.hpp"
+
+void testDataWithBroadcast(PV::Communicator * comm, std::string const& directory) {
+   int const vectorLength = 32;
+   std::vector<float> correctData(vectorLength, 0);
+   for (int i=0; i<vectorLength; i++) { correctData.at(i) = (float) i; }
+   std::vector<float> checkpointData;
+   int const rank = comm->commRank();
+   if (rank==0) {
+      checkpointData = correctData;
+   }
+   else {
+      checkpointData = std::vector<float>(vectorLength, 0);
+   }
+   pvErrorIf((int) checkpointData.size() != vectorLength, "checkpointData has length %zu instead of %d\n", (size_t) checkpointData.size(), vectorLength);
+   PV::CheckpointEntryData<float> checkpointEntryWithBroadcast{"checkpointEntryWithBroadcast", false/*not verifying writes*/, comm,
+         checkpointData.data(), checkpointData.size(), true/*broadcasting read to all processes*/};
+   checkpointEntryWithBroadcast.write(directory, 0.0/*simTime, not used*/);
+
+   // Data has now been checkpointed. Copy it to compare after CheckpointEntry::read,
+   // and change the vector to make sure that checkpointRead is really modifying the data.
+   std::vector<float> dataCopy = checkpointData;
+   for (auto& x : checkpointData) { x = 5.0f; }
+
+   // Then read it back from checkpoint.
+   double dummyTime = 0.0; // in checkpointWrite API, but not used by CheckpointEntryData.
+   checkpointEntryWithBroadcast.read(directory, &dummyTime);
+
+   // All processes should have the original data
+   for (int i=0; i<vectorLength; i++) {
+      pvErrorIf(checkpointData.at(i)!=correctData.at(i), "testDataNoBroadcast failed: data at index %d is %f, but should be %f.\n",
+            i, (double) checkpointData.at(i), (double) correctData.at(i));
+   }
+   MPI_Barrier(comm->communicator());
+   pvInfo() << "testDataWithBroadcast passed.\n";
+}

--- a/tests/CheckpointEntryTest/src/testDataWithBroadcast.hpp
+++ b/tests/CheckpointEntryTest/src/testDataWithBroadcast.hpp
@@ -1,0 +1,9 @@
+#ifndef TESTDATAWITHBROADCAST_HPP_
+#define TESTDATAWITHBROADCAST_HPP_
+
+#include "columns/Communicator.hpp"
+#include <string>
+
+void testDataWithBroadcast(PV::Communicator * comm, std::string const& directory);
+
+#endif // TESTDATAWITHBROADCAST_HPP_

--- a/tests/CheckpointEntryTest/src/testPvpBatch.cpp
+++ b/tests/CheckpointEntryTest/src/testPvpBatch.cpp
@@ -1,0 +1,67 @@
+#include "testPvpBatch.hpp"
+#include "io/CheckpointEntry.hpp"
+#include "utils/conversions.h"
+
+void testPvpBatch(PV::Communicator * comm, std::string const& directory) {
+   PVLayerLoc loc;
+   loc.nbatchGlobal = 4;
+   loc.nxGlobal = 16;
+   loc.nyGlobal = 4;
+   loc.nf = 1;
+   loc.halo.lt = 0;
+   loc.halo.rt = 0;
+   loc.halo.dn = 0;
+   loc.halo.up = 0;
+   pvErrorIf(loc.nbatchGlobal % comm->numCommBatches(), "Global batch size %d is not a multiple of batch width %d\n", loc.nbatchGlobal, comm->numCommBatches());
+   loc.nbatch = loc.nbatchGlobal / comm->numCommBatches();
+   loc.kb0 = loc.nbatchGlobal * comm->commBatch();
+   pvErrorIf(loc.nxGlobal % comm->numCommColumns(), "Global width %d is not a multiple of the number of MPI columns %d\n", loc.nxGlobal, comm->numCommColumns());
+   loc.nx = loc.nxGlobal / comm->numCommColumns();
+   loc.kx0 = loc.nx * comm->commColumn();
+   pvErrorIf(loc.nyGlobal % comm->numCommRows(), "Global height %d is not a multiple of the number of MPI rows %d\n", loc.nyGlobal, comm->numCommRows());
+   loc.ny = loc.nyGlobal / comm->numCommRows();
+   loc.ky0 = loc.ny * comm->commRow();
+
+   int const localSize = loc.nbatch * loc.nx * loc.ny * loc.nf;
+   std::vector<float> correctData(localSize);
+   for (int k=0; k<localSize; k++) {
+      int kbatchGlobal = batchIndex(k, loc.nbatch, loc.nx, loc.ny, loc.nf) + loc.kb0;
+      int kxGlobal = kxPos(k, loc.nx, loc.ny, loc.nf) + loc.kx0;
+      int kyGlobal = kyPos(k, loc.nx, loc.ny, loc.nf) + loc.ky0;
+      int kf = featureIndex(k, loc.nx, loc.ny, loc.nf);
+      int kGlobal = kIndexBatch(kbatchGlobal, kxGlobal, kyGlobal, kf, loc.nbatchGlobal, loc.nxGlobal, loc.nyGlobal, loc.nf);
+      correctData.at(k) = (float) kGlobal;
+   }
+
+   // Initialize checkpointData as a vector with the same size as correctData.
+   // Need to make sure that checkpointData.data() never gets relocated, since the CheckpointEntryPvp's mDataPointer doesn't change with it.
+   std::vector<float> checkpointData(correctData.size());
+   PV::CheckpointEntryPvp<float> checkpointEntryPvp{"checkpointEntryPvpBatch", false/*not verifying writes*/, comm,
+         checkpointData.data(), checkpointData.size(), PV_FLOAT_TYPE, &loc, false/*not extended*/};
+
+   double const simTime = 10.0;
+   // Copy correct data into checkpoint data.
+   for (int k=0; k<localSize; k++) {
+      checkpointData.at(k) = correctData.at(k);
+   }
+   checkpointEntryPvp.write(directory, simTime);
+
+   // Data has now been checkpointed. Change the vector to make sure that checkpointRead is really modifying the data.
+   for (auto& a : checkpointData) {
+      a = -1.0f;
+   }
+
+   // Read the data back
+   double readTime = (double) (simTime==0);
+   pvAssert(simTime != readTime);
+   checkpointEntryPvp.read(directory, &readTime);
+
+   // Verify the read
+   pvErrorIf(readTime != simTime, "Read timestamp %f; expected %f.\n", readTime, simTime);
+   for (int k=0; k<localSize; k++) {
+      pvErrorIf(checkpointData.at(k)!=correctData.at(k), "testDataPvp failed: data at rank %d, index %d is %f, but should be %f\n",
+            comm->commRank(), k, (double) checkpointData.at(k), (double) correctData.at(k));
+   }
+   MPI_Barrier(comm->communicator());
+   pvInfo() << "testDataPvpBatch passed.\n";
+}

--- a/tests/CheckpointEntryTest/src/testPvpBatch.hpp
+++ b/tests/CheckpointEntryTest/src/testPvpBatch.hpp
@@ -1,0 +1,9 @@
+#ifndef TESTPVPBATCH_HPP_
+#define TESTPVPBATCH_HPP_
+
+#include "columns/Communicator.hpp"
+#include <string>
+
+void testPvpBatch(PV::Communicator * comm, std::string const& directory);
+
+#endif // TESTPVPBATCH_HPP_

--- a/tests/CheckpointEntryTest/src/testPvpExtended.cpp
+++ b/tests/CheckpointEntryTest/src/testPvpExtended.cpp
@@ -1,0 +1,75 @@
+#include "testPvpExtended.hpp"
+#include "io/CheckpointEntry.hpp"
+#include "utils/conversions.h"
+#include "utils/PVLog.hpp"
+
+void testPvpExtended(PV::Communicator * comm, std::string const& directory) {
+   PVLayerLoc loc;
+   loc.nbatchGlobal = comm->numCommBatches();
+   loc.nxGlobal = 16;
+   loc.nyGlobal = 4;
+   loc.nf = 4;
+   loc.halo.lt = 2;
+   loc.halo.rt = 2;
+   loc.halo.dn = 2;
+   loc.halo.up = 2;
+   loc.nbatch = 1;
+   loc.kb0 = comm->commBatch();
+   pvErrorIf(loc.nxGlobal % comm->numCommColumns(), "Global width %d is not a multiple of the number of MPI columns %d\n", loc.nxGlobal, comm->numCommColumns());
+   loc.nx = loc.nxGlobal / comm->numCommColumns();
+   loc.kx0 = loc.nx * comm->commColumn();
+   pvErrorIf(loc.nyGlobal % comm->numCommRows(), "Global height %d is not a multiple of the number of MPI rows %d\n", loc.nyGlobal, comm->numCommRows());
+   loc.ny = loc.nyGlobal / comm->numCommRows();
+   loc.ky0 = loc.ny * comm->commRow();
+
+   int const nxLocalExt = loc.nx + loc.halo.lt + loc.halo.rt;
+   int const nyLocalExt = loc.ny + loc.halo.dn + loc.halo.up;
+   int const nxGlobalExt = loc.nxGlobal + loc.halo.lt + loc.halo.rt;
+   int const nyGlobalExt = loc.nyGlobal + loc.halo.dn + loc.halo.up;
+   int const localExtendedSize = nxLocalExt * nyLocalExt * loc.nf;
+   std::vector<float> correctData(localExtendedSize);
+   for (int k=0; k<localExtendedSize; k++) {
+      int kxGlobalExt = kxPos(k, nxLocalExt, nyLocalExt, loc.nf) + loc.kx0;
+      int kyGlobalExt = kyPos(k, nxLocalExt, nyLocalExt, loc.nf) + loc.ky0;
+      int kf = featureIndex(k, nxLocalExt, nyLocalExt, loc.nf);
+      int kGlobal = kIndex(kxGlobalExt, kyGlobalExt, kf, nxGlobalExt, nyGlobalExt, loc.nf);
+      correctData.at(k) = (float) kGlobal;
+   }
+
+   // Initialize checkpointData as a vector with the same size as correctData.
+   // Need to make sure that checkpointData.data() never gets relocated, since the CheckpointEntryPvp's mDataPointer doesn't change with it.
+   std::vector<float> checkpointData(correctData.size());
+   PV::CheckpointEntryPvp<float> checkpointEntryPvp{"checkpointEntryPvpExtended", false/*not verifying writes*/, comm,
+         checkpointData.data(), checkpointData.size(), PV_FLOAT_TYPE, &loc, true/*extended*/};
+
+   double const simTime = 10.0;
+   // Copy correct data into checkpoint data.
+   for (int k=0; k<localExtendedSize; k++) {
+      checkpointData.at(k) = correctData.at(k);
+   }
+   checkpointEntryPvp.write(directory, simTime);
+
+   // Data has now been checkpointed. Change the vector to make sure that checkpointRead is really modifying the data.
+   // Note that we're changing the border region as well as the restricted region, even though the border region doesn't get saved.
+   for (auto& a : checkpointData) {
+      a = -1.0f;
+   }
+
+   // Read the data back
+   double readTime = (double) (simTime==0);
+   pvAssert(simTime != readTime);
+   checkpointEntryPvp.read(directory, &readTime);
+
+   // Verify the read, noting that checkpointWrite only saves the restricted portion and checkpointRead does not modify the extended portion.
+   pvErrorIf(readTime != simTime, "Read timestamp %f; expected %f.\n", readTime, simTime);
+   for (int k=0; k<localExtendedSize; k++) {
+      int kxGlobalExt = kxPos(k, nxLocalExt, nyLocalExt, loc.nf) + loc.kx0;
+      int kyGlobalExt = kyPos(k, nxLocalExt, nyLocalExt, loc.nf) + loc.ky0;
+      bool inBorder = kxGlobalExt < loc.halo.lt || kxGlobalExt >= loc.nxGlobal + loc.halo.lt || kyGlobalExt < loc.halo.up || kyGlobalExt >= loc.nyGlobal + loc.halo.up;
+      float correctValue = inBorder ? -1.0f : correctData.at(k);
+      pvErrorIf(checkpointData.at(k)!=correctValue, "testDataPvp failed: data at rank %d, index %d is %f, but should be %f\n",
+            comm->commRank(), k, (double) checkpointData.at(k), (double) correctValue);
+   }
+   MPI_Barrier(comm->communicator());
+   pvInfo() << "testDataPvpRestricted passed.\n";
+}

--- a/tests/CheckpointEntryTest/src/testPvpExtended.hpp
+++ b/tests/CheckpointEntryTest/src/testPvpExtended.hpp
@@ -1,0 +1,9 @@
+#ifndef TESTPVPEXTENDED_HPP_
+#define TESTPVPEXTENDED_HPP_
+
+#include "columns/Communicator.hpp"
+#include <string>
+
+void testPvpExtended(PV::Communicator * comm, std::string const& directory);
+
+#endif // TESTPVPEXTENDED_HPP_

--- a/tests/CheckpointEntryTest/src/testPvpRestricted.cpp
+++ b/tests/CheckpointEntryTest/src/testPvpRestricted.cpp
@@ -1,0 +1,65 @@
+#include "testPvpRestricted.hpp"
+#include "io/CheckpointEntry.hpp"
+#include "utils/conversions.h"
+
+void testPvpRestricted(PV::Communicator * comm, std::string const& directory) {
+   PVLayerLoc loc;
+   loc.nbatchGlobal = comm->numCommBatches();
+   loc.nxGlobal = 16;
+   loc.nyGlobal = 4;
+   loc.nf = 4;
+   loc.halo.lt = 0;
+   loc.halo.rt = 0;
+   loc.halo.dn = 0;
+   loc.halo.up = 0;
+   loc.nbatch = 1;
+   loc.kb0 = comm->commBatch();
+   pvErrorIf(loc.nxGlobal % comm->numCommColumns(), "Global width %d is not a multiple of the number of MPI columns %d\n", loc.nxGlobal, comm->numCommColumns());
+   loc.nx = loc.nxGlobal / comm->numCommColumns();
+   loc.kx0 = loc.nx * comm->commColumn();
+   pvErrorIf(loc.nyGlobal % comm->numCommRows(), "Global height %d is not a multiple of the number of MPI rows %d\n", loc.nyGlobal, comm->numCommRows());
+   loc.ny = loc.nyGlobal / comm->numCommRows();
+   loc.ky0 = loc.ny * comm->commRow();
+
+   int const localSize = loc.nx * loc.ny * loc.nf;
+   std::vector<float> correctData(localSize);
+   for (int k=0; k<localSize; k++) {
+      int kxGlobal = kxPos(k, loc.nx, loc.ny, loc.nf) + loc.kx0;
+      int kyGlobal = kyPos(k, loc.nx, loc.ny, loc.nf) + loc.ky0;
+      int kf = featureIndex(k, loc.nx, loc.ny, loc.nf);
+      int kGlobal = kIndex(kxGlobal, kyGlobal, kf, loc.nxGlobal, loc.nyGlobal, loc.nf);
+      correctData.at(k) = (float) kGlobal;
+   }
+
+   // Initialize checkpointData as a vector with the same size as correctData.
+   // Need to make sure that checkpointData.data() never gets relocated, since the CheckpointEntryPvp's mDataPointer doesn't change with it.
+   std::vector<float> checkpointData(correctData.size());
+   PV::CheckpointEntryPvp<float> checkpointEntryPvp{"checkpointEntryPvpRestricted", false/*not verifying writes*/, comm,
+         checkpointData.data(), checkpointData.size(), PV_FLOAT_TYPE, &loc, false/*not extended*/};
+
+   double const simTime = 10.0;
+   // Copy correct data into checkpoint data.
+   for (int k=0; k<localSize; k++) {
+      checkpointData.at(k) = correctData.at(k);
+   }
+   checkpointEntryPvp.write(directory, simTime);
+
+   // Data has now been checkpointed. Change the vector to make sure that checkpointRead is really modifying the data.
+   for (auto& a : checkpointData) {
+      a = -1.0f;
+   }
+
+   // Read the data back
+   double readTime = (double) (simTime==0);
+   pvAssert(simTime != readTime);
+   checkpointEntryPvp.read(directory, &readTime);
+
+   // Verify the read
+   pvErrorIf(readTime != simTime, "Read timestamp %f; expected %f.\n", readTime, simTime);
+   for (int k=0; k<localSize; k++) {
+      pvErrorIf(checkpointData.at(k)!=correctData.at(k), "testDataPvp failed: data at rank %d, index %d is %f, but should be %f\n",
+            comm->commRank(), k, (double) checkpointData.at(k), (double) correctData.at(k));
+   }
+   MPI_Barrier(comm->communicator());
+   pvInfo() << "testDataPvpRestricted passed.\n";
+}

--- a/tests/CheckpointEntryTest/src/testPvpRestricted.hpp
+++ b/tests/CheckpointEntryTest/src/testPvpRestricted.hpp
@@ -1,0 +1,9 @@
+#ifndef TESTPVPRESTRICTED_HPP_
+#define TESTPVPRESTRICTED_HPP_
+
+#include "columns/Communicator.hpp"
+#include <string>
+
+void testPvpRestricted(PV::Communicator * comm, std::string const& directory);
+
+#endif // TESTPVPRESTRICTED_HPP_

--- a/tests/test_cocirc/src/test_cocirc.cpp
+++ b/tests/test_cocirc/src/test_cocirc.cpp
@@ -50,7 +50,7 @@ int main(int argc, char * argv[])
    PV::HyPerConn * cCocirc2to1 = new HyPerConn("test_cocirc cocircconn 2 to 1", hc);
    pvErrorIf(!(cCocirc2to1), "Test failed.\n");
 
-   hc->ensureDirExists(hc->getOutputPath());
+   ensureDirExists(hc->getCommunicator(), hc->getOutputPath());
    
    auto objectMap = hc->copyObjectMap();
    auto commMessagePtr = std::make_shared<CommunicateInitInfoMessage>(*objectMap);

--- a/tests/test_datatypes/src/test_datatypes.cpp
+++ b/tests/test_datatypes/src/test_datatypes.cpp
@@ -29,18 +29,6 @@ int main(int argc, char * argv[])
    PV::PV_Init* initObj = new PV::PV_Init(&argc, &argv, true/*allowUnrecognizedArguments*/);
    PV::Communicator * comm = initObj->getCommunicator();
    
-   // Handling of requireReturn copied from HyPerCol::initialize, since this test doesn't create a HyPerCol.
-   if (initObj->getRequireReturnFlag()) {
-      if (comm->commRank()==0) {
-         fprintf(stdout, "Hit enter to begin! ");
-         fflush(stdout);
-         int charhit = -1;
-         while(charhit != '\n') {
-            charhit = getc(stdin);
-         }
-      }
-      MPI_Barrier(comm->globalCommunicator());
-   }
    int err = 0;
    PVLayerLoc loc;
 

--- a/tests/test_gauss2d/src/test_gauss2d.cpp
+++ b/tests/test_gauss2d/src/test_gauss2d.cpp
@@ -72,7 +72,7 @@ int main(int argc, char * argv[])
    
    int status = 0;
 
-   hc->ensureDirExists(hc->getOutputPath());
+   ensureDirExists(hc->getCommunicator(), hc->getOutputPath());
 
    auto objectMap = hc->copyObjectMap();
    auto commMessagePtr = std::make_shared<CommunicateInitInfoMessage>(*objectMap);

--- a/tests/test_post_weights/src/test_post_weights.cpp
+++ b/tests/test_post_weights/src/test_post_weights.cpp
@@ -55,7 +55,7 @@ int main(int argc, char * argv[])
    // But we still need to allocate the weights, so we call the
    // layers' and connections' communicate and allocate methods externally.
 
-   hc->ensureDirExists(hc->getOutputPath());
+   ensureDirExists(hc->getCommunicator(), hc->getOutputPath());
 
    auto objectMap = hc->copyObjectMap();
    auto commMessagePtr = std::make_shared<CommunicateInitInfoMessage>(*objectMap);


### PR DESCRIPTION
This pull requests adds a CheckpointEntry class with three virtual methods: write, read, and remove. There are two subclasses: CheckpointEntryData, which writes raw data as a .bin file and a human-readable version of the data as a .txt file; and CheckpointEntryPvp, which writes a buffer as a nonsparse activity pvp file.

There is also a new test, tests/CheckpointEntry. It requires CheckpointEntry, PV_Arguments, and Communicator but does not require PV_Init, HyPerCol, or any layers or columns.

The remainder of the code does not yet make use of the CheckpointEntry class.  After this pull request is approved, checkpointWrite and checkpointRead methods should make use of it whereever possible.  A CheckpointEntry class for writing weight files also needs to be added.
