### PR TITLE
Clang warning fix

### DIFF
--- a/src/columns/PV_Init.cpp
+++ b/src/columns/PV_Init.cpp
@@ -183,6 +183,7 @@ int PV_Init::setLogFile(char const *log_file, bool appendFlag) {
    arguments->setLogFile(log_file);
    initLogFile(appendFlag);
    printInitMessage();
+   return PV_SUCCESS;
 }
 
 int PV_Init::setMPIConfiguration(int rows, int columns, int batchWidth) {

--- a/src/connections/HyPerConn.hpp
+++ b/src/connections/HyPerConn.hpp
@@ -80,17 +80,17 @@ class HyPerConn : public BaseConnection {
          InitWeights *weightInitializer,
          NormalizeBase *weightNormalizer); // Deprecated June 22, 2016.
    virtual ~HyPerConn();
-   virtual int communicateInitInfo();
-   virtual int allocateDataStructures();
+   virtual int communicateInitInfo() override;
+   virtual int allocateDataStructures() override;
 
-   virtual int checkpointRead(const char *cpDir, double *timef);
-   virtual int checkpointWrite(const char *cpDir);
-   virtual int insertProbe(BaseConnectionProbe *p);
-   int outputProbeParams();
-   virtual int outputState(double time, bool last = false);
-   int updateState(double time, double dt);
-   virtual int finalizeUpdate(double timed, double dt);
-   virtual bool needUpdate(double time, double dt);
+   virtual int checkpointRead(const char *cpDir, double *timef) override;
+   virtual int checkpointWrite(const char *cpDir) override;
+   virtual int insertProbe(BaseConnectionProbe *p) override;
+   int outputProbeParams() override;
+   virtual int outputState(double time, bool last = false) override;
+   int updateState(double time, double dt) override;
+   virtual int finalizeUpdate(double timed, double dt) override;
+   virtual bool needUpdate(double time, double dt) override;
    virtual int updateInd_dW(int arbor_ID, int batch_ID, int kExt);
    virtual double computeNewWeightUpdateTime(double time, double currentUpdateTime);
    virtual int writeWeights(double timed, bool last = false);
@@ -114,7 +114,7 @@ class HyPerConn : public BaseConnection {
    /**
     * Uses presynaptic layer's activity to modify the postsynaptic GSyn or thread_gSyn
     */
-   virtual int deliver();
+   virtual int deliver() override;
    virtual void deliverOnePreNeuronActivity(
          int patchIndex,
          int arbor,
@@ -584,7 +584,7 @@ class HyPerConn : public BaseConnection {
    virtual int setWeightInitializer(); // Note: no longer deprecated.
    virtual InitWeights *createInitWeightsObject(const char *weightInitTypeStr);
    int setWeightNormalizer(); // Note: no longer deprecated.
-   virtual int ioParamsFillGroup(enum ParamsIOFlag ioFlag);
+   virtual int ioParamsFillGroup(enum ParamsIOFlag ioFlag) override;
 
    /**
     * List of parameters needed from the HyPerConn class
@@ -597,7 +597,7 @@ class HyPerConn : public BaseConnection {
     * @details Channels can be -1 for no update, or >= 0 for channel number. <br />
     * 0 is excitatory, 1 is inhibitory
     */
-   virtual void ioParam_channelCode(enum ParamsIOFlag ioFlag);
+   virtual void ioParam_channelCode(enum ParamsIOFlag ioFlag) override;
 
    /**
     * @brief sharedWeights: Defines if the HyPerConn uses shared weights (kernelConn)
@@ -881,10 +881,11 @@ class HyPerConn : public BaseConnection {
          size_t **inAPostOffset,
          int arborId);
    virtual int adjustAxonalArbors(int arborId);
-   virtual int readStateFromCheckpoint(const char *cpDir, double *timeptr);
+   virtual int readStateFromCheckpoint(const char *cpDir, double *timeptr) override;
    virtual int readWeightsFromCheckpoint(const char *cpDir, double *timeptr);
    int checkpointFilename(char *cpFilename, int size, const char *cpDir);
-   virtual int setInitialValues(); // returns PV_SUCCESS if successful, or PV_POSTPONE if it needs
+   virtual int
+   setInitialValues() override; // returns PV_SUCCESS if successful, or PV_POSTPONE if it needs
    // to wait on other objects (e.g. TransposeConn has to wait for
    // original conn)
 

--- a/src/connections/PoolingConn.hpp
+++ b/src/connections/PoolingConn.hpp
@@ -23,12 +23,12 @@ class PoolingConn : public HyPerConn {
    PoolingConn();
    PoolingConn(const char *name, HyPerCol *hc);
    virtual ~PoolingConn();
-   virtual int communicateInitInfo();
-   virtual int allocateDataStructures();
+   virtual int communicateInitInfo() override;
+   virtual int allocateDataStructures() override;
    virtual int checkpointRead(const char *cpDir, double *timef) override { return PV_SUCCESS; }
    virtual int checkpointWrite(const char *cpDir) override { return PV_SUCCESS; }
-   virtual float minWeight(int arborId = 0);
-   virtual float maxWeight(int arborId = 0);
+   virtual float minWeight(int arborId = 0) override;
+   virtual float maxWeight(int arborId = 0) override;
    virtual int finalizeUpdate(double time, double dt) override { return PV_SUCCESS; }
    PoolingIndexLayer *getPostIndexLayer() { return postIndexLayer; }
    bool needPostIndex() { return needPostIndexLayer; }
@@ -41,10 +41,10 @@ class PoolingConn : public HyPerConn {
          HyPerCol *hc,
          InitWeights *weightInitializer,
          NormalizeBase *weightNormalizer);
-   virtual int ioParamsFillGroup(enum ParamsIOFlag ioFlag);
-   void ioParam_plasticityFlag(enum ParamsIOFlag ioFlag);
-   void ioParam_weightInitType(enum ParamsIOFlag ioFlag);
-   void ioParam_pvpatchAccumulateType(enum ParamsIOFlag ioFlag);
+   virtual int ioParamsFillGroup(enum ParamsIOFlag ioFlag) override;
+   void ioParam_plasticityFlag(enum ParamsIOFlag ioFlag) override;
+   void ioParam_weightInitType(enum ParamsIOFlag ioFlag) override;
+   void ioParam_pvpatchAccumulateType(enum ParamsIOFlag ioFlag) override;
    void ioParam_needPostIndexLayer(enum ParamsIOFlag ioFlag);
    void ioParam_postIndexLayerName(enum ParamsIOFlag ioFlag);
 
@@ -52,18 +52,18 @@ class PoolingConn : public HyPerConn {
     * @brief PoolingConn does not have weights to write, and does not use
     * writeStep
     */
-   void ioParam_writeStep(enum ParamsIOFlag ioFlag);
+   void ioParam_writeStep(enum ParamsIOFlag ioFlag) override;
    /**
     * @brief PoolingConn does not have weights to write, and does not use
     * writeCompressedCheckpoints
     */
-   void ioParam_writeCompressedCheckpoints(enum ParamsIOFlag ioFlag);
+   void ioParam_writeCompressedCheckpoints(enum ParamsIOFlag ioFlag) override;
 
    /**
     * @brief PoolingConn does not have weights to normalize, and does not use
     * normalizeMethod
     */
-   void ioParam_normalizeMethod(enum ParamsIOFlag ioFlag);
+   void ioParam_normalizeMethod(enum ParamsIOFlag ioFlag) override;
 #ifdef PV_USE_CUDA
    virtual int allocatePostDeviceWeights() override { return PV_SUCCESS; }
    virtual int allocateDeviceWeights() override { return PV_SUCCESS; }
@@ -73,7 +73,7 @@ class PoolingConn : public HyPerConn {
    int initializeDeliverKernelArgs();
 #endif // PV_USE_CUDA
    virtual int setInitialValues() override;
-   virtual int constructWeights();
+   virtual int constructWeights() override;
 
    virtual int deliverPresynapticPerspective(PVLayerCube const *activity, int arborID) override;
    virtual int deliverPostsynapticPerspective(PVLayerCube const *activity, int arborID) override;

--- a/src/connections/TransposePoolingConn.hpp
+++ b/src/connections/TransposePoolingConn.hpp
@@ -44,21 +44,21 @@ class TransposePoolingConn : public HyPerConn {
    TransposePoolingConn();
    TransposePoolingConn(const char *name, HyPerCol *hc);
    virtual ~TransposePoolingConn();
-   virtual int communicateInitInfo();
-   virtual int allocateDataStructures();
+   virtual int communicateInitInfo() override;
+   virtual int allocateDataStructures() override;
    inline PoolingConn *getOriginalConn() { return mOriginalConn; }
 
-   virtual bool needUpdate(double timed, double dt);
-   virtual int updateState(double time, double dt);
-   virtual double computeNewWeightUpdateTime(double time, double currentUpdateTime);
-   virtual int checkpointRead(const char *cpDir, double *timeptr);
-   virtual int checkpointWrite(const char *cpDir);
+   virtual bool needUpdate(double timed, double dt) override;
+   virtual int updateState(double time, double dt) override;
+   virtual double computeNewWeightUpdateTime(double time, double currentUpdateTime) override;
+   virtual int checkpointRead(const char *cpDir, double *timeptr) override;
+   virtual int checkpointWrite(const char *cpDir) override;
 
   protected:
    int initialize_base();
    int initialize(const char *name, HyPerCol *hc);
-   virtual int ioParamsFillGroup(enum ParamsIOFlag ioFlag);
-   virtual int setPatchSize();
+   virtual int ioParamsFillGroup(enum ParamsIOFlag ioFlag) override;
+   virtual int setPatchSize() override;
 #ifdef PV_USE_CUDA
    virtual int allocatePostDeviceWeights() override { return PV_SUCCESS; }
    virtual int allocateDeviceWeights() override { return PV_SUCCESS; }
@@ -67,10 +67,10 @@ class TransposePoolingConn : public HyPerConn {
    virtual void updateDeviceWeights() override {}
    int initializeTransposePoolingDeliverKernelArgs();
 #endif // PV_USE_CUDA
-   virtual int setInitialValues();
-   virtual int constructWeights();
-   virtual int deliverPresynapticPerspective(PVLayerCube const *activity, int arborID);
-   virtual int deliverPostsynapticPerspective(PVLayerCube const *activity, int arborID);
+   virtual int setInitialValues() override;
+   virtual int constructWeights() override;
+   virtual int deliverPresynapticPerspective(PVLayerCube const *activity, int arborID) override;
+   virtual int deliverPostsynapticPerspective(PVLayerCube const *activity, int arborID) override;
 #ifdef PV_USE_CUDA
    virtual int deliverPresynapticPerspectiveGPU(PVLayerCube const *activity, int arborID);
    virtual int deliverPostsynapticPerspectiveGPU(PVLayerCube const *activity, int arborID);

--- a/src/io/CheckpointEntryDataStore.hpp
+++ b/src/io/CheckpointEntryDataStore.hpp
@@ -37,7 +37,7 @@ class CheckpointEntryDataStore : public CheckpointEntry {
    virtual void write(std::string const &checkpointDirectory, double simTime, bool verifyWritesFlag)
          const override;
    virtual void read(std::string const &checkpointDirectory, double *simTimePtr) const override;
-   virtual void remove(std::string const &checkpointDirectory) const;
+   virtual void remove(std::string const &checkpointDirectory) const override;
 
   protected:
    void initialize(DataStore *dataStore, PVLayerLoc const *layerLoc);

--- a/src/layers/CloneVLayer.hpp
+++ b/src/layers/CloneVLayer.hpp
@@ -15,26 +15,27 @@ namespace PV {
 class CloneVLayer : public PV::HyPerLayer {
   public:
    CloneVLayer(const char *name, HyPerCol *hc);
-   virtual int communicateInitInfo();
-   virtual int allocateDataStructures();
-   virtual int requireChannel(int channelNeeded, int *numChannelsResult);
-   virtual int allocateGSyn();
-   virtual int requireMarginWidth(int marginWidthNeeded, int *marginWidthResult, char axis);
-   virtual bool activityIsSpiking() { return false; }
+   virtual int communicateInitInfo() override;
+   virtual int allocateDataStructures() override;
+   virtual int requireChannel(int channelNeeded, int *numChannelsResult) override;
+   virtual int allocateGSyn() override;
+   virtual int
+   requireMarginWidth(int marginWidthNeeded, int *marginWidthResult, char axis) override;
+   virtual bool activityIsSpiking() override { return false; }
    HyPerLayer *getOriginalLayer() { return originalLayer; }
    virtual ~CloneVLayer();
 
   protected:
    CloneVLayer();
    int initialize(const char *name, HyPerCol *hc);
-   virtual int ioParamsFillGroup(enum ParamsIOFlag ioFlag);
+   virtual int ioParamsFillGroup(enum ParamsIOFlag ioFlag) override;
    virtual void ioParam_originalLayerName(enum ParamsIOFlag ioFlag);
-   virtual void ioParam_InitVType(enum ParamsIOFlag ioFlag);
-   virtual int allocateV();
+   virtual void ioParam_InitVType(enum ParamsIOFlag ioFlag) override;
+   virtual int allocateV() override;
    virtual int registerData(Secretary *secretary, std::string const &objName) override;
-   virtual int initializeV();
-   virtual int readVFromCheckpoint(const char *cpDir, double *timeptr);
-   virtual int updateState(double timed, double dt);
+   virtual int initializeV() override;
+   virtual int readVFromCheckpoint(const char *cpDir, double *timeptr) override;
+   virtual int updateState(double timed, double dt) override;
 
   private:
    int initialize_base();

--- a/src/layers/HyPerLCALayer.hpp
+++ b/src/layers/HyPerLCALayer.hpp
@@ -17,15 +17,15 @@ class HyPerLCALayer : public PV::ANNLayer {
   public:
    HyPerLCALayer(const char *name, HyPerCol *hc);
    virtual ~HyPerLCALayer();
-   virtual double getDeltaUpdateTime();
-   virtual int requireChannel(int channelNeeded, int *numChannelsResult);
+   virtual double getDeltaUpdateTime() override;
+   virtual int requireChannel(int channelNeeded, int *numChannelsResult) override;
 
   protected:
    HyPerLCALayer();
    int initialize(const char *name, HyPerCol *hc);
    virtual int communicateInitInfo() override;
    virtual int allocateDataStructures() override;
-   virtual int ioParamsFillGroup(enum ParamsIOFlag ioFlag);
+   virtual int ioParamsFillGroup(enum ParamsIOFlag ioFlag) override;
 
    /**
     * List of parameters needed from the HyPerLCALayer class
@@ -52,13 +52,15 @@ class HyPerLCALayer : public PV::ANNLayer {
    virtual void ioParam_adaptiveTimeScaleProbe(enum ParamsIOFlag ioFlag);
    /** @} */
 
-   virtual int updateState(double time, double dt);
+   virtual int updateState(double time, double dt) override;
 
 #ifdef PV_USE_CUDA
    virtual int updateStateGpu(double time, double dt);
 #endif
 
-   virtual float getChannelTimeConst(enum ChannelType channel_type) { return timeConstantTau; };
+   virtual float getChannelTimeConst(enum ChannelType channel_type) override {
+      return timeConstantTau;
+   };
 
 #ifdef PV_USE_CUDA
    virtual int allocateUpdateKernel();

--- a/src/layers/ImageFromMemoryBuffer.cpp
+++ b/src/layers/ImageFromMemoryBuffer.cpp
@@ -35,6 +35,7 @@ int ImageFromMemoryBuffer::initialize(char const *name, HyPerCol *hc) {
       MPI_Barrier(parent->getCommunicator()->communicator());
       exit(EXIT_FAILURE);
    }
+   return PV_SUCCESS;
 }
 
 int ImageFromMemoryBuffer::ioParamsFillGroup(enum ParamsIOFlag ioFlag) {

--- a/src/layers/InputLayer.hpp
+++ b/src/layers/InputLayer.hpp
@@ -57,11 +57,11 @@ class InputLayer : public HyPerLayer {
    virtual void ioParam_padValue(enum ParamsIOFlag ioFlag);
 
    // initVType: InputLayers do not have a V, do not set
-   virtual void ioParam_InitVType(enum ParamsIOFlag ioFlag);
+   virtual void ioParam_InitVType(enum ParamsIOFlag ioFlag) override;
 
    // triggerLayerName: InputLayer and derived classes do not use triggering, and always set
    // triggerLayerName to NULL.
-   virtual void ioParam_triggerLayerName(enum ParamsIOFlag ioFlag);
+   virtual void ioParam_triggerLayerName(enum ParamsIOFlag ioFlag) override;
 
    // displayPeriod: the number of timesteps each input is displayed before switching to the next.
    // If this is <= 0 or inputPath does not end in .txt, assumes the input is a single file and will
@@ -113,12 +113,12 @@ class InputLayer : public HyPerLayer {
    // This method post processes the activity buffer after a file is loaded and scattered.
    // Overload this to add additional post process steps in subclasses.
    virtual int postProcess(double timef, double dt);
-   virtual int allocateV();
-   virtual int initializeV();
-   virtual int initializeActivity();
-   virtual int ioParamsFillGroup(enum ParamsIOFlag ioFlag);
+   virtual int allocateV() override;
+   virtual int initializeV() override;
+   virtual int initializeActivity() override;
+   virtual int ioParamsFillGroup(enum ParamsIOFlag ioFlag) override;
    virtual int registerData(Secretary *secretary, std::string const &objName) override;
-   virtual double getDeltaUpdateTime();
+   virtual double getDeltaUpdateTime() override;
 
    // Method that signals when to load the next file.
    // Can be overridden for different file list logic in subclasses.
@@ -134,10 +134,10 @@ class InputLayer : public HyPerLayer {
    InputLayer(const char *name, HyPerCol *hc);
    virtual ~InputLayer();
 
-   virtual int requireChannel(int channelNeeded, int *numChannelsResult);
-   virtual int allocateDataStructures();
-   virtual int updateState(double time, double dt);
-   virtual bool activityIsSpiking() { return false; }
+   virtual int requireChannel(int channelNeeded, int *numChannelsResult) override;
+   virtual int allocateDataStructures() override;
+   virtual int updateState(double time, double dt) override;
+   virtual bool activityIsSpiking() override { return false; }
    void exchange();
    int getDisplayPeriod() { return mDisplayPeriod; }
    int getStartIndex(int batchIndex) { return mStartFrameIndex.at(batchIndex); }

--- a/src/layers/LCALIFLayer.hpp
+++ b/src/layers/LCALIFLayer.hpp
@@ -18,8 +18,8 @@ class LCALIFLayer : public PV::LIFGap {
   public:
    LCALIFLayer(const char *name, HyPerCol *hc); // The constructor called by other methods
    virtual ~LCALIFLayer();
-   virtual int allocateDataStructures();
-   virtual int updateState(double timef, double dt);
+   virtual int allocateDataStructures() override;
+   virtual int updateState(double timef, double dt) override;
    int findFlag(int numMatrixCol, int numMatrixRow);
 
    inline float getTargetRate() { return targetRateHz; }
@@ -31,17 +31,17 @@ class LCALIFLayer : public PV::LIFGap {
   protected:
    LCALIFLayer();
    int initialize(const char *name, HyPerCol *hc, const char *kernel_name);
-   virtual int ioParamsFillGroup(enum ParamsIOFlag ioFlag);
+   virtual int ioParamsFillGroup(enum ParamsIOFlag ioFlag) override;
    virtual void ioParam_tauTHR(enum ParamsIOFlag ioFlag);
    virtual void ioParam_targetRate(enum ParamsIOFlag ioFlag);
    virtual void ioParam_normalizeInput(enum ParamsIOFlag ioFlag);
    virtual void ioParam_Vscale(enum ParamsIOFlag ioFlag);
    virtual int registerData(Secretary *secretary, std::string const &objName) override;
-   virtual int readStateFromCheckpoint(const char *cpDir, double *timeptr);
+   virtual int readStateFromCheckpoint(const char *cpDir, double *timeptr) override;
    virtual int read_integratedSpikeCountFromCheckpoint(const char *cpDir, double *timeptr);
    virtual int readVadptFromCheckpoint(const char *cpDir, double *timeptr);
 
-   int allocateBuffers();
+   int allocateBuffers() override;
 
    pvdata_t *integratedSpikeCount; // plasticity decrement variable for postsynaptic layer
    pvdata_t *G_Norm; // Copy of GSyn[CHANNEL_NORM] to be written out during checkpointing

--- a/src/layers/LIF.hpp
+++ b/src/layers/LIF.hpp
@@ -55,23 +55,23 @@ class LIF : public PV::HyPerLayer {
    LIF(const char *name, HyPerCol *hc, int num_channels);
    virtual ~LIF();
 
-   virtual int communicateInitInfo();
-   virtual int allocateDataStructures();
+   virtual int communicateInitInfo() override;
+   virtual int allocateDataStructures() override;
    virtual int registerData(Secretary *secretary, std::string const &objName) override;
 
-   virtual int updateState(double time, double dt);
-   virtual int setActivity();
+   virtual int updateState(double time, double dt) override;
+   virtual int setActivity() override;
 
    pvdata_t *getVth() { return Vth; }
    virtual pvconductance_t *getConductance(ChannelType ch) {
       return ch < this->numChannels ? G_E + ch * getNumNeurons() : NULL;
    }
 
-   virtual float getChannelTimeConst(enum ChannelType channel_type);
+   virtual float getChannelTimeConst(enum ChannelType channel_type) override;
 
    virtual LIF_params *getLIFParams() { return &lParams; };
 
-   virtual bool activityIsSpiking() { return true; }
+   virtual bool activityIsSpiking() override { return true; }
 
   protected:
    LIF_params lParams;
@@ -87,7 +87,7 @@ class LIF : public PV::HyPerLayer {
   protected:
    LIF();
    int initialize(const char *name, HyPerCol *hc, const char *kernel_name);
-   virtual int ioParamsFillGroup(enum ParamsIOFlag ioFlag);
+   virtual int ioParamsFillGroup(enum ParamsIOFlag ioFlag) override;
    virtual void ioParam_Vrest(enum ParamsIOFlag ioFlag);
    virtual void ioParam_Vexc(enum ParamsIOFlag ioFlag);
    virtual void ioParam_Vinh(enum ParamsIOFlag ioFlag);
@@ -107,9 +107,9 @@ class LIF : public PV::HyPerLayer {
    virtual void ioParam_noiseFreqI(enum ParamsIOFlag ioFlag);
    virtual void ioParam_noiseFreqIB(enum ParamsIOFlag ioFlag);
    virtual void ioParam_method(enum ParamsIOFlag ioFlag);
-   virtual int allocateBuffers();
+   virtual int allocateBuffers() override;
    virtual int allocateConductances(int num_channels);
-   virtual int readStateFromCheckpoint(const char *cpDir, double *timeptr);
+   virtual int readStateFromCheckpoint(const char *cpDir, double *timeptr) override;
    virtual int readVthFromCheckpoint(const char *cpDir, double *timeptr);
    virtual int readG_EFromCheckpoint(const char *cpDir, double *timeptr);
    virtual int readG_IFromCheckpoint(const char *cpDir, double *timeptr);

--- a/src/layers/LIFGap.hpp
+++ b/src/layers/LIFGap.hpp
@@ -22,16 +22,16 @@ class LIFGap : public PV::LIF {
    LIFGap(const char *name, HyPerCol *hc);
    virtual ~LIFGap();
 
-   int virtual updateState(double time, double dt);
+   int virtual updateState(double time, double dt) override;
 
-   int virtual readStateFromCheckpoint(const char *cpDir, double *timeptr);
+   int virtual readStateFromCheckpoint(const char *cpDir, double *timeptr) override;
 
    const pvgsyndata_t *getGapStrength() { return gapStrength; }
 
   protected:
    LIFGap();
    int initialize(const char *name, HyPerCol *hc, const char *kernel_name);
-   virtual int allocateConductances(int num_channels);
+   virtual int allocateConductances(int num_channels) override;
    virtual int registerData(Secretary *secretary, std::string const &objName) override;
    virtual int readGapStrengthFromCheckpoint(const char *cpDir, double *timeptr);
 

--- a/src/layers/MomentumLCALayer.hpp
+++ b/src/layers/MomentumLCALayer.hpp
@@ -20,8 +20,8 @@ class MomentumLCALayer : public PV::HyPerLCALayer {
   protected:
    MomentumLCALayer();
    int initialize(const char *name, HyPerCol *hc);
-   virtual int allocateDataStructures();
-   virtual int ioParamsFillGroup(enum ParamsIOFlag ioFlag);
+   virtual int allocateDataStructures() override;
+   virtual int ioParamsFillGroup(enum ParamsIOFlag ioFlag) override;
 
    /**
     * List of parameters needed from the MomentumLCALayer class
@@ -37,7 +37,7 @@ class MomentumLCALayer : public PV::HyPerLCALayer {
    virtual int processCheckpointRead() override;
    virtual int prepareCheckpointWrite() override;
 
-   virtual int updateState(double time, double dt);
+   virtual int updateState(double time, double dt) override;
 
 #ifdef PV_USE_CUDA
    virtual int updateStateGpu(double time, double dt);

--- a/src/probes/AdaptiveTimeScaleProbe.hpp
+++ b/src/probes/AdaptiveTimeScaleProbe.hpp
@@ -34,7 +34,7 @@ class AdaptiveTimeScaleProbe : public ColProbe {
     * The target probe's values are used as the input to compute the adaptive
     * timesteps.
     */
-   virtual void ioParam_targetName(enum ParamsIOFlag ioFlag);
+   virtual void ioParam_targetName(enum ParamsIOFlag ioFlag) override;
 
    /**
     * @brief baseMax: Specifies the initial maximum timescale allowed.
@@ -95,13 +95,13 @@ class AdaptiveTimeScaleProbe : public ColProbe {
   protected:
    AdaptiveTimeScaleProbe();
    int initialize(char const *name, HyPerCol *hc);
-   int ioParamsFillGroup(enum ParamsIOFlag ioFlag);
+   int ioParamsFillGroup(enum ParamsIOFlag ioFlag) override;
    int respondAdaptTimestep(AdaptTimestepMessage const *message);
    bool needRecalc(double timeValue) override {
       return parent->simulationTime() > getLastUpdateTime();
    }
    double referenceUpdateTime() const override { return parent->simulationTime(); }
-   int calcValues(double timeValue);
+   int calcValues(double timeValue) override;
    virtual bool needUpdate(double timeValue, double dt) override { return true; }
 
   protected:

--- a/src/probes/StatsProbe.hpp
+++ b/src/probes/StatsProbe.hpp
@@ -17,13 +17,13 @@ class StatsProbe : public PV::LayerProbe {
    StatsProbe(const char *probeName, HyPerCol *hc);
    virtual ~StatsProbe();
 
-   virtual int outputState(double timef);
+   virtual int outputState(double timef) override;
    virtual int checkpointTimers(PrintStream &timerstream);
 
   protected:
    StatsProbe();
    int initStatsProbe(const char *probeName, HyPerCol *hc);
-   virtual int ioParamsFillGroup(enum ParamsIOFlag ioFlag);
+   virtual int ioParamsFillGroup(enum ParamsIOFlag ioFlag) override;
    virtual void ioParam_buffer(enum ParamsIOFlag ioFlag);
    virtual void ioParam_nnzThreshold(enum ParamsIOFlag ioFlag);
    void requireType(PVBufType requiredType);
@@ -36,7 +36,7 @@ class StatsProbe : public PV::LayerProbe {
     * getValues-friendly
     * probes.
     */
-   virtual int initNumValues();
+   virtual int initNumValues() override;
 
    virtual int registerData(Secretary *secretary, std::string const &objName) override;
 
@@ -45,14 +45,14 @@ class StatsProbe : public PV::LayerProbe {
     * and getValue methods
     * should not be used).
     */
-   virtual bool needRecalc(double timevalue) { return false; }
+   virtual bool needRecalc(double timevalue) override { return false; }
 
    /**
     * Implements calcValues() for StatsProbe to always fail (getValues and
     * getValue methods should
     * not be used).
     */
-   virtual int calcValues(double timevalue) { return PV_FAILURE; }
+   virtual int calcValues(double timevalue) override { return PV_FAILURE; }
 
    // Member variables
    PVBufType type;

--- a/tests/DryRunFlagTest/src/DryRunFlagTest.cpp
+++ b/tests/DryRunFlagTest/src/DryRunFlagTest.cpp
@@ -89,7 +89,7 @@ void compareParamsFiles(char const *paramsFile1, char const *paramsFile2, PV::Co
    // create a map between groups in paramsFile1 and those in paramsFile2.
    std::map<PV::ParameterGroup *, PV::ParameterGroup *> parameterGroupMap;
    char const *groupName = nullptr;
-   for (int idx = 0; groupName = params1.groupNameFromIndex(idx); idx++) {
+   for (int idx = 0; (groupName = params1.groupNameFromIndex(idx))!=nullptr; idx++) {
       PV::ParameterGroup *g1 = params1.group(groupName);
       PV::ParameterGroup *g2 = params2.group(groupName);
       pvErrorIf(
@@ -100,7 +100,7 @@ void compareParamsFiles(char const *paramsFile1, char const *paramsFile2, PV::Co
             paramsFile2);
       parameterGroupMap.emplace(std::make_pair(g1, g2));
    }
-   for (int idx = 0; groupName = params2.groupNameFromIndex(idx); idx++) {
+   for (int idx = 0; (groupName = params2.groupNameFromIndex(idx))!=nullptr; idx++) {
       pvErrorIf(
             params1.group(groupName) == nullptr,
             "Group name \"%s\" is in \"%s\" but not in \"%s\".\n",

--- a/tests/DryRunFlagTest/src/DryRunFlagTest.cpp
+++ b/tests/DryRunFlagTest/src/DryRunFlagTest.cpp
@@ -89,7 +89,7 @@ void compareParamsFiles(char const *paramsFile1, char const *paramsFile2, PV::Co
    // create a map between groups in paramsFile1 and those in paramsFile2.
    std::map<PV::ParameterGroup *, PV::ParameterGroup *> parameterGroupMap;
    char const *groupName = nullptr;
-   for (int idx = 0; (groupName = params1.groupNameFromIndex(idx))!=nullptr; idx++) {
+   for (int idx = 0; (groupName = params1.groupNameFromIndex(idx)) != nullptr; idx++) {
       PV::ParameterGroup *g1 = params1.group(groupName);
       PV::ParameterGroup *g2 = params2.group(groupName);
       pvErrorIf(
@@ -100,7 +100,7 @@ void compareParamsFiles(char const *paramsFile1, char const *paramsFile2, PV::Co
             paramsFile2);
       parameterGroupMap.emplace(std::make_pair(g1, g2));
    }
-   for (int idx = 0; (groupName = params2.groupNameFromIndex(idx))!=nullptr; idx++) {
+   for (int idx = 0; (groupName = params2.groupNameFromIndex(idx)) != nullptr; idx++) {
       pvErrorIf(
             params1.group(groupName) == nullptr,
             "Group name \"%s\" is in \"%s\" but not in \"%s\".\n",


### PR DESCRIPTION
This pull request addresses many warnings produced by clang++ but not by g++. The vast majority of them are inconsistent missing overrides, but there are also a missing return value and some missing parentheses warnings.
