### PR TITLE
Added FilenameParsingGroundTruthLayer phase error check

### DIFF
--- a/src/layers/FilenameParsingGroundTruthLayer.cpp
+++ b/src/layers/FilenameParsingGroundTruthLayer.cpp
@@ -61,11 +61,17 @@ void FilenameParsingGroundTruthLayer::ioParam_classes(enum ParamsIOFlag ioFlag) 
 
 int FilenameParsingGroundTruthLayer::communicateInitInfo() {
    mInputLayer = dynamic_cast<InputLayer *>(parent->getLayerFromName(mInputLayerName));
-   pvErrorIf(
-         mInputLayer == nullptr && parent->columnId() == 0,
-         "%s: movieLayerName \"%s\" is not a layer in the HyPerCol.\n",
+   pvErrorIf(mInputLayer == nullptr && parent->columnId() == 0,
+         "%s: inputLayerName \"%s\" is not a layer in the HyPerCol.\n",
          getDescription_c(),
          mInputLayerName);
+   pvErrorIf(mInputLayer->getPhase() >= getPhase(),
+         "%s: The phase of layer %s (%d) must be less than the phase of the "
+         "FilenameParsingGroundTruthLayer (%d)\n",
+         getName(),
+         mInputLayerName,
+         mInputLayer->getPhase(),
+         getPhase());
    return PV_SUCCESS;
 }
 


### PR DESCRIPTION
FilenameParsingGroundTruthLayer checks the value of inputLayerName's getFileName method to determine its value. However, if the phase of FilenameParsingGroundTruthLayer is greater than its Input Layer's, this value will have advanced to the next file, causing an off by one error. This pull request adds a check to FilenameParsingGroundTruthLayer's communicateInitInfo that ensures its phase is lower than the phase of its Input Layer. If it is not, it exits with a descriptive error indicating the issue. This should help prevent wasted time from off by one errors in the future.
