### PR TITLE
BufferUtilsPvp now stores PVP headers as a struct instead of a vector…

### DIFF
--- a/src/checkpointing/CheckpointEntryDataStore.cpp
+++ b/src/checkpointing/CheckpointEntryDataStore.cpp
@@ -61,13 +61,13 @@ void CheckpointEntryDataStore::read(std::string const &checkpointDirectory, doub
    if (getCommunicator()->commRank() == 0) {
       std::string path        = generatePath(checkpointDirectory, "pvp");
       fileStream              = new FileStream(path.c_str(), std::ios_base::in, false);
-      std::vector<int> header = BufferUtils::readHeader(*fileStream);
+      struct BufferUtils::ActivityHeader header = BufferUtils::readActivityHeader(*fileStream);
       pvErrorIf(
-            header.at(INDEX_NBANDS) != numBands,
+            header.nBands != numBands,
             "readDataStoreFromFile error reading \"%s\": delays*batchwidth in file is %d, "
             "but delays*batchwidth in layer is %d\n",
             path.c_str(),
-            header.at(INDEX_NBANDS),
+            header.nBands,
             numBands);
    }
    int const nxExtGlobal = mLayerLoc->nxGlobal + mLayerLoc->halo.lt + mLayerLoc->halo.rt;

--- a/src/io/fileio.cpp
+++ b/src/io/fileio.cpp
@@ -1733,14 +1733,14 @@ int writeActivitySparse(
          //
          long fpos = fileStream->getOutPos();
          if (fpos == 0L) {
-            auto header = BufferUtils::buildHeader<pvadata_t>(
-                  loc->nxGlobal, loc->nyGlobal, loc->nf, 1, true /*sparse*/);
+            auto header = BufferUtils::buildActivityHeader<pvadata_t>(
+                  loc->nxGlobal, loc->nyGlobal, loc->nf, 1);
             // Hack because buildHeader doesn't handle sparse binary type.
             if (!includeValues) {
-               header.at(INDEX_FILE_TYPE) = PVP_ACT_FILE_TYPE;
-               header.at(INDEX_DATA_TYPE) = PV_INT_TYPE;
+               header.fileType = PVP_ACT_FILE_TYPE;
+               header.dataType = PV_INT_TYPE;
             }
-            fileStream->write(header.data(), (long)(header.size() * sizeof(*header.data())));
+            fileStream->write(&header, sizeof(header));
          }
          // write time, total active count, and local activity
          //

--- a/src/layers/PvpLayer.cpp
+++ b/src/layers/PvpLayer.cpp
@@ -38,15 +38,16 @@ Buffer<float> PvpLayer::retrieveData(std::string filename, int batchIndex) {
    // frame in the batch.
    if (mPvpFrameCount == -1) {
       FileStream headerStream(filename.c_str(), std::ios_base::in | std::ios_base::binary, false);
-      vector<int> header = BufferUtils::readHeader(headerStream);
-      mInputNx           = header.at(INDEX_NX);
-      mInputNy           = header.at(INDEX_NY);
-      mInputNf           = header.at(INDEX_NF);
-      mFileType          = header.at(INDEX_FILE_TYPE);
-      mPvpFrameCount     = header.at(INDEX_NBANDS);
+      struct BufferUtils::ActivityHeader header = BufferUtils::readActivityHeader(headerStream);
+
+      mInputNx       = header.nx;
+      mInputNy       = header.ny;
+      mInputNf       = header.nf;
+      mFileType      = header.fileType;
+      mPvpFrameCount = header.nBands;
       initializeBatchIndexer(mPvpFrameCount);
-      if (header.at(INDEX_FILE_TYPE) == PVP_ACT_SPARSEVALUES_FILE_TYPE
-          || header.at(INDEX_FILE_TYPE) == PVP_ACT_FILE_TYPE) {
+      if (header.fileType == PVP_ACT_SPARSEVALUES_FILE_TYPE
+            || header.fileType == PVP_ACT_FILE_TYPE) {
          sparseTable = BufferUtils::buildSparseFileTable(headerStream, mPvpFrameCount - 1);
       }
    }

--- a/src/utils/BufferUtilsPvp.hpp
+++ b/src/utils/BufferUtilsPvp.hpp
@@ -24,6 +24,28 @@ struct SparseFileTable {
    bool valuesIncluded;
 };
 
+struct ActivityHeader {
+   int headerSize,
+       numParams,
+       fileType,
+       nx,
+       ny,
+       nf,
+       numRecords,
+       recordSize,
+       dataSize,
+       dataType,
+       nxProcs,
+       nyProcs,
+       nxGlobal,
+       nyGlobal,
+       kx0,
+       ky0,
+       nBatch,
+       nBands;
+   double timestamp;
+};
+
 template <typename T>
 void writeFrame(FileStream &fStream, Buffer<T> *buffer, double timeStamp);
 
@@ -31,7 +53,10 @@ template <typename T>
 double readFrame(FileStream &fStream, Buffer<T> *buffer);
 
 template <typename T>
-vector<int> buildHeader(int width, int height, int features, int numFrames, bool isSparse);
+struct ActivityHeader buildActivityHeader(int width, int height, int features, int numFrames);
+
+template <typename T>
+struct ActivityHeader buildSparseActivityHeader(int width, int height, int features, int numFrames);
 
 template <typename T>
 void writeToPvp(const char *fName, Buffer<T> *buffer, double timeStamp, bool verifyWrites = false);
@@ -89,8 +114,8 @@ double readSparseBinaryFromPvp(
       T oneVal,
       SparseFileTable *cachedTable = nullptr);
 
-static void writeHeader(FileStream &fStream, vector<int> header);
-static vector<int> readHeader(FileStream &fStream);
+static void writeActivityHeader(FileStream &fStream, struct ActivityHeader header);
+static struct ActivityHeader readActivityHeader(FileStream &fStream);
 static SparseFileTable buildSparseFileTable(FileStream &fStream, int upToIndex);
 }
 }


### PR DESCRIPTION
This pull request refactors BufferUtilsPvp.tpp to use a structure to store PVP headers instead of a vector of ints.

All tests pass.
