### PR TITLE
Optimizations identified in recent hackathon [WIP]

### DIFF
--- a/mlab/util/combinebatches.m
+++ b/mlab/util/combinebatches.m
@@ -34,7 +34,7 @@ function combinebatches(directory, layer_name, num_batch, batch_method, batch_wi
                result_index++;
             else
                per_batch_left = per_batch;
-               result_index += num_batch - 1;
+               result_index += num_batch - per_batch + 1;
             endif
          endfor
          i--;

--- a/src/connections/CloneConn.cpp
+++ b/src/connections/CloneConn.cpp
@@ -216,7 +216,7 @@ int CloneConn::communicateInitInfo() {
 
    // Don't allocate post, just grab in allocate from orig
    if (needPost) {
-      originalConn->setNeedPost(true);
+      originalConn->setNeedPost();
    }
 
 #ifdef PV_USE_CUDA

--- a/src/connections/HyPerConn.cpp
+++ b/src/connections/HyPerConn.cpp
@@ -3161,23 +3161,72 @@ int HyPerConn::deliverPostsynapticPerspectiveConvolve(
    int numPerStride      = postConn->xPatchSize() * postConn->fPatchSize();
    int neuronIndexStride = nfp < 4 ? 1 : nfp / 4;
 
-   for (int b = 0; b < nbatch; b++) {
-      int numNeurons = recvPostSparse ? numActive[b] : numPostRestricted;
+   if (sharedWeights) {
+      for (int b = 0; b < nbatch; b++) {
+         int numNeurons = recvPostSparse ? numActive[b] : numPostRestricted;
 
-      pvdata_t *activityBatch = activity->data
-                                + b * (sourceNx + sourceHalo->rt + sourceHalo->lt)
-                                        * (sourceNy + sourceHalo->up + sourceHalo->dn) * sourceNf;
-      pvdata_t *gSynPatchHeadBatch = gSynPatchHead + b * targetNx * targetNy * targetNf;
+         int sourceNxExt              = sourceNx + sourceHalo->rt + sourceHalo->lt;
+         int sourceNyExt              = sourceNy + sourceHalo->dn + sourceHalo->up;
+         pvdata_t *activityBatch      = activity->data + b * sourceNxExt * sourceNyExt * sourceNf;
+         pvdata_t *gSynPatchHeadBatch = gSynPatchHead + b * targetNx * targetNy * targetNf;
 
-      // Iterate over each line in the y axis, the goal is to keep weights in the cache
-      for (int ky = 0; ky < yPatchSize; ky++) {
+         // Iterate over each line in the y axis, the goal is to keep weights in the cache
+         for (int ky = 0; ky < yPatchSize; ky++) {
 // Threading over feature was the important change that improved cache performance by
 // 5-10x. dynamic scheduling also gave another performance increase over static.
 #ifdef PV_USE_OPENMP_THREADS
 #pragma omp parallel for schedule(static)
 #endif
-         for (int feature = 0; feature < neuronIndexStride; feature++) {
-            for (int idx = feature; idx < numNeurons; idx += neuronIndexStride) {
+            for (int feature = 0; feature < neuronIndexStride; feature++) {
+               for (int idx = feature; idx < numNeurons; idx += neuronIndexStride) {
+                  int kTargetRes = recvPostSparse ? activeList[b][idx] : idx;
+                  // gSyn
+                  pvdata_t *gSyn = gSynPatchHeadBatch + kTargetRes;
+
+                  // Activity
+                  float *a = activityBatch + startSourceExtBuf[kTargetRes] + ky * sy;
+
+                  // Weight
+                  int kTargetExt = kIndexExtended(
+                        kTargetRes,
+                        targetNx,
+                        targetNy,
+                        targetNf,
+                        targetHalo->lt,
+                        targetHalo->rt,
+                        targetHalo->dn,
+                        targetHalo->up);
+                  int kernelIndex           = postConn->patchToDataLUT(kTargetExt);
+                  pvwdata_t *weightStartBuf = postConn->get_wDataHead(arbor, kernelIndex);
+                  pvwdata_t *w              = weightStartBuf + ky * syp;
+
+                  float dv = 0.0;
+                  for (int k = 0; k < numPerStride; k++) {
+                     dv += a[k] * w[k];
+                  }
+                  *gSyn += dt_factor * dv;
+               }
+            }
+         }
+      }
+   }
+   else {
+      for (int b = 0; b < nbatch; b++) {
+         int numNeurons = recvPostSparse ? numActive[b] : numPostRestricted;
+
+         int sourceNxExt              = sourceNx + sourceHalo->rt + sourceHalo->lt;
+         int sourceNyExt              = sourceNy + sourceHalo->dn + sourceHalo->up;
+         pvdata_t *activityBatch      = activity->data + b * sourceNxExt * sourceNyExt * sourceNf;
+         pvdata_t *gSynPatchHeadBatch = gSynPatchHead + b * targetNx * targetNy * targetNf;
+
+         // Iterate over each line in the y axis, the goal is to keep weights in the cache
+         for (int ky = 0; ky < yPatchSize; ky++) {
+// Threading over feature was the important change that improved cache performance by
+// 5-10x. dynamic scheduling also gave another performance increase over static.
+#ifdef PV_USE_OPENMP_THREADS
+#pragma omp parallel for schedule(static)
+#endif
+            for (int idx = 0; idx < numNeurons; idx++) {
                int kTargetRes = recvPostSparse ? activeList[b][idx] : idx;
                // gSyn
                pvdata_t *gSyn = gSynPatchHeadBatch + kTargetRes;
@@ -3195,7 +3244,7 @@ int HyPerConn::deliverPostsynapticPerspectiveConvolve(
                      targetHalo->rt,
                      targetHalo->dn,
                      targetHalo->up);
-               int kernelIndex           = postConn->patchToDataLUT(kTargetExt);
+               int kernelIndex           = kTargetExt;
                pvwdata_t *weightStartBuf = postConn->get_wDataHead(arbor, kernelIndex);
                pvwdata_t *w              = weightStartBuf + ky * syp;
 

--- a/src/connections/HyPerConn.hpp
+++ b/src/connections/HyPerConn.hpp
@@ -317,7 +317,10 @@ class HyPerConn : public BaseConnection {
    virtual int
    dataIndexToUnitCellIndex(int dataIndex, int *kx = NULL, int *ky = NULL, int *kf = NULL);
 
-   void setNeedPost(bool inBool) { needPost = inBool; }
+   /**
+    * Sets the flag indicating that the postsynaptic perspective is needed.
+    */
+   void setNeedPost() { needPost = true; }
    void setNeedAllocPostWeights(bool inBool) { needAllocPostWeights = inBool; }
 
   protected:

--- a/src/connections/HyPerConn.hpp
+++ b/src/connections/HyPerConn.hpp
@@ -364,15 +364,17 @@ class HyPerConn : public BaseConnection {
    // Percentage of weights that are ignored. Weight values must be above this threshold
    // to be included in the calculation. Valid values are 0.0 - 1.0. But there's no
    // point in setting this to 1.0.
-   float _weightSparsity;
+   float mWeightSparsity;
+
+   // Commented out 11/3/16, seem to be unused?
    // The output offset into the post layer for a weight
-   std::vector<int> _sparsePost;
+   // std::vector<int> mSparsePost;
    // Start of sparse weight data in the _sparseWeight array, indexed by data patch
-   std::vector<int> _patchSparseWeightIndex;
+   // std::vector<int> mPatchSparseWeightIndex;
    // Number of sparse weights for a patch, indexed by data patch
-   std::vector<int> _patchSparseWeightCount;
+   // std::vector<int> mPatchSparseWeightCount;
    // Have sparse weights been allocated for each arbor?
-   std::vector<bool> _sparseWeightsAllocated;
+   std::vector<bool> mSparseWeightsAllocated;
 
    typedef std::map<const WeightType *const, const WeightListType> WeightPtrMapType;
    typedef std::map<const WeightType *const, const IndexListType> WeightIndexMapType;
@@ -382,14 +384,15 @@ class HyPerConn : public BaseConnection {
    // Map nk -> weight ptr -> output index
    typedef std::map<int, WeightIndexMapType> IndexMapType;
 
-   WeightMapType _sparseWeightValues;
-   IndexMapType _sparseWeightIndexes;
-   SparseWeightInfo _sparseWeightInfo;
+   WeightMapType mSparseWeightValues;
+   IndexMapType mSparseWeightIndices;
+   SparseWeightInfo mSparseWeightInfo;
 
-   std::set<int> _kPreExtWeightSparsified;
+   std::set<int> mKPreExtWeightSparsified;
 
-   unsigned long _numDeliverCalls; // Number of times deliver has been called
-   unsigned long _allocateSparseWeightsFrequency; // Number of _numDeliverCalls that need to happen
+   // unsigned long mNumDeliverCalls; // Number of times deliver has been called
+   // unsigned long mAllocateSparseWeightsFrequency; // Number of mNumDeliverCalls that need to
+   // happen
    // before the pre list needs to be rebuilt
 
    // Allocate sparse weights when performing presynaptic delivery

--- a/src/connections/PoolingConn.cpp
+++ b/src/connections/PoolingConn.cpp
@@ -318,7 +318,7 @@ int PoolingConn::communicateInitInfo() {
    }
 
    if (getUpdateGSynFromPostPerspective()) {
-      setNeedPost(true);
+      setNeedPost();
       needAllocPostWeights = false;
    }
 

--- a/src/connections/TransposeConn.cpp
+++ b/src/connections/TransposeConn.cpp
@@ -286,7 +286,7 @@ int TransposeConn::communicateInitInfo() {
       exit(EXIT_FAILURE);
    }
 
-   originalConn->setNeedPost(true);
+   originalConn->setNeedPost();
 
 #ifdef PV_USE_CUDA
    if ((updateGSynFromPostPerspective && receiveGpu) || allocPostDeviceWeights) {

--- a/src/connections/TransposeConn.cpp
+++ b/src/connections/TransposeConn.cpp
@@ -286,7 +286,7 @@ int TransposeConn::communicateInitInfo() {
       exit(EXIT_FAILURE);
    }
 
-   originalConn->setNeedPost();
+   if (!updateGSynFromPostPerspective) { originalConn->setNeedPost(); }
 
 #ifdef PV_USE_CUDA
    if ((updateGSynFromPostPerspective && receiveGpu) || allocPostDeviceWeights) {
@@ -359,6 +359,11 @@ int TransposeConn::allocatePostDeviceWeights() { return PV_SUCCESS; }
 int TransposeConn::allocatePostConn() {
    pvInfo() << "Connection " << name << " setting " << originalConn->getName() << " as postConn\n";
    postConn = originalConn;
+
+   // Can't do this with shrink patches flag
+   if (needPost && !shrinkPatches_flag) {
+      allocatePostToPreBuffer();
+   }
    return PV_SUCCESS;
 }
 
@@ -385,12 +390,14 @@ int TransposeConn::allocateDataStructures() {
 }
 
 int TransposeConn::constructWeights() {
-   setPatchStrides();
-   wPatches       = this->originalConn->postConn->get_wPatches();
-   wDataStart     = this->originalConn->postConn->get_wDataStart();
-   gSynPatchStart = this->originalConn->postConn->getGSynPatchStart();
-   aPostOffset    = this->originalConn->postConn->getAPostOffset();
-   dwDataStart    = this->originalConn->postConn->get_dwDataStart();
+   if (originalConn->postConn) {
+      setPatchStrides();
+      wPatches       = this->originalConn->postConn->get_wPatches();
+      wDataStart     = this->originalConn->postConn->get_wDataStart();
+      gSynPatchStart = this->originalConn->postConn->getGSynPatchStart();
+      aPostOffset    = this->originalConn->postConn->getAPostOffset();
+      dwDataStart    = this->originalConn->postConn->get_dwDataStart();
+   }
    return PV_SUCCESS;
 }
 

--- a/src/connections/TransposeConn.cpp
+++ b/src/connections/TransposeConn.cpp
@@ -103,7 +103,6 @@ void TransposeConn::ioParam_triggerLayerName(enum ParamsIOFlag ioFlag) {
       // make sure that TransposePoolingConn always checks if its originalConn has updated
       triggerFlag      = false;
       triggerLayerName = NULL;
-      parent->parameters()->handleUnnecessaryParameter(name, "triggerFlag", triggerFlag);
       parent->parameters()->handleUnnecessaryStringParameter(name, "triggerLayerName", NULL);
    }
 }
@@ -286,7 +285,9 @@ int TransposeConn::communicateInitInfo() {
       exit(EXIT_FAILURE);
    }
 
-   if (!updateGSynFromPostPerspective) { originalConn->setNeedPost(); }
+   if (!updateGSynFromPostPerspective) {
+      originalConn->setNeedPost();
+   }
 
 #ifdef PV_USE_CUDA
    if ((updateGSynFromPostPerspective && receiveGpu) || allocPostDeviceWeights) {
@@ -317,9 +318,11 @@ int TransposeConn::setPatchSize() {
    assert(originalConn);
 
    int xscaleDiff = pre->getXScale() - post->getXScale();
+   int yscaleDiff = pre->getYScale() - post->getYScale();
    int nxp_orig   = originalConn->xPatchSize();
    int nyp_orig   = originalConn->yPatchSize();
-   nxp            = nxp_orig;
+
+   nxp = nxp_orig;
    if (xscaleDiff > 0) {
       nxp *= (int)pow(2, xscaleDiff);
    }
@@ -328,8 +331,7 @@ int TransposeConn::setPatchSize() {
       assert(nxp_orig == nxp * pow(2, (float)(-xscaleDiff)));
    }
 
-   int yscaleDiff = pre->getYScale() - post->getYScale();
-   nyp            = nyp_orig;
+   nyp = nyp_orig;
    if (yscaleDiff > 0) {
       nyp *= (int)pow(2, yscaleDiff);
    }
@@ -338,10 +340,10 @@ int TransposeConn::setPatchSize() {
       assert(nyp_orig == nyp * pow(2, (float)(-yscaleDiff)));
    }
 
-   nfp = post->getLayerLoc()->nf;
    // post->getLayerLoc()->nf must be the same as
    // originalConn->preSynapticLayer()->getLayerLoc()->nf.
    // This requirement is checked in communicateInitInfo
+   nfp = post->getLayerLoc()->nf;
 
    parent->parameters()->handleUnnecessaryParameter(name, "nxp", nxp);
    parent->parameters()->handleUnnecessaryParameter(name, "nyp", nyp);
@@ -392,11 +394,11 @@ int TransposeConn::allocateDataStructures() {
 int TransposeConn::constructWeights() {
    if (originalConn->postConn) {
       setPatchStrides();
-      wPatches       = this->originalConn->postConn->get_wPatches();
-      wDataStart     = this->originalConn->postConn->get_wDataStart();
-      gSynPatchStart = this->originalConn->postConn->getGSynPatchStart();
-      aPostOffset    = this->originalConn->postConn->getAPostOffset();
-      dwDataStart    = this->originalConn->postConn->get_dwDataStart();
+      wPatches       = originalConn->postConn->get_wPatches();
+      wDataStart     = originalConn->postConn->get_wDataStart();
+      gSynPatchStart = originalConn->postConn->getGSynPatchStart();
+      aPostOffset    = originalConn->postConn->getAPostOffset();
+      dwDataStart    = originalConn->postConn->get_dwDataStart();
    }
    return PV_SUCCESS;
 }

--- a/src/connections/TransposeConn.hpp
+++ b/src/connections/TransposeConn.hpp
@@ -34,8 +34,6 @@ class TransposeConn : public HyPerConn {
    virtual void setAllocPostDeviceWeights() { originalConn->setAllocDeviceWeights(); }
 #endif // PV_USE_CUDA
 
-   virtual long *getPostToPreActivity() { return originalConn->postConn->getPostToPreActivity(); }
-
 #ifdef PV_USE_CUDA
    virtual PVCuda::CudaBuffer *getDeviceWData() { return originalConn->postConn->getDeviceWData(); }
 #endif

--- a/src/connections/TransposeConn.hpp
+++ b/src/connections/TransposeConn.hpp
@@ -56,11 +56,6 @@ class TransposeConn : public HyPerConn {
    virtual void ioParam_initializeFromCheckpointFlag(enum ParamsIOFlag ioFlag);
    virtual void ioParam_numAxonalArbors(enum ParamsIOFlag ioFlag);
    virtual void ioParam_plasticityFlag(enum ParamsIOFlag ioFlag);
-   virtual void ioParam_triggerFlag(enum ParamsIOFlag ioFlag) { /* triggerFlag is deprecated as of
-                                                                   Aug 17, 2015.  See
-                                                                   HyPerConn::ioParam_triggerFlag
-                                                                   for details*/
-   }
    virtual void ioParam_triggerLayerName(enum ParamsIOFlag ioFlag);
    virtual void ioParam_combine_dW_with_W_flag(enum ParamsIOFlag ioFlag);
    virtual void ioParam_nxp(enum ParamsIOFlag ioFlag);

--- a/src/connections/TransposePoolingConn.cpp
+++ b/src/connections/TransposePoolingConn.cpp
@@ -393,7 +393,7 @@ int TransposePoolingConn::communicateInitInfo() {
       exit(EXIT_FAILURE);
    }
 
-   mOriginalConn->setNeedPost(true);
+   mOriginalConn->setNeedPost();
    mOriginalConn->setNeedAllocPostWeights(false);
 
    // Synchronize margines of this post and orig pre, and vice versa

--- a/src/connections/TransposePoolingConn.cpp
+++ b/src/connections/TransposePoolingConn.cpp
@@ -393,7 +393,7 @@ int TransposePoolingConn::communicateInitInfo() {
       exit(EXIT_FAILURE);
    }
 
-   mOriginalConn->setNeedPost();
+   if (!updateGSynFromPostPerspective) { mOriginalConn->setNeedPost(); }
    mOriginalConn->setNeedAllocPostWeights(false);
 
    // Synchronize margines of this post and orig pre, and vice versa

--- a/src/connections/TransposePoolingConn.cpp
+++ b/src/connections/TransposePoolingConn.cpp
@@ -393,7 +393,9 @@ int TransposePoolingConn::communicateInitInfo() {
       exit(EXIT_FAILURE);
    }
 
-   if (!updateGSynFromPostPerspective) { mOriginalConn->setNeedPost(); }
+   if (!updateGSynFromPostPerspective) {
+      mOriginalConn->setNeedPost();
+   }
    mOriginalConn->setNeedAllocPostWeights(false);
 
    // Synchronize margines of this post and orig pre, and vice versa

--- a/src/normalizers/NormalizeMultiply.hpp
+++ b/src/normalizers/NormalizeMultiply.hpp
@@ -19,10 +19,10 @@ class NormalizeMultiply : public NormalizeBase {
    virtual ~NormalizeMultiply();
 
    const char *getName() { return name; }
-   const float getRMinX() { return rMinX; }
-   const float getRMinY() { return rMinY; }
-   const float getNormalizeCutoff() { return normalize_cutoff; }
-   const bool getNormalizeFromPostPerspectiveFlag() { return normalizeFromPostPerspective; }
+   float getRMinX() { return rMinX; }
+   float getRMinY() { return rMinY; }
+   float getNormalizeCutoff() { return normalize_cutoff; }
+   bool getNormalizeFromPostPerspectiveFlag() { return normalizeFromPostPerspective; }
 
    virtual int ioParamsFillGroup(enum ParamsIOFlag ioFlag);
 

--- a/src/structures/Buffer.hpp
+++ b/src/structures/Buffer.hpp
@@ -24,10 +24,10 @@ class Buffer {
    void grow(int newWidth, int newHeight, enum Anchor anchor);
    void translate(int offsetX, int offsetY);
    std::vector<T> asVector() const { return mData; }
-   const int getHeight() const { return mHeight; }
-   const int getWidth() const { return mWidth; }
-   const int getFeatures() const { return mFeatures; }
-   const int getTotalElements() const { return mHeight * mWidth * mFeatures; }
+   int getHeight() const { return mHeight; }
+   int getWidth() const { return mWidth; }
+   int getFeatures() const { return mFeatures; }
+   int getTotalElements() const { return mHeight * mWidth * mFeatures; }
 
   protected:
    static int getAnchorX(enum Anchor anchor, int smallerWidth, int biggerWidth);


### PR DESCRIPTION
This pull request makes a few changes identified in the recent hackathon, using connections with shared weights off:

deliverFromPostSynapticPerspective branches based on sharedWeights outside the outermost for-loop, in order to avoid the conditional inside the innermost loop, and to allow loop ordering to depend on the sharedWeights flag.

postConn is set only when needed (the connection or a clone delivers from the post-synaptic perspective, or a transpose delivers from the pre-synaptic perspective). Without this change, there could be many expensive and unneeded calls to transpose().

Methods returning const-qualified scalars had the const qualifier removed, addressing warnings generated by the Intel compiler.

This pull request passes all tests both with and without PV_USE_GPU. However, some additional polishing might be necessary.