### PR TITLE
RandState is checkpointed as .pvp instead of .bin

### DIFF
--- a/src/checkpointing/CheckpointEntryPvp.hpp
+++ b/src/checkpointing/CheckpointEntryPvp.hpp
@@ -20,14 +20,10 @@ class CheckpointEntryPvp : public CheckpointEntry {
          std::string const &name,
          Communicator *communicator,
          T *dataPtr,
-         size_t dataSize,
-         int dataType,
          PVLayerLoc const *layerLoc,
          bool extended)
          : CheckpointEntry(name, communicator),
            mDataPointer(dataPtr),
-           mDataSize(dataSize),
-           mDataType(dataType),
            mLayerLoc(layerLoc),
            mExtended(extended) {}
    CheckpointEntryPvp(
@@ -35,14 +31,10 @@ class CheckpointEntryPvp : public CheckpointEntry {
          std::string const &dataName,
          Communicator *communicator,
          T *dataPtr,
-         size_t dataSize,
-         int dataType,
          PVLayerLoc const *layerLoc,
          bool extended)
          : CheckpointEntry(objName, dataName, communicator),
            mDataPointer(dataPtr),
-           mDataSize(dataSize),
-           mDataType(dataType),
            mLayerLoc(layerLoc),
            mExtended(extended) {}
    virtual void write(std::string const &checkpointDirectory, double simTime, bool verifyWritesFlag)
@@ -55,8 +47,6 @@ class CheckpointEntryPvp : public CheckpointEntry {
 
   private:
    T *mDataPointer;
-   size_t mDataSize;
-   int mDataType;
    PVLayerLoc const *mLayerLoc = nullptr;
    bool mExtended              = false;
 };

--- a/src/checkpointing/CheckpointEntryRandState.cpp
+++ b/src/checkpointing/CheckpointEntryRandState.cpp
@@ -14,15 +14,15 @@ void CheckpointEntryRandState::write(
       std::string const &checkpointDirectory,
       double simTime,
       bool verifyWritesFlag) const {
-   std::string path = generatePath(checkpointDirectory, "bin");
+   std::string path = generatePath(checkpointDirectory, "pvp");
    writeRandState(
-         path, getCommunicator(), mDataPointer, mLayerLoc, mExtendedFlag, verifyWritesFlag);
+         path, getCommunicator(), mDataPointer, mLayerLoc, mExtendedFlag, simTime, verifyWritesFlag);
 }
 
 void CheckpointEntryRandState::read(std::string const &checkpointDirectory, double *simTimePtr)
       const {
-   std::string path = generatePath(checkpointDirectory, "bin");
-   readRandState(path, getCommunicator(), mDataPointer, mLayerLoc, mExtendedFlag);
+   std::string path = generatePath(checkpointDirectory, "pvp");
+   *simTimePtr = readRandState(path, getCommunicator(), mDataPointer, mLayerLoc, mExtendedFlag);
 }
 
 void CheckpointEntryRandState::remove(std::string const &checkpointDirectory) const {

--- a/src/checkpointing/CheckpointEntryRandState.cpp
+++ b/src/checkpointing/CheckpointEntryRandState.cpp
@@ -16,7 +16,13 @@ void CheckpointEntryRandState::write(
       bool verifyWritesFlag) const {
    std::string path = generatePath(checkpointDirectory, "pvp");
    writeRandState(
-         path, getCommunicator(), mDataPointer, mLayerLoc, mExtendedFlag, simTime, verifyWritesFlag);
+         path,
+         getCommunicator(),
+         mDataPointer,
+         mLayerLoc,
+         mExtendedFlag,
+         simTime,
+         verifyWritesFlag);
 }
 
 void CheckpointEntryRandState::read(std::string const &checkpointDirectory, double *simTimePtr)

--- a/src/io/fileio.cpp
+++ b/src/io/fileio.cpp
@@ -32,17 +32,17 @@ double timeFromParams(void *params) {
 }
 
 size_t pv_sizeof(int datatype) {
-   if (datatype == PV_INT_TYPE) {
+   if (datatype == BufferUtils::INT) {
       return sizeof(int);
    }
-   if (datatype == PV_FLOAT_TYPE) {
+   if (datatype == BufferUtils::FLOAT) {
       return sizeof(float);
    }
-   if (datatype == PV_BYTE_TYPE) {
+   if (datatype == BufferUtils::BYTE) {
       return sizeof(unsigned char);
    }
-   if (datatype == PV_SPARSEVALUES_TYPE) {
-      return sizeof(indexvaluepair);
+   if (datatype == BufferUtils::TAUS_UINT4) {
+      return sizeof(taus_uint4);
    }
 
    // shouldn't arrive here
@@ -1491,7 +1491,7 @@ int writeActivity(
          long fpos = fileStream->getOutPos();
          if (fpos == 0L) {
             int *params =
-                  pvp_set_nonspiking_act_params(comm, timed, loc, PV_FLOAT_TYPE, 1 /*numbands*/);
+                  pvp_set_nonspiking_act_params(comm, timed, loc, BufferUtils::FLOAT, 1 /*numbands*/);
             assert(params && params[1] == NUM_BIN_PARAMS);
             long int numParams = (long int)params[1];
             fileStream->write(params, (long int)sizeof(*params) * numParams);
@@ -1708,7 +1708,7 @@ int writeActivitySparse(
             // Hack because buildHeader doesn't handle sparse binary type.
             if (!includeValues) {
                header.fileType = PVP_ACT_FILE_TYPE;
-               header.dataType = PV_INT_TYPE;
+               header.dataType = BufferUtils::INT;
             }
             fileStream->write(&header, sizeof(header));
          }
@@ -1854,7 +1854,7 @@ int readWeights(
 
    const int icRank = comm->commRank();
 
-   bool compress       = header_data_type == PV_BYTE_TYPE;
+   bool compress       = header_data_type == BufferUtils::BYTE;
    unsigned char *cbuf = (unsigned char *)malloc(localSize);
    if (cbuf == NULL) {
       pvError(errorMessage);
@@ -2111,7 +2111,7 @@ int writeWeights(
       int file_type) {
    int status = PV_SUCCESS;
 
-   int datatype = compress ? PV_BYTE_TYPE : PV_FLOAT_TYPE;
+   int datatype = compress ? BufferUtils::BYTE : BufferUtils::FLOAT;
 
    const int icRank = comm->commRank();
 

--- a/src/io/fileio.cpp
+++ b/src/io/fileio.cpp
@@ -1490,8 +1490,8 @@ int writeActivity(
       if (rank == 0) {
          long fpos = fileStream->getOutPos();
          if (fpos == 0L) {
-            int *params =
-                  pvp_set_nonspiking_act_params(comm, timed, loc, BufferUtils::FLOAT, 1 /*numbands*/);
+            int *params = pvp_set_nonspiking_act_params(
+                  comm, timed, loc, BufferUtils::FLOAT, 1 /*numbands*/);
             assert(params && params[1] == NUM_BIN_PARAMS);
             long int numParams = (long int)params[1];
             fileStream->write(params, (long int)sizeof(*params) * numParams);

--- a/src/io/io.hpp
+++ b/src/io/io.hpp
@@ -28,11 +28,8 @@
 
 #define PV_ERR_FILE_NOT_FOUND 1
 
-#define PV_BYTE_TYPE 1
-#define PV_INT_TYPE 2
-#define PV_FLOAT_TYPE 3
-#define PV_SPARSEVALUES_TYPE                                                                       \
-   4 // Ddata is a list of (location, data) pairs; used by nonspiking layers with sparse activity
+// Oct 31, 2016. Macros used in INDEX_DATA_TYPE have been changed to values of HeaderDataType
+// defined in utils/BufferUtilsPvp.hpp
 
 #define PVP_FILE_TYPE                                                                              \
    1 // File type of activities where there are no timestamps in the individual frames.  No longer

--- a/src/io/randomstateio.cpp
+++ b/src/io/randomstateio.cpp
@@ -65,8 +65,10 @@ void writeRandState(
 namespace BufferUtils {
 
 template <>
-HeaderDataType returnDataType<taus_uint4>() { return TAUS_UINT4; }
+HeaderDataType returnDataType<taus_uint4>() {
+   return TAUS_UINT4;
+}
 
-}  // end namespace BufferUtils
+} // end namespace BufferUtils
 
 } // end namespace PV

--- a/src/io/randomstateio.cpp
+++ b/src/io/randomstateio.cpp
@@ -2,10 +2,11 @@
 #include "io/FileStream.hpp"
 #include "structures/Buffer.hpp"
 #include "utils/BufferUtilsMPI.hpp"
+#include "utils/BufferUtilsPvp.hpp"
 
 namespace PV {
 
-void readRandState(
+double readRandState(
       std::string const &path,
       Communicator *comm,
       taus_uint4 *randState,
@@ -21,11 +22,9 @@ void readRandState(
    int numGlobal = nxGlobal * nyGlobal * nf;
 
    Buffer<taus_uint4> buffer{nxGlobal, nyGlobal, nf};
+   double timestamp;
    if (comm->commRank() == 0) {
-      taus_uint4 globalData[numGlobal];
-      FileStream fileStream{path.c_str(), std::ios_base::in, false /*verifyWrites, not needed*/};
-      fileStream.read(globalData, numGlobal);
-      buffer.set(globalData, nxGlobal, nyGlobal, nf);
+      timestamp = BufferUtils::readFromPvp(path.c_str(), &buffer, 0 /*frameReadIndex*/);
    }
    BufferUtils::scatter(comm, buffer, loc->nx, loc->ny);
    int nxLocal = loc->nx;
@@ -37,6 +36,8 @@ void readRandState(
    int numLocal         = nxLocal * nyLocal * nf;
    std::size_t numBytes = sizeof(taus_uint4) * (std::size_t)numLocal;
    memcpy(randState, buffer.asVector().data(), numBytes);
+   MPI_Bcast(&timestamp, 1, MPI_DOUBLE, 0 /*root proc*/, comm->communicator());
+   return timestamp;
 }
 
 void writeRandState(
@@ -45,6 +46,7 @@ void writeRandState(
       taus_uint4 const *randState,
       PVLayerLoc const *loc,
       bool extended,
+      double simTime,
       bool verifyWrites) {
    int nxLocal = loc->nx;
    int nyLocal = loc->ny;
@@ -56,10 +58,15 @@ void writeRandState(
    Buffer<taus_uint4> localBuffer{randState, nxLocal, nyLocal, nf};
    Buffer<taus_uint4> globalBuffer = BufferUtils::gather(comm, localBuffer, loc->nx, loc->ny);
    if (comm->commRank() == 0) {
-      FileStream fileStream{path.c_str(), std::ios_base::out, verifyWrites};
-      fileStream.write(
-            globalBuffer.asVector().data(), globalBuffer.getTotalElements() * sizeof(taus_uint4));
+      BufferUtils::writeToPvp<taus_uint4>(path.c_str(), &globalBuffer, simTime, verifyWrites);
    }
 }
+
+namespace BufferUtils {
+
+template <>
+HeaderDataType returnDataType<taus_uint4>() { return TAUS_UINT4; }
+
+}  // end namespace BufferUtils
 
 } // end namespace PV

--- a/src/io/randomstateio.hpp
+++ b/src/io/randomstateio.hpp
@@ -5,7 +5,7 @@
 
 namespace PV {
 
-void readRandState(
+double readRandState(
       std::string const &path,
       Communicator *comm,
       taus_uint4 *randState,
@@ -18,5 +18,6 @@ void writeRandState(
       taus_uint4 const *randState,
       PVLayerLoc const *loc,
       bool extended,
+      double simTime,
       bool verifyWrites = false);
 }

--- a/src/layers/HyPerLayer.hpp
+++ b/src/layers/HyPerLayer.hpp
@@ -265,7 +265,6 @@ class HyPerLayer : public BaseLayer {
    char *pathInCheckpoint(const char *cpDir, const char *suffix);
    int readDataStoreFromFile(const char *filename, Communicator *comm, double *timed);
    int incrementNBands(int *numCalls);
-   int writeDataStoreToFile(const char *filename, Communicator *comm, double dtime);
    void calcNumExtended();
 
    /**
@@ -396,15 +395,6 @@ class HyPerLayer : public BaseLayer {
          const char *filename,
          Communicator *comm,
          double *timed,
-         T **buffers,
-         int numbands,
-         bool extended,
-         const PVLayerLoc *loc);
-   template <typename T>
-   static int writeBufferFile(
-         const char *filename,
-         Communicator *comm,
-         double dtime,
          T **buffers,
          int numbands,
          bool extended,

--- a/src/layers/LIF.cpp
+++ b/src/layers/LIF.cpp
@@ -406,8 +406,8 @@ int LIF::readG_IBFromCheckpoint(const char *cpDir, double *timeptr) {
 }
 
 int LIF::readRandStateFromCheckpoint(const char *cpDir, double *timeptr) {
-   char *filename = parent->pathInCheckpoint(cpDir, getName(), "_rand_state.bin");
-   readRandState(
+   char *filename = parent->pathInCheckpoint(cpDir, getName(), "_rand_state.pvp");
+   *timeptr = readRandState(
          filename,
          parent->getCommunicator(),
          randState->getRNG(0),

--- a/src/layers/LIF.cpp
+++ b/src/layers/LIF.cpp
@@ -407,7 +407,7 @@ int LIF::readG_IBFromCheckpoint(const char *cpDir, double *timeptr) {
 
 int LIF::readRandStateFromCheckpoint(const char *cpDir, double *timeptr) {
    char *filename = parent->pathInCheckpoint(cpDir, getName(), "_rand_state.pvp");
-   *timeptr = readRandState(
+   *timeptr       = readRandState(
          filename,
          parent->getCommunicator(),
          randState->getRNG(0),

--- a/src/layers/Retina.cpp
+++ b/src/layers/Retina.cpp
@@ -287,7 +287,7 @@ int Retina::readStateFromCheckpoint(const char *cpDir, double *timeptr) {
 int Retina::readRandStateFromCheckpoint(const char *cpDir) {
    int status = PV_SUCCESS;
    if (spikingFlag) {
-      char *filename = parent->pathInCheckpoint(cpDir, getName(), "_rand_state.bin");
+      char *filename = parent->pathInCheckpoint(cpDir, getName(), "_rand_state.pvp");
       readRandState(
             filename,
             parent->getCommunicator(),

--- a/src/utils/BufferUtilsPvp.hpp
+++ b/src/utils/BufferUtilsPvp.hpp
@@ -15,6 +15,19 @@ namespace PV {
 
 namespace BufferUtils {
 
+/**
+ * The enum for the dataType field of the pvp file header.
+ */
+typedef enum HeaderDataTypeEnum {
+   // Values are hardcoded to ensure consistency between builds.
+   UNRECOGNIZED_DATATYPE=0,
+   BYTE=1,
+   INT=2,
+   FLOAT=3,
+   // datatype 4 is obsolete;
+   TAUS_UINT4=5,
+} HeaderDataType;
+
 // This structure is used to avoid having to traverse
 // a sparse pvp file from start to finish every time
 // we want to load data from it.
@@ -35,6 +48,9 @@ void writeFrame(FileStream &fStream, Buffer<T> *buffer, double timeStamp);
 
 template <typename T>
 double readFrame(FileStream &fStream, Buffer<T> *buffer);
+
+template <typename T>
+BufferUtils::HeaderDataType returnDataType();
 
 template <typename T>
 struct ActivityHeader buildActivityHeader(int width, int height, int features, int numFrames);

--- a/src/utils/BufferUtilsPvp.hpp
+++ b/src/utils/BufferUtilsPvp.hpp
@@ -20,12 +20,12 @@ namespace BufferUtils {
  */
 typedef enum HeaderDataTypeEnum {
    // Values are hardcoded to ensure consistency between builds.
-   UNRECOGNIZED_DATATYPE=0,
-   BYTE=1,
-   INT=2,
-   FLOAT=3,
+   UNRECOGNIZED_DATATYPE = 0,
+   BYTE                  = 1,
+   INT                   = 2,
+   FLOAT                 = 3,
    // datatype 4 is obsolete;
-   TAUS_UINT4=5,
+   TAUS_UINT4 = 5,
 } HeaderDataType;
 
 // This structure is used to avoid having to traverse

--- a/src/utils/BufferUtilsPvp.tpp
+++ b/src/utils/BufferUtilsPvp.tpp
@@ -34,9 +34,11 @@ template <typename T>
 HeaderDataType returnDataType() {
    // Specializations for byte types and taus_uint4 in BufferUtilsPvp.cpp
    if (std::numeric_limits<T>::is_integer) {
-      return sizeof(T)==(std::size_t) 1 ? BYTE : INT;
-    }
-   if (std::numeric_limits<T>::is_iec559) { return FLOAT; }
+      return sizeof(T) == (std::size_t)1 ? BYTE : INT;
+   }
+   if (std::numeric_limits<T>::is_iec559) {
+      return FLOAT;
+   }
    return BufferUtils::UNRECOGNIZED_DATATYPE;
 }
 
@@ -45,7 +47,9 @@ HeaderDataType returnDataType() {
 template <typename T>
 struct ActivityHeader buildActivityHeader(int width, int height, int features, int numFrames) {
    HeaderDataType dataType = returnDataType<T>();
-   pvErrorIf(dataType==UNRECOGNIZED_DATATYPE, "buildActivityHeader called with unrecognized data type.\n");
+   pvErrorIf(
+         dataType == UNRECOGNIZED_DATATYPE,
+         "buildActivityHeader called with unrecognized data type.\n");
 
    struct ActivityHeader result;
    result.headerSize = sizeof(result);

--- a/src/utils/CMakeLists.txt
+++ b/src/utils/CMakeLists.txt
@@ -8,13 +8,13 @@ set (PVLibSrcCpp ${PVLibSrcCpp}
 )
 
 set (PVLibSrcHpp ${PVLibSrcHpp}
+   ${SUBDIR}/BufferUtilsMPI.hpp
+   ${SUBDIR}/BufferUtilsPvp.hpp
+   ${SUBDIR}/BufferUtilsRescale.hpp
    ${SUBDIR}/Clock.hpp
    ${SUBDIR}/PVAssert.hpp
    ${SUBDIR}/PVAlloc.hpp
    ${SUBDIR}/PVLog.hpp
-   ${SUBDIR}/BufferUtilsRescale.hpp
-   ${SUBDIR}/BufferUtilsMPI.hpp
-   ${SUBDIR}/BufferUtilsPvp.hpp
    ${SUBDIR}/Timer.hpp
 )
 

--- a/tests/CheckpointEntryTest/src/testPvpBatch.cpp
+++ b/tests/CheckpointEntryTest/src/testPvpBatch.cpp
@@ -57,11 +57,8 @@ void testPvpBatch(PV::Communicator *comm, std::string const &directory) {
    // Need to make sure that checkpointData.data() never gets relocated, since the
    // CheckpointEntryPvp's mDataPointer doesn't change with it.
    std::vector<float> checkpointData(correctData.size());
-   PV::CheckpointEntryPvp<float> checkpointEntryPvp{"checkpointEntryPvpBatch",
-                                                    comm,
-                                                    checkpointData.data(),
-                                                    &loc,
-                                                    false /*not extended*/};
+   PV::CheckpointEntryPvp<float> checkpointEntryPvp{
+         "checkpointEntryPvpBatch", comm, checkpointData.data(), &loc, false /*not extended*/};
 
    double const simTime = 10.0;
    // Copy correct data into checkpoint data.

--- a/tests/CheckpointEntryTest/src/testPvpBatch.cpp
+++ b/tests/CheckpointEntryTest/src/testPvpBatch.cpp
@@ -60,8 +60,6 @@ void testPvpBatch(PV::Communicator *comm, std::string const &directory) {
    PV::CheckpointEntryPvp<float> checkpointEntryPvp{"checkpointEntryPvpBatch",
                                                     comm,
                                                     checkpointData.data(),
-                                                    checkpointData.size(),
-                                                    PV_FLOAT_TYPE,
                                                     &loc,
                                                     false /*not extended*/};
 

--- a/tests/CheckpointEntryTest/src/testPvpExtended.cpp
+++ b/tests/CheckpointEntryTest/src/testPvpExtended.cpp
@@ -51,8 +51,6 @@ void testPvpExtended(PV::Communicator *comm, std::string const &directory) {
    PV::CheckpointEntryPvp<float> checkpointEntryPvp{"checkpointEntryPvpExtended",
                                                     comm,
                                                     checkpointData.data(),
-                                                    checkpointData.size(),
-                                                    PV_FLOAT_TYPE,
                                                     &loc,
                                                     true /*extended*/};
 

--- a/tests/CheckpointEntryTest/src/testPvpExtended.cpp
+++ b/tests/CheckpointEntryTest/src/testPvpExtended.cpp
@@ -48,11 +48,8 @@ void testPvpExtended(PV::Communicator *comm, std::string const &directory) {
    // Need to make sure that checkpointData.data() never gets relocated, since the
    // CheckpointEntryPvp's mDataPointer doesn't change with it.
    std::vector<float> checkpointData(correctData.size());
-   PV::CheckpointEntryPvp<float> checkpointEntryPvp{"checkpointEntryPvpExtended",
-                                                    comm,
-                                                    checkpointData.data(),
-                                                    &loc,
-                                                    true /*extended*/};
+   PV::CheckpointEntryPvp<float> checkpointEntryPvp{
+         "checkpointEntryPvpExtended", comm, checkpointData.data(), &loc, true /*extended*/};
 
    double const simTime = 10.0;
    // Copy correct data into checkpoint data.

--- a/tests/CheckpointEntryTest/src/testPvpRestricted.cpp
+++ b/tests/CheckpointEntryTest/src/testPvpRestricted.cpp
@@ -46,8 +46,6 @@ void testPvpRestricted(PV::Communicator *comm, std::string const &directory) {
    PV::CheckpointEntryPvp<float> checkpointEntryPvp{"checkpointEntryPvpRestricted",
                                                     comm,
                                                     checkpointData.data(),
-                                                    checkpointData.size(),
-                                                    PV_FLOAT_TYPE,
                                                     &loc,
                                                     false /*not extended*/};
 

--- a/tests/CheckpointEntryTest/src/testPvpRestricted.cpp
+++ b/tests/CheckpointEntryTest/src/testPvpRestricted.cpp
@@ -43,11 +43,8 @@ void testPvpRestricted(PV::Communicator *comm, std::string const &directory) {
    // Need to make sure that checkpointData.data() never gets relocated, since the
    // CheckpointEntryPvp's mDataPointer doesn't change with it.
    std::vector<float> checkpointData(correctData.size());
-   PV::CheckpointEntryPvp<float> checkpointEntryPvp{"checkpointEntryPvpRestricted",
-                                                    comm,
-                                                    checkpointData.data(),
-                                                    &loc,
-                                                    false /*not extended*/};
+   PV::CheckpointEntryPvp<float> checkpointEntryPvp{
+         "checkpointEntryPvpRestricted", comm, checkpointData.data(), &loc, false /*not extended*/};
 
    double const simTime = 10.0;
    // Copy correct data into checkpoint data.

--- a/tests/CheckpointEntryTest/src/testSeparatedName.cpp
+++ b/tests/CheckpointEntryTest/src/testSeparatedName.cpp
@@ -20,8 +20,6 @@ void testSeparatedName(PV::Communicator *comm) {
                                                        "name",
                                                        comm,
                                                        (float *)nullptr,
-                                                       (size_t)0,
-                                                       PV_FLOAT_TYPE,
                                                        (PVLayerLoc const *)nullptr,
                                                        false /*no broadcast*/};
 


### PR DESCRIPTION
This pull request changes the way that random states (used by LIF and spiking retinas) are checkpointed. Currently, the RNGs are saved in a raw .bin file, with no information about the dimensions of the buffer. This pull request saves the RNGs in a .pvp file. There is a new possibility for the dataType field in the header, to indicate that the type is taus_uint4. The dataType macros have been removed from io.hpp, and replaced with an enum defined in BufferUtilsPvp.hpp.