### PR TITLE
readStateFromCheckpoint uses Checkpointer class

### DIFF
--- a/src/checkpointing/Checkpointer.cpp
+++ b/src/checkpointing/Checkpointer.cpp
@@ -430,7 +430,8 @@ bool Checkpointer::registerCheckpointEntry(
 
 void Checkpointer::registerTimer(Timer const *timer) { mTimers.push_back(timer); }
 
-void Checkpointer::readNamedCheckpointEntry(std::string objName, std::string dataName) const {
+void Checkpointer::readNamedCheckpointEntry(std::string const &objName, std::string const &dataName)
+      const {
    std::string checkpointEntryName(objName);
    if (!(objName.empty() || dataName.empty())) {
       checkpointEntryName.append("_");
@@ -439,7 +440,7 @@ void Checkpointer::readNamedCheckpointEntry(std::string objName, std::string dat
    readNamedCheckpointEntry(checkpointEntryName);
 }
 
-void Checkpointer::readNamedCheckpointEntry(std::string checkpointEntryName) const {
+void Checkpointer::readNamedCheckpointEntry(std::string const &checkpointEntryName) const {
    for (auto &c : mCheckpointRegistry) {
       if (c->getName() == checkpointEntryName) {
          double timestamp = 0.0; // not used

--- a/src/checkpointing/Checkpointer.cpp
+++ b/src/checkpointing/Checkpointer.cpp
@@ -433,6 +433,8 @@ void Checkpointer::registerTimer(Timer const *timer) { mTimers.push_back(timer);
 void Checkpointer::initializeFromCheckpointDir(std::string checkpointEntryName) {
    for (auto &c : mCheckpointRegistry) {
       if (c->getName() == checkpointEntryName) {
+         double timestamp = 0.0; // not used
+         c->read(mInitializeFromCheckpointDir, &timestamp);
          return;
       }
    }

--- a/src/checkpointing/Checkpointer.cpp
+++ b/src/checkpointing/Checkpointer.cpp
@@ -430,7 +430,14 @@ bool Checkpointer::registerCheckpointEntry(
 
 void Checkpointer::registerTimer(Timer const *timer) { mTimers.push_back(timer); }
 
-void Checkpointer::initializeFromCheckpointDir(std::string checkpointEntryName) {
+void Checkpointer::readNamedCheckpointEntry(std::string objName, std::string dataName) {
+   std::string checkpointEntryName(objName);
+   if (!(objName.empty() || dataName.empty())) { checkpointEntryName.append("_"); }
+   checkpointEntryName.append(dataName);
+   readNamedCheckpointEntry(checkpointEntryName);
+}
+
+void Checkpointer::readNamedCheckpointEntry(std::string checkpointEntryName) {
    for (auto &c : mCheckpointRegistry) {
       if (c->getName() == checkpointEntryName) {
          double timestamp = 0.0; // not used

--- a/src/checkpointing/Checkpointer.cpp
+++ b/src/checkpointing/Checkpointer.cpp
@@ -430,7 +430,7 @@ bool Checkpointer::registerCheckpointEntry(
 
 void Checkpointer::registerTimer(Timer const *timer) { mTimers.push_back(timer); }
 
-void Checkpointer::readNamedCheckpointEntry(std::string objName, std::string dataName) {
+void Checkpointer::readNamedCheckpointEntry(std::string objName, std::string dataName) const {
    std::string checkpointEntryName(objName);
    if (!(objName.empty() || dataName.empty())) {
       checkpointEntryName.append("_");
@@ -439,7 +439,7 @@ void Checkpointer::readNamedCheckpointEntry(std::string objName, std::string dat
    readNamedCheckpointEntry(checkpointEntryName);
 }
 
-void Checkpointer::readNamedCheckpointEntry(std::string checkpointEntryName) {
+void Checkpointer::readNamedCheckpointEntry(std::string checkpointEntryName) const {
    for (auto &c : mCheckpointRegistry) {
       if (c->getName() == checkpointEntryName) {
          double timestamp = 0.0; // not used

--- a/src/checkpointing/Checkpointer.cpp
+++ b/src/checkpointing/Checkpointer.cpp
@@ -423,6 +423,15 @@ bool Checkpointer::registerCheckpointEntry(
 
 void Checkpointer::registerTimer(Timer const *timer) { mTimers.push_back(timer); }
 
+void Checkpointer::initializeFromCheckpointDir(std::string checkpointEntryName) {
+   for (auto &c : mCheckpointRegistry) {
+      if (c->getName() == checkpointEntryName) {
+         return;
+      }
+   }
+   Fatal() << "initializeFromCheckpoint failed to find checkpointEntryName " << checkpointEntryName << "\n";
+}
+
 void Checkpointer::checkpointRead(
       std::string const &checkpointReadDir,
       double *simTimePointer,

--- a/src/checkpointing/Checkpointer.cpp
+++ b/src/checkpointing/Checkpointer.cpp
@@ -68,6 +68,8 @@ void Checkpointer::ioParamsFillGroup(enum ParamsIOFlag ioFlag, PVParams *params)
    ioParam_deleteOlderCheckpoints(ioFlag, params);
    ioParam_numCheckpointsKept(ioFlag, params);
    ioParam_suppressLastOutput(ioFlag, params);
+   ioParam_initializeFromCheckpointDir(ioFlag, params);
+   ioParam_defaultInitializeFromCheckpointFlag(ioFlag, params);
 }
 
 void Checkpointer::ioParam_verifyWrites(enum ParamsIOFlag ioFlag, PVParams *params) {
@@ -372,6 +374,24 @@ void Checkpointer::ioParam_suppressLastOutput(enum ParamsIOFlag ioFlag, PVParams
    if (!mCheckpointWriteFlag) {
       params->ioParamValue(
             ioFlag, mName.c_str(), "suppressLastOutput", &mSuppressLastOutput, mSuppressLastOutput);
+   }
+}
+
+void Checkpointer::ioParam_initializeFromCheckpointDir(enum ParamsIOFlag ioFlag, PVParams *params) {
+   params->ioParamString(
+         ioFlag, mName.c_str(), "initializeFromCheckpointDir", &mInitializeFromCheckpointDir, "", true);
+}
+
+void Checkpointer::ioParam_defaultInitializeFromCheckpointFlag(enum ParamsIOFlag ioFlag, PVParams *params) {
+   assert(!params->presentAndNotBeenRead(mName.c_str(), "initializeFromCheckpointDir"));
+   if (mInitializeFromCheckpointDir != nullptr && mInitializeFromCheckpointDir[0] != '\0') {
+      params->ioParamValue(
+            ioFlag,
+            mName.c_str(),
+            "defaultInitializeFromCheckpointFlag",
+            &mDefaultInitializeFromCheckpointFlag,
+            mDefaultInitializeFromCheckpointFlag,
+            true);
    }
 }
 

--- a/src/checkpointing/Checkpointer.cpp
+++ b/src/checkpointing/Checkpointer.cpp
@@ -432,7 +432,9 @@ void Checkpointer::registerTimer(Timer const *timer) { mTimers.push_back(timer);
 
 void Checkpointer::readNamedCheckpointEntry(std::string objName, std::string dataName) {
    std::string checkpointEntryName(objName);
-   if (!(objName.empty() || dataName.empty())) { checkpointEntryName.append("_"); }
+   if (!(objName.empty() || dataName.empty())) {
+      checkpointEntryName.append("_");
+   }
    checkpointEntryName.append(dataName);
    readNamedCheckpointEntry(checkpointEntryName);
 }

--- a/src/checkpointing/Checkpointer.cpp
+++ b/src/checkpointing/Checkpointer.cpp
@@ -379,10 +379,17 @@ void Checkpointer::ioParam_suppressLastOutput(enum ParamsIOFlag ioFlag, PVParams
 
 void Checkpointer::ioParam_initializeFromCheckpointDir(enum ParamsIOFlag ioFlag, PVParams *params) {
    params->ioParamString(
-         ioFlag, mName.c_str(), "initializeFromCheckpointDir", &mInitializeFromCheckpointDir, "", true);
+         ioFlag,
+         mName.c_str(),
+         "initializeFromCheckpointDir",
+         &mInitializeFromCheckpointDir,
+         "",
+         true);
 }
 
-void Checkpointer::ioParam_defaultInitializeFromCheckpointFlag(enum ParamsIOFlag ioFlag, PVParams *params) {
+void Checkpointer::ioParam_defaultInitializeFromCheckpointFlag(
+      enum ParamsIOFlag ioFlag,
+      PVParams *params) {
    assert(!params->presentAndNotBeenRead(mName.c_str(), "initializeFromCheckpointDir"));
    if (mInitializeFromCheckpointDir != nullptr && mInitializeFromCheckpointDir[0] != '\0') {
       params->ioParamValue(
@@ -429,7 +436,8 @@ void Checkpointer::initializeFromCheckpointDir(std::string checkpointEntryName) 
          return;
       }
    }
-   Fatal() << "initializeFromCheckpoint failed to find checkpointEntryName " << checkpointEntryName << "\n";
+   Fatal() << "initializeFromCheckpoint failed to find checkpointEntryName " << checkpointEntryName
+           << "\n";
 }
 
 void Checkpointer::checkpointRead(

--- a/src/checkpointing/Checkpointer.hpp
+++ b/src/checkpointing/Checkpointer.hpp
@@ -90,8 +90,8 @@ class Checkpointer : public Subject {
    void registerTimer(Timer const *timer);
    virtual void addObserver(Observer *observer, BaseMessage const &message) override;
 
-   void readNamedCheckpointEntry(std::string objName, std::string dataName) const;
-   void readNamedCheckpointEntry(std::string checkpointEntryName) const;
+   void readNamedCheckpointEntry(std::string const &objName, std::string const &dataName) const;
+   void readNamedCheckpointEntry(std::string const &checkpointEntryName) const;
    void checkpointRead(
          std::string const &checkpointReadDir,
          double *simTimePointer,

--- a/src/checkpointing/Checkpointer.hpp
+++ b/src/checkpointing/Checkpointer.hpp
@@ -58,7 +58,8 @@ class Checkpointer : public Subject {
     * based off of initializeFromCheckpointDir. Only used if
     * initializeFromCheckpointDir is set.
     */
-   virtual void ioParam_defaultInitializeFromCheckpointFlag(enum ParamsIOFlag ioFlag, PVParams *params);
+   virtual void
+   ioParam_defaultInitializeFromCheckpointFlag(enum ParamsIOFlag ioFlag, PVParams *params);
    /** @} */
 
    enum CheckpointWriteTriggerMode { NONE, STEP, SIMTIME, WALLCLOCK };
@@ -113,7 +114,9 @@ class Checkpointer : public Subject {
    bool getSuppressNonplasticCheckpoints() const { return mSuppressNonplasticCheckpoints; }
    bool getSuppressLastOutput() const { return mSuppressLastOutput; }
    char const *getInitializeFromCheckpointDir() const { return mInitializeFromCheckpointDir; }
-   bool getDefaultInitializeFromCheckpointFlag() const { return mDefaultInitializeFromCheckpointFlag; }
+   bool getDefaultInitializeFromCheckpointFlag() const {
+      return mDefaultInitializeFromCheckpointFlag;
+   }
 
   private:
    void initialize();

--- a/src/checkpointing/Checkpointer.hpp
+++ b/src/checkpointing/Checkpointer.hpp
@@ -44,18 +44,17 @@ class Checkpointer : public Subject {
    virtual void ioParam_numCheckpointsKept(enum ParamsIOFlag ioFlag, PVParams *params);
 
    /**
-    * @brief mFilenamesContainLayerNames is obsolete.
-    * The file produced by outputState has the form NameOfLayer.pvp
+    * @brief initializeFromCheckpointDir: Sets directory used by
+    * Checkpointer::initializeFromCheckpoint(). Layers and connections use this
+    * directory if they set their initializeFromCheckpointFlag parameter.
     */
    virtual void ioParam_initializeFromCheckpointDir(enum ParamsIOFlag ioFlag, PVParams *params);
 
    /**
     * @brief defaultInitializeFromCheckpointFlag: Flag to set the default for
-    * layers and
-    * connections.
+    * layers and connections.
     * @details Sets the default for layers and connections to use for initialize
-    * from checkpoint
-    * based off of initializeFromCheckpointDir. Only used if
+    * from checkpoint based off of initializeFromCheckpointDir. Only used if
     * initializeFromCheckpointDir is set.
     */
    virtual void

--- a/src/checkpointing/Checkpointer.hpp
+++ b/src/checkpointing/Checkpointer.hpp
@@ -89,6 +89,8 @@ class Checkpointer : public Subject {
          bool constantEntireRun = false);
    void registerTimer(Timer const *timer);
    virtual void addObserver(Observer *observer, BaseMessage const &message) override;
+
+   void initializeFromCheckpointDir(std::string checkpointEntryName);
    void checkpointRead(
          std::string const &checkpointReadDir,
          double *simTimePointer,

--- a/src/checkpointing/Checkpointer.hpp
+++ b/src/checkpointing/Checkpointer.hpp
@@ -90,7 +90,8 @@ class Checkpointer : public Subject {
    void registerTimer(Timer const *timer);
    virtual void addObserver(Observer *observer, BaseMessage const &message) override;
 
-   void initializeFromCheckpointDir(std::string checkpointEntryName);
+   void readNamedCheckpointEntry(std::string objName, std::string dataName);
+   void readNamedCheckpointEntry(std::string checkpointEntryName);
    void checkpointRead(
          std::string const &checkpointReadDir,
          double *simTimePointer,

--- a/src/checkpointing/Checkpointer.hpp
+++ b/src/checkpointing/Checkpointer.hpp
@@ -90,8 +90,8 @@ class Checkpointer : public Subject {
    void registerTimer(Timer const *timer);
    virtual void addObserver(Observer *observer, BaseMessage const &message) override;
 
-   void readNamedCheckpointEntry(std::string objName, std::string dataName);
-   void readNamedCheckpointEntry(std::string checkpointEntryName);
+   void readNamedCheckpointEntry(std::string objName, std::string dataName) const;
+   void readNamedCheckpointEntry(std::string checkpointEntryName) const;
    void checkpointRead(
          std::string const &checkpointReadDir,
          double *simTimePointer,

--- a/src/checkpointing/Checkpointer.hpp
+++ b/src/checkpointing/Checkpointer.hpp
@@ -42,6 +42,23 @@ class Checkpointer : public Subject {
     * Default is 1 (delete a checkpoint when a newer checkpoint is written.)
     */
    virtual void ioParam_numCheckpointsKept(enum ParamsIOFlag ioFlag, PVParams *params);
+
+   /**
+    * @brief mFilenamesContainLayerNames is obsolete.
+    * The file produced by outputState has the form NameOfLayer.pvp
+    */
+   virtual void ioParam_initializeFromCheckpointDir(enum ParamsIOFlag ioFlag, PVParams *params);
+
+   /**
+    * @brief defaultInitializeFromCheckpointFlag: Flag to set the default for
+    * layers and
+    * connections.
+    * @details Sets the default for layers and connections to use for initialize
+    * from checkpoint
+    * based off of initializeFromCheckpointDir. Only used if
+    * initializeFromCheckpointDir is set.
+    */
+   virtual void ioParam_defaultInitializeFromCheckpointFlag(enum ParamsIOFlag ioFlag, PVParams *params);
    /** @} */
 
    enum CheckpointWriteTriggerMode { NONE, STEP, SIMTIME, WALLCLOCK };
@@ -93,6 +110,8 @@ class Checkpointer : public Subject {
    int getCheckpointIndexWidth() const { return mCheckpointIndexWidth; }
    bool getSuppressNonplasticCheckpoints() const { return mSuppressNonplasticCheckpoints; }
    bool getSuppressLastOutput() const { return mSuppressLastOutput; }
+   char const *getInitializeFromCheckpointDir() const { return mInitializeFromCheckpointDir; }
+   bool getDefaultInitializeFromCheckpointFlag() const { return mDefaultInitializeFromCheckpointFlag; }
 
   private:
    void initialize();
@@ -143,6 +162,8 @@ class Checkpointer : public Subject {
    bool mDeleteOlderCheckpoints                                            = false;
    int mNumCheckpointsKept                                                 = 2;
    bool mSuppressLastOutput                                                = false;
+   char *mInitializeFromCheckpointDir                                      = nullptr;
+   bool mDefaultInitializeFromCheckpointFlag                               = false;
    std::string mCheckpointReadDirectory;
    int mCheckpointSignal                = 0;
    long int mNextCheckpointStep         = 0L; // kept only for consistency with HyPerCol

--- a/src/columns/BaseObject.cpp
+++ b/src/columns/BaseObject.cpp
@@ -91,8 +91,8 @@ int BaseObject::respond(std::shared_ptr<BaseMessage const> message) {
       return respondRegisterData(castMessage);
    }
    else if (
-         InitializeStateMessage const *castMessage =
-               dynamic_cast<InitializeStateMessage const *>(message.get())) {
+         InitializeStateMessage<Checkpointer> const *castMessage =
+               dynamic_cast<InitializeStateMessage<Checkpointer> const *>(message.get())) {
       return respondInitializeState(castMessage);
    }
    else if (
@@ -142,7 +142,7 @@ int BaseObject::respondRegisterData(RegisterDataMessage<Checkpointer> const *mes
    return status;
 }
 
-int BaseObject::respondInitializeState(InitializeStateMessage const *message) {
+int BaseObject::respondInitializeState(InitializeStateMessage<Checkpointer> const *message) {
    int status = PV_SUCCESS;
    if (getInitialValuesSetFlag()) {
       return status;

--- a/src/columns/BaseObject.cpp
+++ b/src/columns/BaseObject.cpp
@@ -147,7 +147,7 @@ int BaseObject::respondInitializeState(InitializeStateMessage<Checkpointer> cons
    if (getInitialValuesSetFlag()) {
       return status;
    }
-   status = initializeState();
+   status = initializeState(message->mDataRegistry);
    if (status == PV_SUCCESS) {
       setInitialValuesSetFlag();
    }

--- a/src/columns/BaseObject.hpp
+++ b/src/columns/BaseObject.hpp
@@ -85,7 +85,7 @@ class BaseObject : public Observer, public CheckpointerDataInterface {
 
    virtual int communicateInitInfo() { return PV_SUCCESS; }
    virtual int allocateDataStructures() { return PV_SUCCESS; }
-   virtual int initializeState() { return PV_SUCCESS; }
+   virtual int initializeState(Checkpointer *checkpointer) { return PV_SUCCESS; }
    virtual int processCheckpointRead() { return PV_SUCCESS; }
    virtual int prepareCheckpointWrite() { return PV_SUCCESS; }
 

--- a/src/columns/BaseObject.hpp
+++ b/src/columns/BaseObject.hpp
@@ -79,7 +79,7 @@ class BaseObject : public Observer, public CheckpointerDataInterface {
    int respondCommunicateInitInfo(CommunicateInitInfoMessage const *message);
    int respondAllocateData(AllocateDataMessage const *message);
    int respondRegisterData(RegisterDataMessage<Checkpointer> const *message);
-   int respondInitializeState(InitializeStateMessage const *message);
+   int respondInitializeState(InitializeStateMessage<Checkpointer> const *message);
    int respondProcessCheckpointRead(ProcessCheckpointReadMessage const *message);
    int respondPrepareCheckpointWrite(PrepareCheckpointWriteMessage const *message);
 

--- a/src/columns/HyPerCol.cpp
+++ b/src/columns/HyPerCol.cpp
@@ -101,30 +101,30 @@ int HyPerCol::initialize_base() {
    // Initialize all member variables to safe values.  They will be set to their
    // actual values in
    // initialize()
-   mWarmStart                           = false;
-   mReadyFlag                           = false;
-   mParamsProcessedFlag                 = false;
-   mNumPhases                           = 0;
-   mCheckpointReadFlag                  = false;
-   mCheckpointWriteFlag                 = false;
-   mCheckpointReadDir                   = nullptr;
-   mCheckpointReadDirBase               = nullptr;
-   mCpReadDirIndex                      = -1L;
-   mCheckpointWriteDir                  = nullptr;
-   mCheckpointWriteTriggerMode          = CPWRITE_TRIGGER_STEP;
-   mCpWriteStepInterval                 = -1L;
-   mNextCpWriteStep                     = 0L;
-   mCpWriteTimeInterval                 = -1.0;
-   mNextCpWriteTime                     = 0.0;
-   mCpWriteClockInterval                = -1.0;
-   mDeleteOlderCheckpoints              = false;
-   mSuppressLastOutput                  = false;
-   mSuppressNonplasticCheckpoints       = false;
-   mCheckpointIndexWidth                = -1; // defaults to automatically determine index width
-   mStartTime                           = 0.0;
-   mStopTime                            = 0.0;
-   mDeltaTime                           = DEFAULT_DELTA_T;
-   mWriteTimeScaleFieldnames            = true;
+   mWarmStart                     = false;
+   mReadyFlag                     = false;
+   mParamsProcessedFlag           = false;
+   mNumPhases                     = 0;
+   mCheckpointReadFlag            = false;
+   mCheckpointWriteFlag           = false;
+   mCheckpointReadDir             = nullptr;
+   mCheckpointReadDirBase         = nullptr;
+   mCpReadDirIndex                = -1L;
+   mCheckpointWriteDir            = nullptr;
+   mCheckpointWriteTriggerMode    = CPWRITE_TRIGGER_STEP;
+   mCpWriteStepInterval           = -1L;
+   mNextCpWriteStep               = 0L;
+   mCpWriteTimeInterval           = -1.0;
+   mNextCpWriteTime               = 0.0;
+   mCpWriteClockInterval          = -1.0;
+   mDeleteOlderCheckpoints        = false;
+   mSuppressLastOutput            = false;
+   mSuppressNonplasticCheckpoints = false;
+   mCheckpointIndexWidth          = -1; // defaults to automatically determine index width
+   mStartTime                     = 0.0;
+   mStopTime                      = 0.0;
+   mDeltaTime                     = DEFAULT_DELTA_T;
+   mWriteTimeScaleFieldnames      = true;
    // Sep 26, 2016: Adaptive timestep routines and member variables have been
    // moved to
    // AdaptiveTimeScaleProbe.

--- a/src/columns/HyPerCol.cpp
+++ b/src/columns/HyPerCol.cpp
@@ -83,7 +83,6 @@ HyPerCol::~HyPerCol() {
    // TODO: Change these old C strings into std::string
    free(mPrintParamsFilename);
    free(mOutputPath);
-   free(mInitializeFromCheckpointDir);
    if (mCheckpointWriteFlag) {
       free(mCheckpointWriteDir);
       mCheckpointWriteDir = nullptr;
@@ -119,7 +118,6 @@ int HyPerCol::initialize_base() {
    mNextCpWriteTime                     = 0.0;
    mCpWriteClockInterval                = -1.0;
    mDeleteOlderCheckpoints              = false;
-   mDefaultInitializeFromCheckpointFlag = false;
    mSuppressLastOutput                  = false;
    mSuppressNonplasticCheckpoints       = false;
    mCheckpointIndexWidth                = -1; // defaults to automatically determine index width
@@ -503,8 +501,6 @@ int HyPerCol::ioParamsFillGroup(enum ParamsIOFlag ioFlag) {
    ioParam_nBatch(ioFlag);
    ioParam_filenamesContainLayerNames(ioFlag);
    ioParam_filenamesContainConnectionNames(ioFlag);
-   ioParam_initializeFromCheckpointDir(ioFlag);
-   ioParam_defaultInitializeFromCheckpointFlag(ioFlag);
    ioParam_checkpointRead(ioFlag); // checkpointRead is obsolete as of June 27, 2016.
    ioParam_writeTimescales(ioFlag);
    ioParam_errorOnNotANumber(ioFlag);
@@ -854,24 +850,6 @@ void HyPerCol::ioParam_filenamesContainConnectionNames(enum ParamsIOFlag ioFlag)
       else {
          Fatal() << msg;
       }
-   }
-}
-
-void HyPerCol::ioParam_initializeFromCheckpointDir(enum ParamsIOFlag ioFlag) {
-   parameters()->ioParamString(
-         ioFlag, mName, "initializeFromCheckpointDir", &mInitializeFromCheckpointDir, "", true);
-}
-
-void HyPerCol::ioParam_defaultInitializeFromCheckpointFlag(enum ParamsIOFlag ioFlag) {
-   assert(!mParams->presentAndNotBeenRead(mName, "initializeFromCheckpointDir"));
-   if (mInitializeFromCheckpointDir != nullptr && mInitializeFromCheckpointDir[0] != '\0') {
-      parameters()->ioParamValue(
-            ioFlag,
-            mName,
-            "defaultInitializeFromCheckpointFlag",
-            &mDefaultInitializeFromCheckpointFlag,
-            mDefaultInitializeFromCheckpointFlag,
-            true);
    }
 }
 

--- a/src/columns/HyPerCol.cpp
+++ b/src/columns/HyPerCol.cpp
@@ -1159,10 +1159,13 @@ int HyPerCol::run(double start_time, double stop_time, double dt) {
       // This needs to happen after initPublishers so that we can initialize
       // the values in the data stores, and before the mLayers' publish calls
       // so that the data in border regions gets copied correctly.
-      notify(std::make_shared<InitializeStateMessage>());
+      notify(std::make_shared<InitializeStateMessage<Checkpointer>>(mCheckpointer));
       if (mCheckpointReadFlag) {
          mCheckpointer->checkpointRead(mCheckpointReadDir, &mSimTime, &mCurrentStep);
       }
+      // Note: ideally, in checkpointReadFlag is set, calling InitializeState should
+      // be unnecessary. However, currently initializeState does some CUDA kernel
+      // initializations that still need to happen when reading from checkpoint.
 
       // Initial normalization moved here to facilitate normalizations of groups
       // of HyPerConns

--- a/src/columns/HyPerCol.hpp
+++ b/src/columns/HyPerCol.hpp
@@ -229,23 +229,6 @@ class HyPerCol : public Subject, Observer {
    virtual void ioParam_filenamesContainConnectionNames(enum ParamsIOFlag ioFlag);
 
    /**
-    * @brief mFilenamesContainLayerNames is obsolete.
-    * The file produced by outputState has the form NameOfLayer.pvp
-    */
-   virtual void ioParam_initializeFromCheckpointDir(enum ParamsIOFlag ioFlag);
-
-   /**
-    * @brief defaultInitializeFromCheckpointFlag: Flag to set the default for
-    * layers and
-    * connections.
-    * @details Sets the default for layers and connections to use for initialize
-    * from checkpoint
-    * based off of initializeFromCheckpointDir. Only used if
-    * initializeFromCheckpointDir is set.
-    */
-   virtual void ioParam_defaultInitializeFromCheckpointFlag(enum ParamsIOFlag ioFlag);
-
-   /**
     * @brief checkpointRead is obsolete.  Instead use -c foo/Checkpoint100 on the
     * command line.
     */
@@ -398,7 +381,7 @@ class HyPerCol : public Subject, Observer {
    BaseProbe *getBaseProbe(int which) { return mBaseProbes.at(which); }
    bool getVerifyWrites() { return mVerifyWrites; }
    bool warmStartup() const { return mWarmStart; }
-   bool getDefaultInitializeFromCheckpointFlag() { return mDefaultInitializeFromCheckpointFlag; }
+   bool getDefaultInitializeFromCheckpointFlag() { return mCheckpointer->getDefaultInitializeFromCheckpointFlag(); }
    bool getCheckpointReadFlag() const { return mCheckpointReadFlag; }
    bool getCheckpointWriteFlag() const { return mCheckpointWriteFlag; }
    bool getSuppressLastOutputFlag() const { return mSuppressLastOutput; }
@@ -406,7 +389,7 @@ class HyPerCol : public Subject, Observer {
    bool getWriteTimescales() const { return mWriteTimescales; }
    const char *getName() { return mName; }
    const char *getOutputPath() { return mOutputPath; }
-   const char *getInitializeFromCheckpointDir() const { return mInitializeFromCheckpointDir; }
+   const char *getInitializeFromCheckpointDir() const { return mCheckpointer->getInitializeFromCheckpointDir(); }
    const char *getCheckpointReadDir() const { return mCheckpointReadDir; }
    const char *getPrintParamsFilename() const { return mPrintParamsFilename; }
    ColProbe *getColProbe(int which) { return mColProbes.at(which); }
@@ -506,10 +489,6 @@ class HyPerCol : public Subject, Observer {
    bool mErrorOnNotANumber; // If true, check each layer's activity buffer for
    // not-a-numbers and
    // exit with an error if any appear
-   bool mDefaultInitializeFromCheckpointFlag; // Each Layer and connection can
-   // individually set its
-   // own initializeFromCheckpointFlag.  This sets the
-   // default value for those flags.
    bool mWarmStart; // whether to start from a checkpoint
    bool mCheckpointReadFlag; // whether to load from a checkpoint directory
    bool mCheckpointWriteFlag; // whether to write from a checkpoint directory
@@ -558,11 +537,6 @@ class HyPerCol : public Subject, Observer {
    char *mPrintParamsFilename; // filename for outputting the mParams, including
    // defaults and
    // excluding unread mParams
-   char *mInitializeFromCheckpointDir; // If nonempty, mLayers and mConnections
-   // can load from this
-   // directory as in checkpointRead, by setting their
-   // initializeFromCheckpointFlag parameter, but the run still
-   // starts at mSimTime=mStartTime
    std::vector<ColProbe *> mColProbes; // ColProbe ** mColProbes;
    double mStartTime;
    double mSimTime;

--- a/src/columns/HyPerCol.hpp
+++ b/src/columns/HyPerCol.hpp
@@ -381,7 +381,9 @@ class HyPerCol : public Subject, Observer {
    BaseProbe *getBaseProbe(int which) { return mBaseProbes.at(which); }
    bool getVerifyWrites() { return mVerifyWrites; }
    bool warmStartup() const { return mWarmStart; }
-   bool getDefaultInitializeFromCheckpointFlag() { return mCheckpointer->getDefaultInitializeFromCheckpointFlag(); }
+   bool getDefaultInitializeFromCheckpointFlag() {
+      return mCheckpointer->getDefaultInitializeFromCheckpointFlag();
+   }
    bool getCheckpointReadFlag() const { return mCheckpointReadFlag; }
    bool getCheckpointWriteFlag() const { return mCheckpointWriteFlag; }
    bool getSuppressLastOutputFlag() const { return mSuppressLastOutput; }
@@ -389,7 +391,9 @@ class HyPerCol : public Subject, Observer {
    bool getWriteTimescales() const { return mWriteTimescales; }
    const char *getName() { return mName; }
    const char *getOutputPath() { return mOutputPath; }
-   const char *getInitializeFromCheckpointDir() const { return mCheckpointer->getInitializeFromCheckpointDir(); }
+   const char *getInitializeFromCheckpointDir() const {
+      return mCheckpointer->getInitializeFromCheckpointDir();
+   }
    const char *getCheckpointReadDir() const { return mCheckpointReadDir; }
    const char *getPrintParamsFilename() const { return mPrintParamsFilename; }
    ColProbe *getColProbe(int which) { return mColProbes.at(which); }

--- a/src/columns/Messages.hpp
+++ b/src/columns/Messages.hpp
@@ -47,9 +47,7 @@ class RegisterDataMessage : public BaseMessage {
 template <typename T> // In practice, T is always Checkpointer.
 class InitializeStateMessage : public BaseMessage {
   public:
-   InitializeStateMessage(T *dataRegistry) {
-      setMessageType("InitializeState");
-   }
+   InitializeStateMessage(T *dataRegistry) { setMessageType("InitializeState"); }
    T *mDataRegistry;
 };
 

--- a/src/columns/Messages.hpp
+++ b/src/columns/Messages.hpp
@@ -44,9 +44,13 @@ class RegisterDataMessage : public BaseMessage {
    T *mDataRegistry;
 };
 
+template <typename T> // In practice, T is always Checkpointer.
 class InitializeStateMessage : public BaseMessage {
   public:
-   InitializeStateMessage() { setMessageType("InitializeState"); }
+   InitializeStateMessage(T *dataRegistry) {
+      setMessageType("InitializeState");
+   }
+   T *mDataRegistry;
 };
 
 class AdaptTimestepMessage : public BaseMessage {

--- a/src/connections/BaseConnection.cpp
+++ b/src/connections/BaseConnection.cpp
@@ -642,7 +642,7 @@ void BaseConnection::setDelay(int arborId, double delay) {
    delays[arborId] = (int)(intDelay);
 }
 
-int BaseConnection::initializeState() {
+int BaseConnection::initializeState(Checkpointer *checkpointer) {
    int status = PV_SUCCESS;
    status     = setInitialValues();
    if (initializeFromCheckpointFlag && getPlasticityFlag()) {

--- a/src/connections/BaseConnection.cpp
+++ b/src/connections/BaseConnection.cpp
@@ -646,10 +646,7 @@ int BaseConnection::initializeState(Checkpointer *checkpointer) {
    int status = PV_SUCCESS;
    status     = setInitialValues();
    if (initializeFromCheckpointFlag && getPlasticityFlag()) {
-      pvAssert(
-            parent->getInitializeFromCheckpointDir()
-            && parent->getInitializeFromCheckpointDir()[0]);
-      status = readStateFromCheckpoint(parent->getInitializeFromCheckpointDir(), nullptr);
+      status = readStateFromCheckpoint(checkpointer);
    }
    return status;
 }

--- a/src/connections/BaseConnection.hpp
+++ b/src/connections/BaseConnection.hpp
@@ -390,13 +390,11 @@ class BaseConnection : public BaseObject {
    virtual void ioParam_initializeFromCheckpointFlag(enum ParamsIOFlag ioFlag);
 
    /**
-    * A pure virtual method that uses an existing checkpoint to
-    * initialize the connection.  BaseConnection::initializeState calls it
-    * when initializeFromCheckpointFlag is true.  A Subclass may also
-    * call this method as part of the implementation of checkpointRead
-    * (for example, HyPerConn does this).
+    * A pure virtual method that calls a Checkpointer's initializeFromCheckpointDir
+    * method to initialize the connection.  BaseConnection::initializeState calls it
+    * when initializeFromCheckpointFlag is true.
     */
-   virtual int readStateFromCheckpoint(const char *cpDir, double *timeptr) = 0;
+   virtual int readStateFromCheckpoint(Checkpointer *checkpointer) = 0;
 
    /**
     * A pure virtual method for initializing the connection if we are neither

--- a/src/connections/BaseConnection.hpp
+++ b/src/connections/BaseConnection.hpp
@@ -89,9 +89,10 @@ class BaseConnection : public BaseObject {
     * is
     * usually done in HyPerCol::run.
     */
-   virtual int initializeState() override final; // Not overridable because all connections should
-   // initializeState in the same way.  BaseConnection::initializeState() calls
-   // either checkpointRead() or setInitialValues(), both of which are virtual.
+   virtual int initializeState(Checkpointer *checkpointer) override final;
+   // Not overridable because all connections should initializeState in the same way.
+   // BaseConnection::initializeState() calls either checkpointRead() or setInitialValues(),
+   // both of which are virtual.
 
    /**
     * A pure virtual function for writing the state of the connection to file(s) in the output

--- a/src/connections/CloneConn.hpp
+++ b/src/connections/CloneConn.hpp
@@ -83,7 +83,7 @@ class CloneConn : public HyPerConn {
    virtual int setWeightInitializer();
    virtual PVPatch ***initializeWeights(PVPatch ***patches, float **dataStart);
    virtual int cloneParameters();
-   virtual int readStateFromCheckpoint(const char *cpDir, double *timeptr) { return PV_SUCCESS; }
+   virtual int readStateFromCheckpoint(Checkpointer *checkpointer) { return PV_SUCCESS; }
    virtual int constructWeights();
    void constructWeightsOutOfMemory();
    virtual int createAxonalArbors(int arborId);

--- a/src/connections/HyPerConn.cpp
+++ b/src/connections/HyPerConn.cpp
@@ -2076,13 +2076,14 @@ int HyPerConn::writeTextWeights(const char *filename, int k) {
    return 0;
 }
 
-int HyPerConn::readStateFromCheckpoint(const char *cpDir, double *timeptr) {
+int HyPerConn::readStateFromCheckpoint(Checkpointer *checkpointer) {
    // If timeptr is NULL, the timestamps in the pvp files are ignored.  If non-null, they are
    // compared to the value of *timeptr and
    // a warning is issued if there is a discrepancy.
-   int status = PV_SUCCESS;
-   status     = readWeightsFromCheckpoint(cpDir, timeptr);
-   return status;
+   std::string checkpointEntryName(name);
+   checkpointEntryName.append("_W");
+   checkpointer->initializeFromCheckpointDir(checkpointEntryName);
+   return PV_SUCCESS;
 }
 
 int HyPerConn::readWeightsFromCheckpoint(const char *cpDir, double *timeptr) {

--- a/src/connections/HyPerConn.cpp
+++ b/src/connections/HyPerConn.cpp
@@ -2082,7 +2082,7 @@ int HyPerConn::readStateFromCheckpoint(Checkpointer *checkpointer) {
    // a warning is issued if there is a discrepancy.
    std::string checkpointEntryName(name);
    checkpointEntryName.append("_W");
-   checkpointer->initializeFromCheckpointDir(checkpointEntryName);
+   checkpointer->readNamedCheckpointEntry(checkpointEntryName);
    return PV_SUCCESS;
 }
 

--- a/src/connections/HyPerConn.cpp
+++ b/src/connections/HyPerConn.cpp
@@ -2081,34 +2081,6 @@ int HyPerConn::readStateFromCheckpoint(Checkpointer *checkpointer) {
    return PV_SUCCESS;
 }
 
-int HyPerConn::readWeightsFromCheckpoint(const char *cpDir, double *timeptr) {
-   clearWeights(get_wDataStart(), getNumDataPatches(), nxp, nyp, nfp);
-   char *path             = parent->pathInCheckpoint(cpDir, getName(), "_W.pvp");
-   PVPatch ***patches_arg = sharedWeights ? NULL : wPatches;
-   double filetime        = 0.0;
-   int status             = PV::readWeights(
-         patches_arg,
-         get_wDataStart(),
-         numberOfAxonalArborLists(),
-         getNumDataPatches(),
-         nxp,
-         nyp,
-         nfp,
-         path,
-         parent->getCommunicator(),
-         &filetime,
-         pre->getLayerLoc());
-   if (parent->columnId() == 0 && timeptr && *timeptr != filetime) {
-      WarnLog().printf(
-            "\"%s\" checkpoint has timestamp %g instead of the expected value %g.\n",
-            path,
-            filetime,
-            *timeptr);
-   }
-   free(path);
-   return status;
-}
-
 void HyPerConn::checkpointWeightPvp(
       Checkpointer *checkpointer,
       char const *bufferName,

--- a/src/connections/HyPerConn.cpp
+++ b/src/connections/HyPerConn.cpp
@@ -2077,12 +2077,7 @@ int HyPerConn::writeTextWeights(const char *filename, int k) {
 }
 
 int HyPerConn::readStateFromCheckpoint(Checkpointer *checkpointer) {
-   // If timeptr is NULL, the timestamps in the pvp files are ignored.  If non-null, they are
-   // compared to the value of *timeptr and
-   // a warning is issued if there is a discrepancy.
-   std::string checkpointEntryName(name);
-   checkpointEntryName.append("_W");
-   checkpointer->readNamedCheckpointEntry(checkpointEntryName);
+   checkpointer->readNamedCheckpointEntry(std::string(name), std::string("W"));
    return PV_SUCCESS;
 }
 

--- a/src/connections/HyPerConn.hpp
+++ b/src/connections/HyPerConn.hpp
@@ -865,7 +865,7 @@ class HyPerConn : public BaseConnection {
          size_t **inAPostOffset,
          int arborId);
    virtual int adjustAxonalArbors(int arborId);
-   virtual int readStateFromCheckpoint(const char *cpDir, double *timeptr) override;
+   virtual int readStateFromCheckpoint(Checkpointer *checkpointer) override;
    virtual int readWeightsFromCheckpoint(const char *cpDir, double *timeptr);
    void checkpointWeightPvp(
          Checkpointer *checkpointer,

--- a/src/connections/HyPerConn.hpp
+++ b/src/connections/HyPerConn.hpp
@@ -866,7 +866,6 @@ class HyPerConn : public BaseConnection {
          int arborId);
    virtual int adjustAxonalArbors(int arborId);
    virtual int readStateFromCheckpoint(Checkpointer *checkpointer) override;
-   virtual int readWeightsFromCheckpoint(const char *cpDir, double *timeptr);
    void checkpointWeightPvp(
          Checkpointer *checkpointer,
          char const *bufferName,

--- a/src/connections/MomentumConn.cpp
+++ b/src/connections/MomentumConn.cpp
@@ -263,7 +263,7 @@ int MomentumConn::readStateFromCheckpoint(Checkpointer *checkpointer) {
    int status = HyPerConn::readStateFromCheckpoint(checkpointer);
    std::string checkpointEntryName(name);
    checkpointEntryName.append("_prev_dW");
-   checkpointer->initializeFromCheckpointDir(checkpointEntryName);
+   checkpointer->readNamedCheckpointEntry(checkpointEntryName);
    return status;
 }
 

--- a/src/connections/MomentumConn.cpp
+++ b/src/connections/MomentumConn.cpp
@@ -259,4 +259,12 @@ int MomentumConn::registerData(Checkpointer *checkpointer, std::string const &ob
    return status;
 }
 
+int MomentumConn::readStateFromCheckpoint(Checkpointer *checkpointer) {
+   int status = HyPerConn::readStateFromCheckpoint(checkpointer);
+   std::string checkpointEntryName(name);
+   checkpointEntryName.append("_prev_dW");
+   checkpointer->initializeFromCheckpointDir(checkpointEntryName);
+   return status;
+}
+
 } // end namespace PV

--- a/src/connections/MomentumConn.cpp
+++ b/src/connections/MomentumConn.cpp
@@ -260,11 +260,8 @@ int MomentumConn::registerData(Checkpointer *checkpointer, std::string const &ob
 }
 
 int MomentumConn::readStateFromCheckpoint(Checkpointer *checkpointer) {
-   int status = HyPerConn::readStateFromCheckpoint(checkpointer);
-   std::string checkpointEntryName(name);
-   checkpointEntryName.append("_prev_dW");
-   checkpointer->readNamedCheckpointEntry(checkpointEntryName);
-   return status;
+   checkpointer->readNamedCheckpointEntry(std::string(name), std::string("prev_dW"));
+   return PV_SUCCESS;
 }
 
 } // end namespace PV

--- a/src/connections/MomentumConn.hpp
+++ b/src/connections/MomentumConn.hpp
@@ -29,6 +29,7 @@ class MomentumConn : public HyPerConn {
    virtual void ioParam_batchPeriod(enum ParamsIOFlag ioFlag);
 
    virtual int registerData(Checkpointer *checkpointer, std::string const &objName) override;
+   virtual int readStateFromCheckpoint(Checkpointer *checkpointer) override;
 
    inline float *get_prev_dwDataHead(int arborId, int dataIndex) {
       return &prev_dwDataStart[arborId][dataIndex * nxp * nyp * nfp];

--- a/src/layers/CloneVLayer.cpp
+++ b/src/layers/CloneVLayer.cpp
@@ -139,7 +139,7 @@ int CloneVLayer::allocateGSyn() {
 
 int CloneVLayer::initializeV() { return PV_SUCCESS; }
 
-int CloneVLayer::readVFromCheckpoint(const char *cpDir, double *timeptr) {
+int CloneVLayer::readVFromCheckpoint(Checkpointer *checkpointer) {
    // If we just inherit HyPerLayer::readVFromCheckpoint, we checkpoint V since it is non-null.
    // This is redundant since V is a clone.
    return PV_SUCCESS;

--- a/src/layers/CloneVLayer.hpp
+++ b/src/layers/CloneVLayer.hpp
@@ -34,7 +34,7 @@ class CloneVLayer : public PV::HyPerLayer {
    virtual int allocateV() override;
    virtual int registerData(Checkpointer *checkpointer, std::string const &objName) override;
    virtual int initializeV() override;
-   virtual int readVFromCheckpoint(const char *cpDir, double *timeptr) override;
+   virtual int readVFromCheckpoint(Checkpointer *checkpointer) override;
    virtual int updateState(double timed, double dt) override;
 
   private:

--- a/src/layers/HyPerLayer.cpp
+++ b/src/layers/HyPerLayer.cpp
@@ -2218,7 +2218,7 @@ int HyPerLayer::readStateFromCheckpoint(Checkpointer *checkpointer) {
 int HyPerLayer::readActivityFromCheckpoint(Checkpointer *checkpointer) {
    std::string checkpointEntryName(name);
    checkpointEntryName.append("_A");
-   checkpointer->initializeFromCheckpointDir(checkpointEntryName);
+   checkpointer->readNamedCheckpointEntry(checkpointEntryName);
    return PV_SUCCESS;
 }
 
@@ -2226,7 +2226,7 @@ int HyPerLayer::readVFromCheckpoint(Checkpointer *checkpointer) {
    if (getV() != nullptr) {
       std::string checkpointEntryName(name);
       checkpointEntryName.append("_V");
-      checkpointer->initializeFromCheckpointDir(checkpointEntryName);
+      checkpointer->readNamedCheckpointEntry(checkpointEntryName);
    }
    return PV_SUCCESS;
 }
@@ -2234,7 +2234,7 @@ int HyPerLayer::readVFromCheckpoint(Checkpointer *checkpointer) {
 int HyPerLayer::readDelaysFromCheckpoint(Checkpointer *checkpointer) {
    std::string checkpointEntryName(name);
    checkpointEntryName.append("_Delays");
-   checkpointer->initializeFromCheckpointDir(checkpointEntryName);
+   checkpointer->readNamedCheckpointEntry(checkpointEntryName);
    return PV_SUCCESS;
 }
 

--- a/src/layers/HyPerLayer.cpp
+++ b/src/layers/HyPerLayer.cpp
@@ -2216,25 +2216,19 @@ int HyPerLayer::readStateFromCheckpoint(Checkpointer *checkpointer) {
 }
 
 int HyPerLayer::readActivityFromCheckpoint(Checkpointer *checkpointer) {
-   std::string checkpointEntryName(name);
-   checkpointEntryName.append("_A");
-   checkpointer->readNamedCheckpointEntry(checkpointEntryName);
+   checkpointer->readNamedCheckpointEntry(std::string(name), std::string("A"));
    return PV_SUCCESS;
 }
 
 int HyPerLayer::readVFromCheckpoint(Checkpointer *checkpointer) {
    if (getV() != nullptr) {
-      std::string checkpointEntryName(name);
-      checkpointEntryName.append("_V");
-      checkpointer->readNamedCheckpointEntry(checkpointEntryName);
+      checkpointer->readNamedCheckpointEntry(std::string(name), std::string("V"));
    }
    return PV_SUCCESS;
 }
 
 int HyPerLayer::readDelaysFromCheckpoint(Checkpointer *checkpointer) {
-   std::string checkpointEntryName(name);
-   checkpointEntryName.append("_Delays");
-   checkpointer->readNamedCheckpointEntry(checkpointEntryName);
+   checkpointer->readNamedCheckpointEntry(std::string(name), std::string("Delays"));
    return PV_SUCCESS;
 }
 

--- a/src/layers/HyPerLayer.cpp
+++ b/src/layers/HyPerLayer.cpp
@@ -574,7 +574,7 @@ void HyPerLayer::checkpointRandState(
          bufferName);
 }
 
-int HyPerLayer::initializeState() {
+int HyPerLayer::initializeState(Checkpointer *checkpointer) {
    int status       = PV_SUCCESS;
    PVParams *params = parent->parameters();
 

--- a/src/layers/HyPerLayer.cpp
+++ b/src/layers/HyPerLayer.cpp
@@ -585,7 +585,7 @@ int HyPerLayer::initializeState(Checkpointer *checkpointer) {
          parent->getInitializeFromCheckpointDir() && parent->getInitializeFromCheckpointDir()[0]) {
       assert(!params->presentAndNotBeenRead(name, "initializeFromCheckpointFlag"));
       if (initializeFromCheckpointFlag) {
-         status = readStateFromCheckpoint(parent->getInitializeFromCheckpointDir(), NULL);
+         status = readStateFromCheckpoint(checkpointer);
       }
       else {
          status = setInitialValues();
@@ -2204,52 +2204,38 @@ int HyPerLayer::outputState(double timef, bool last) {
    return status;
 }
 
-int HyPerLayer::readStateFromCheckpoint(const char *cpDir, double *timeptr) {
+int HyPerLayer::readStateFromCheckpoint(Checkpointer *checkpointer) {
    // If timeptr is NULL, the timestamps in the pvp files are ignored.  If non-null, they are
    // compared to the value of *timeptr and
    // a warning is issued if there is a discrepancy.
    int status = PV_SUCCESS;
-   status     = readActivityFromCheckpoint(cpDir, timeptr);
-   status     = readVFromCheckpoint(cpDir, timeptr);
-   status     = readDelaysFromCheckpoint(cpDir, timeptr);
+   status     = readActivityFromCheckpoint(checkpointer);
+   status     = readVFromCheckpoint(checkpointer);
+   status     = readDelaysFromCheckpoint(checkpointer);
    return status;
 }
 
-int HyPerLayer::readActivityFromCheckpoint(const char *cpDir, double *timeptr) {
-   char *filename = parent->pathInCheckpoint(cpDir, getName(), "_A.pvp");
-   int status     = readBufferFile(
-         filename,
-         parent->getCommunicator(),
-         timeptr,
-         &clayer->activity->data,
-         1,
-         /*extended*/ true,
-         getLayerLoc());
-   assert(status == PV_SUCCESS);
-   free(filename);
-   assert(status == PV_SUCCESS);
-   return status;
+int HyPerLayer::readActivityFromCheckpoint(Checkpointer *checkpointer) {
+   std::string checkpointEntryName(name);
+   checkpointEntryName.append("_A");
+   checkpointer->initializeFromCheckpointDir(checkpointEntryName);
+   return PV_SUCCESS;
 }
 
-int HyPerLayer::readVFromCheckpoint(const char *cpDir, double *timeptr) {
-   int status = PV_SUCCESS;
-   if (getV() != NULL) {
-      char *filename = parent->pathInCheckpoint(cpDir, getName(), "_V.pvp");
-      float *V       = getV();
-      status         = readBufferFile(
-            filename, parent->getCommunicator(), timeptr, &V, 1, /*extended*/ false, getLayerLoc());
-      assert(status == PV_SUCCESS);
-      free(filename);
+int HyPerLayer::readVFromCheckpoint(Checkpointer *checkpointer) {
+   if (getV() != nullptr) {
+      std::string checkpointEntryName(name);
+      checkpointEntryName.append("_V");
+      checkpointer->initializeFromCheckpointDir(checkpointEntryName);
    }
-   return status;
+   return PV_SUCCESS;
 }
 
-int HyPerLayer::readDelaysFromCheckpoint(const char *cpDir, double *timeptr) {
-   char *filename = parent->pathInCheckpoint(cpDir, getName(), "_Delays.pvp");
-   int status     = readDataStoreFromFile(filename, parent->getCommunicator(), timeptr);
-   assert(status == PV_SUCCESS);
-   free(filename);
-   return status;
+int HyPerLayer::readDelaysFromCheckpoint(Checkpointer *checkpointer) {
+   std::string checkpointEntryName(name);
+   checkpointEntryName.append("_Delays");
+   checkpointer->initializeFromCheckpointDir(checkpointEntryName);
+   return PV_SUCCESS;
 }
 
 template <class T>

--- a/src/layers/HyPerLayer.hpp
+++ b/src/layers/HyPerLayer.hpp
@@ -255,10 +255,10 @@ class HyPerLayer : public BaseLayer {
 
    virtual int initializeV();
    virtual int initializeActivity();
-   virtual int readStateFromCheckpoint(const char *cpDir, double *timeptr);
-   virtual int readActivityFromCheckpoint(const char *cpDir, double *timeptr);
-   virtual int readVFromCheckpoint(const char *cpDir, double *timeptr);
-   virtual int readDelaysFromCheckpoint(const char *cpDir, double *timeptr);
+   virtual int readStateFromCheckpoint(Checkpointer *checkpointer);
+   virtual int readActivityFromCheckpoint(Checkpointer *checkpointer);
+   virtual int readVFromCheckpoint(Checkpointer *checkpointer);
+   virtual int readDelaysFromCheckpoint(Checkpointer *checkpointer);
 #ifdef PV_USE_CUDA
    virtual int copyInitialStateToGPU();
 #endif // PV_USE_CUDA

--- a/src/layers/HyPerLayer.hpp
+++ b/src/layers/HyPerLayer.hpp
@@ -475,9 +475,10 @@ class HyPerLayer : public BaseLayer {
    virtual int communicateInitInfo() override;
    virtual int allocateDataStructures() override;
    virtual int registerData(Checkpointer *checkpointer, std::string const &objName) override;
-   virtual int initializeState() final; // Not overridable since all layers should respond to
-   // initializeFromCheckpointFlag and (deprecated) restartFlag in the same way.
-   // initializeState calls the virtual methods readStateFromCheckpoint() and setInitialValues().
+   virtual int initializeState(Checkpointer *checkpointer) override final;
+   // Not overridable since all layers should respond to initializeFromCheckpointFlag and
+   // (deprecated) restartFlag in the same way. initializeState calls the virtual methods
+   // readStateFromCheckpoint() and setInitialValues().
 
    int openOutputStateFile();
 /* static methods called by updateState({long_argument_list})*/

--- a/src/layers/LCALIFLayer.cpp
+++ b/src/layers/LCALIFLayer.cpp
@@ -258,30 +258,24 @@ int LCALIFLayer::updateState(double timed, double dt) {
    return PV_SUCCESS;
 }
 
-int LCALIFLayer::readStateFromCheckpoint(const char *cpDir, double *timeptr) {
-   int status      = LIFGap::readStateFromCheckpoint(cpDir, timeptr);
+int LCALIFLayer::readStateFromCheckpoint(Checkpointer *checkpointer) {
+   int status      = LIFGap::readStateFromCheckpoint(checkpointer);
    double filetime = 0.0;
-   status          = read_integratedSpikeCountFromCheckpoint(cpDir, timeptr);
-   status          = readVadptFromCheckpoint(cpDir, timeptr);
+   status          = read_integratedSpikeCountFromCheckpoint(checkpointer);
+   status          = readVadptFromCheckpoint(checkpointer);
    return status;
 }
 
-int LCALIFLayer::read_integratedSpikeCountFromCheckpoint(const char *cpDir, double *timeptr) {
-   char *filename = parent->pathInCheckpoint(cpDir, getName(), "_integratedSpikeCount.pvp");
-   int status     = readBufferFile(
-         filename, parent->getCommunicator(), timeptr, &Vth, 1, /*extended*/ true, getLayerLoc());
-   assert(status == PV_SUCCESS);
-   free(filename);
-   return status;
+int LCALIFLayer::read_integratedSpikeCountFromCheckpoint(Checkpointer *checkpointer) {
+   std::string checkpointEntryName(name);
+   checkpointEntryName.append("_integratedSpikeCount.pvp");
+   return PV_SUCCESS;
 }
 
-int LCALIFLayer::readVadptFromCheckpoint(const char *cpDir, double *timeptr) {
-   char *filename = parent->pathInCheckpoint(cpDir, getName(), "_Vadpt.pvp");
-   int status     = readBufferFile(
-         filename, parent->getCommunicator(), timeptr, &Vth, 1, /*extended*/ true, getLayerLoc());
-   assert(status == PV_SUCCESS);
-   free(filename);
-   return status;
+int LCALIFLayer::readVadptFromCheckpoint(Checkpointer *checkpointer) {
+   std::string checkpointEntryName(name);
+   checkpointEntryName.append("_Vadpt.pvp");
+   return PV_SUCCESS;
 }
 
 } // namespace PV

--- a/src/layers/LCALIFLayer.hpp
+++ b/src/layers/LCALIFLayer.hpp
@@ -37,9 +37,9 @@ class LCALIFLayer : public PV::LIFGap {
    virtual void ioParam_normalizeInput(enum ParamsIOFlag ioFlag);
    virtual void ioParam_Vscale(enum ParamsIOFlag ioFlag);
    virtual int registerData(Checkpointer *checkpointer, std::string const &objName) override;
-   virtual int readStateFromCheckpoint(const char *cpDir, double *timeptr) override;
-   virtual int read_integratedSpikeCountFromCheckpoint(const char *cpDir, double *timeptr);
-   virtual int readVadptFromCheckpoint(const char *cpDir, double *timeptr);
+   virtual int readStateFromCheckpoint(Checkpointer *checkpointer) override;
+   virtual int read_integratedSpikeCountFromCheckpoint(Checkpointer *checkpointer);
+   virtual int readVadptFromCheckpoint(Checkpointer *checkpointer);
 
    int allocateBuffers() override;
 

--- a/src/layers/LIF.cpp
+++ b/src/layers/LIF.cpp
@@ -349,61 +349,48 @@ int LIF::allocateConductances(int num_channels) {
    return PV_SUCCESS;
 }
 
-int LIF::readStateFromCheckpoint(const char *cpDir, double *timeptr) {
-   HyPerLayer::readStateFromCheckpoint(cpDir, timeptr);
-   readVthFromCheckpoint(cpDir, timeptr);
-   readG_EFromCheckpoint(cpDir, timeptr);
-   readG_IFromCheckpoint(cpDir, timeptr);
-   readG_IBFromCheckpoint(cpDir, timeptr);
-   readRandStateFromCheckpoint(cpDir, timeptr);
+int LIF::readStateFromCheckpoint(Checkpointer *checkpointer) {
+   HyPerLayer::readStateFromCheckpoint(checkpointer);
+   readVthFromCheckpoint(checkpointer);
+   readG_EFromCheckpoint(checkpointer);
+   readG_IFromCheckpoint(checkpointer);
+   readG_IBFromCheckpoint(checkpointer);
+   readRandStateFromCheckpoint(checkpointer);
    return PV_SUCCESS;
 }
 
-int LIF::readVthFromCheckpoint(const char *cpDir, double *timeptr) {
-   char *filename = parent->pathInCheckpoint(cpDir, getName(), "_Vth.pvp");
-   int status     = readBufferFile(
-         filename, parent->getCommunicator(), timeptr, &Vth, 1, /*extended*/ true, getLayerLoc());
-   assert(status == PV_SUCCESS);
-   free(filename);
-   return status;
+int LIF::readVthFromCheckpoint(Checkpointer *checkpointer) {
+   std::string checkpointEntryName(name);
+   checkpointEntryName.append("_Vth.pvp");
+   checkpointer->initializeFromCheckpointDir(checkpointEntryName);
+   return PV_SUCCESS;
 }
 
-int LIF::readG_EFromCheckpoint(const char *cpDir, double *timeptr) {
-   char *filename = parent->pathInCheckpoint(cpDir, getName(), "_G_E.pvp");
-   int status     = readBufferFile(
-         filename, parent->getCommunicator(), timeptr, &G_E, 1, /*extended*/ true, getLayerLoc());
-   assert(status == PV_SUCCESS);
-   free(filename);
-   return status;
+int LIF::readG_EFromCheckpoint(Checkpointer *checkpointer) {
+   std::string checkpointEntryName(name);
+   checkpointEntryName.append("_G_E.pvp");
+   checkpointer->initializeFromCheckpointDir(checkpointEntryName);
+   return PV_SUCCESS;
 }
 
-int LIF::readG_IFromCheckpoint(const char *cpDir, double *timeptr) {
-   char *filename = parent->pathInCheckpoint(cpDir, getName(), "_G_I.pvp");
-   int status     = readBufferFile(
-         filename, parent->getCommunicator(), timeptr, &G_I, 1, /*extended*/ true, getLayerLoc());
-   assert(status == PV_SUCCESS);
-   free(filename);
-   return status;
+int LIF::readG_IFromCheckpoint(Checkpointer *checkpointer) {
+   std::string checkpointEntryName(name);
+   checkpointEntryName.append("_G_I.pvp");
+   checkpointer->initializeFromCheckpointDir(checkpointEntryName);
+   return PV_SUCCESS;
 }
 
-int LIF::readG_IBFromCheckpoint(const char *cpDir, double *timeptr) {
-   char *filename = parent->pathInCheckpoint(cpDir, getName(), "_G_IB.pvp");
-   int status     = readBufferFile(
-         filename, parent->getCommunicator(), timeptr, &G_IB, 1, /*extended*/ true, getLayerLoc());
-   assert(status == PV_SUCCESS);
-   free(filename);
-   return status;
+int LIF::readG_IBFromCheckpoint(Checkpointer *checkpointer) {
+   std::string checkpointEntryName(name);
+   checkpointEntryName.append("_G_IB.pvp");
+   checkpointer->initializeFromCheckpointDir(checkpointEntryName);
+   return PV_SUCCESS;
 }
 
-int LIF::readRandStateFromCheckpoint(const char *cpDir, double *timeptr) {
-   char *filename = parent->pathInCheckpoint(cpDir, getName(), "_rand_state.pvp");
-   *timeptr       = readRandState(
-         filename,
-         parent->getCommunicator(),
-         randState->getRNG(0),
-         getLayerLoc(),
-         false /*extended*/);
-   free(filename);
+int LIF::readRandStateFromCheckpoint(Checkpointer *checkpointer) {
+   std::string checkpointEntryName(name);
+   checkpointEntryName.append("_rand_state.pvp");
+   checkpointer->initializeFromCheckpointDir(checkpointEntryName);
    return PV_SUCCESS;
 }
 

--- a/src/layers/LIF.cpp
+++ b/src/layers/LIF.cpp
@@ -362,35 +362,35 @@ int LIF::readStateFromCheckpoint(Checkpointer *checkpointer) {
 int LIF::readVthFromCheckpoint(Checkpointer *checkpointer) {
    std::string checkpointEntryName(name);
    checkpointEntryName.append("_Vth.pvp");
-   checkpointer->initializeFromCheckpointDir(checkpointEntryName);
+   checkpointer->readNamedCheckpointEntry(checkpointEntryName);
    return PV_SUCCESS;
 }
 
 int LIF::readG_EFromCheckpoint(Checkpointer *checkpointer) {
    std::string checkpointEntryName(name);
    checkpointEntryName.append("_G_E.pvp");
-   checkpointer->initializeFromCheckpointDir(checkpointEntryName);
+   checkpointer->readNamedCheckpointEntry(checkpointEntryName);
    return PV_SUCCESS;
 }
 
 int LIF::readG_IFromCheckpoint(Checkpointer *checkpointer) {
    std::string checkpointEntryName(name);
    checkpointEntryName.append("_G_I.pvp");
-   checkpointer->initializeFromCheckpointDir(checkpointEntryName);
+   checkpointer->readNamedCheckpointEntry(checkpointEntryName);
    return PV_SUCCESS;
 }
 
 int LIF::readG_IBFromCheckpoint(Checkpointer *checkpointer) {
    std::string checkpointEntryName(name);
    checkpointEntryName.append("_G_IB.pvp");
-   checkpointer->initializeFromCheckpointDir(checkpointEntryName);
+   checkpointer->readNamedCheckpointEntry(checkpointEntryName);
    return PV_SUCCESS;
 }
 
 int LIF::readRandStateFromCheckpoint(Checkpointer *checkpointer) {
    std::string checkpointEntryName(name);
    checkpointEntryName.append("_rand_state.pvp");
-   checkpointer->initializeFromCheckpointDir(checkpointEntryName);
+   checkpointer->readNamedCheckpointEntry(checkpointEntryName);
    return PV_SUCCESS;
 }
 

--- a/src/layers/LIF.cpp
+++ b/src/layers/LIF.cpp
@@ -360,37 +360,27 @@ int LIF::readStateFromCheckpoint(Checkpointer *checkpointer) {
 }
 
 int LIF::readVthFromCheckpoint(Checkpointer *checkpointer) {
-   std::string checkpointEntryName(name);
-   checkpointEntryName.append("_Vth.pvp");
-   checkpointer->readNamedCheckpointEntry(checkpointEntryName);
+   checkpointer->readNamedCheckpointEntry(std::string(name), "Vth");
    return PV_SUCCESS;
 }
 
 int LIF::readG_EFromCheckpoint(Checkpointer *checkpointer) {
-   std::string checkpointEntryName(name);
-   checkpointEntryName.append("_G_E.pvp");
-   checkpointer->readNamedCheckpointEntry(checkpointEntryName);
+   checkpointer->readNamedCheckpointEntry(std::string(name), "G_E");
    return PV_SUCCESS;
 }
 
 int LIF::readG_IFromCheckpoint(Checkpointer *checkpointer) {
-   std::string checkpointEntryName(name);
-   checkpointEntryName.append("_G_I.pvp");
-   checkpointer->readNamedCheckpointEntry(checkpointEntryName);
+   checkpointer->readNamedCheckpointEntry(std::string(name), "G_I");
    return PV_SUCCESS;
 }
 
 int LIF::readG_IBFromCheckpoint(Checkpointer *checkpointer) {
-   std::string checkpointEntryName(name);
-   checkpointEntryName.append("_G_IB.pvp");
-   checkpointer->readNamedCheckpointEntry(checkpointEntryName);
+   checkpointer->readNamedCheckpointEntry(std::string(name), "G_IB");
    return PV_SUCCESS;
 }
 
 int LIF::readRandStateFromCheckpoint(Checkpointer *checkpointer) {
-   std::string checkpointEntryName(name);
-   checkpointEntryName.append("_rand_state.pvp");
-   checkpointer->readNamedCheckpointEntry(checkpointEntryName);
+   checkpointer->readNamedCheckpointEntry(std::string(name), "rand_state");
    return PV_SUCCESS;
 }
 

--- a/src/layers/LIF.hpp
+++ b/src/layers/LIF.hpp
@@ -109,12 +109,12 @@ class LIF : public PV::HyPerLayer {
    virtual void ioParam_method(enum ParamsIOFlag ioFlag);
    virtual int allocateBuffers() override;
    virtual int allocateConductances(int num_channels);
-   virtual int readStateFromCheckpoint(const char *cpDir, double *timeptr) override;
-   virtual int readVthFromCheckpoint(const char *cpDir, double *timeptr);
-   virtual int readG_EFromCheckpoint(const char *cpDir, double *timeptr);
-   virtual int readG_IFromCheckpoint(const char *cpDir, double *timeptr);
-   virtual int readG_IBFromCheckpoint(const char *cpDir, double *timeptr);
-   virtual int readRandStateFromCheckpoint(const char *cpDir, double *timeptr);
+   virtual int readStateFromCheckpoint(Checkpointer *checkpointer) override;
+   virtual int readVthFromCheckpoint(Checkpointer *checkpointer);
+   virtual int readG_EFromCheckpoint(Checkpointer *checkpointer);
+   virtual int readG_IFromCheckpoint(Checkpointer *checkpointer);
+   virtual int readG_IBFromCheckpoint(Checkpointer *checkpointer);
+   virtual int readRandStateFromCheckpoint(Checkpointer *checkpointer);
 
   private:
    int initialize_base();

--- a/src/layers/LIFGap.cpp
+++ b/src/layers/LIFGap.cpp
@@ -199,9 +199,7 @@ int LIFGap::readStateFromCheckpoint(Checkpointer *checkpointer) {
 }
 
 int LIFGap::readGapStrengthFromCheckpoint(Checkpointer *checkpointer) {
-   std::string checkpointEntryName(name);
-   checkpointEntryName.append("_gapStrength.pvp");
-   checkpointer->readNamedCheckpointEntry(checkpointEntryName);
+   checkpointer->readNamedCheckpointEntry(std::string(name), std::string("gapStrength"));
 }
 
 int LIFGap::updateState(double time, double dt) {

--- a/src/layers/LIFGap.cpp
+++ b/src/layers/LIFGap.cpp
@@ -201,7 +201,7 @@ int LIFGap::readStateFromCheckpoint(Checkpointer *checkpointer) {
 int LIFGap::readGapStrengthFromCheckpoint(Checkpointer *checkpointer) {
    std::string checkpointEntryName(name);
    checkpointEntryName.append("_gapStrength.pvp");
-   checkpointer->initializeFromCheckpointDir(checkpointEntryName);
+   checkpointer->readNamedCheckpointEntry(checkpointEntryName);
 }
 
 int LIFGap::updateState(double time, double dt) {

--- a/src/layers/LIFGap.cpp
+++ b/src/layers/LIFGap.cpp
@@ -192,27 +192,18 @@ int LIFGap::registerData(Checkpointer *checkpointer, std::string const &objName)
    return status;
 }
 
-int LIFGap::readStateFromCheckpoint(const char *cpDir, double *timeptr) {
-   int status = LIF::readStateFromCheckpoint(cpDir, timeptr);
-   status     = readGapStrengthFromCheckpoint(cpDir, timeptr);
+int LIFGap::readStateFromCheckpoint(Checkpointer *checkpointer) {
+   int status = LIF::readStateFromCheckpoint(checkpointer);
+   status     = readGapStrengthFromCheckpoint(checkpointer);
    return status;
 }
 
-int LIFGap::readGapStrengthFromCheckpoint(const char *cpDir, double *timeptr) {
-   char *filename = parent->pathInCheckpoint(cpDir, getName(), "_gapStrength.pvp");
-   int status     = readBufferFile(
-         filename,
-         parent->getCommunicator(),
-         timeptr,
-         &gapStrength,
-         1,
-         /*extended*/ false,
-         getLayerLoc());
-   assert(status == PV_SUCCESS);
-   free(filename);
-   gapStrengthInitialized = true;
-   return status;
+int LIFGap::readGapStrengthFromCheckpoint(Checkpointer *checkpointer) {
+   std::string checkpointEntryName(name);
+   checkpointEntryName.append("_gapStrength.pvp");
+   checkpointer->initializeFromCheckpointDir(checkpointEntryName);
 }
+
 int LIFGap::updateState(double time, double dt) {
    int status = PV_SUCCESS;
 

--- a/src/layers/LIFGap.hpp
+++ b/src/layers/LIFGap.hpp
@@ -24,7 +24,7 @@ class LIFGap : public PV::LIF {
 
    int virtual updateState(double time, double dt) override;
 
-   int virtual readStateFromCheckpoint(const char *cpDir, double *timeptr) override;
+   int virtual readStateFromCheckpoint(Checkpointer *checkpointer) override;
 
    const float *getGapStrength() { return gapStrength; }
 
@@ -33,7 +33,7 @@ class LIFGap : public PV::LIF {
    int initialize(const char *name, HyPerCol *hc, const char *kernel_name);
    virtual int allocateConductances(int num_channels) override;
    virtual int registerData(Checkpointer *checkpointer, std::string const &objName) override;
-   virtual int readGapStrengthFromCheckpoint(const char *cpDir, double *timeptr);
+   virtual int readGapStrengthFromCheckpoint(Checkpointer *checkpointer);
 
   private:
    int initialize_base();

--- a/src/layers/Retina.cpp
+++ b/src/layers/Retina.cpp
@@ -276,26 +276,18 @@ int Retina::setRetinaParams(PVParams *p) {
    return 0;
 }
 
-int Retina::readStateFromCheckpoint(const char *cpDir, double *timeptr) {
-   int status      = HyPerLayer::readStateFromCheckpoint(cpDir, timeptr);
+int Retina::readStateFromCheckpoint(Checkpointer *checkpointer) {
+   int status      = HyPerLayer::readStateFromCheckpoint(checkpointer);
    double filetime = 0.0;
-   readRandStateFromCheckpoint(cpDir);
+   readRandStateFromCheckpoint(checkpointer);
    return status;
 }
 
-int Retina::readRandStateFromCheckpoint(const char *cpDir) {
-   int status = PV_SUCCESS;
-   if (spikingFlag) {
-      char *filename = parent->pathInCheckpoint(cpDir, getName(), "_rand_state.pvp");
-      readRandState(
-            filename,
-            parent->getCommunicator(),
-            randState->getRNG(0),
-            getLayerLoc(),
-            true /*isExtended*/);
-      free(filename);
-   }
-   return status;
+int Retina::readRandStateFromCheckpoint(Checkpointer *checkpointer) {
+   std::string checkpointEntryName(name);
+   checkpointEntryName.append("_rand_state.pvp");
+   checkpointer->initializeFromCheckpointDir(checkpointEntryName);
+   return PV_SUCCESS;
 }
 
 int Retina::registerData(Checkpointer *checkpointer, std::string const &objName) {

--- a/src/layers/Retina.cpp
+++ b/src/layers/Retina.cpp
@@ -286,7 +286,7 @@ int Retina::readStateFromCheckpoint(Checkpointer *checkpointer) {
 int Retina::readRandStateFromCheckpoint(Checkpointer *checkpointer) {
    std::string checkpointEntryName(name);
    checkpointEntryName.append("_rand_state.pvp");
-   checkpointer->initializeFromCheckpointDir(checkpointEntryName);
+   checkpointer->readNamedCheckpointEntry(checkpointEntryName);
    return PV_SUCCESS;
 }
 

--- a/src/layers/Retina.cpp
+++ b/src/layers/Retina.cpp
@@ -284,9 +284,7 @@ int Retina::readStateFromCheckpoint(Checkpointer *checkpointer) {
 }
 
 int Retina::readRandStateFromCheckpoint(Checkpointer *checkpointer) {
-   std::string checkpointEntryName(name);
-   checkpointEntryName.append("_rand_state.pvp");
-   checkpointer->readNamedCheckpointEntry(checkpointEntryName);
+   checkpointer->readNamedCheckpointEntry(std::string(name), std::string("rand_state.pvp"));
    return PV_SUCCESS;
 }
 

--- a/src/layers/Retina.hpp
+++ b/src/layers/Retina.hpp
@@ -68,8 +68,8 @@ class Retina : public PV::HyPerLayer {
    virtual int registerData(Checkpointer *checkpointer, std::string const &objName);
    virtual int initializeV();
    virtual int initializeActivity();
-   virtual int readStateFromCheckpoint(const char *cpDir, double *timeptr);
-   virtual int readRandStateFromCheckpoint(const char *cpDir);
+   virtual int readStateFromCheckpoint(Checkpointer *checkpointer) override;
+   virtual int readRandStateFromCheckpoint(Checkpointer *checkpointer);
 
    bool spikingFlag; // specifies that layer is spiking
    Retina_params rParams; // used in update state

--- a/src/utils/PVLog.hpp
+++ b/src/utils/PVLog.hpp
@@ -54,7 +54,14 @@
 #endif // __GNUC__
 
 namespace PV {
-enum LogTypeEnum { LogInfoType, LogWarnType, LogFatalType, LogErrorType, LogDebugType, LogStackTraceType };
+enum LogTypeEnum {
+   LogInfoType,
+   LogWarnType,
+   LogFatalType,
+   LogErrorType,
+   LogDebugType,
+   LogStackTraceType
+};
 
 /**
  * Returns the stream used by InfoLog and, DebugLog

--- a/tests/CheckpointWeightTest/src/CheckpointWeightTest.cpp
+++ b/tests/CheckpointWeightTest/src/CheckpointWeightTest.cpp
@@ -19,7 +19,7 @@ int main(int argc, char *argv[]) {
    PV::PV_Init pv_initObj{&argc, &argv, false /*do not allow unrecognized arguments*/};
 
    // Delete checkpointDirectory, if present, to start fresh
-   if (pv_initObj.getCommunicator()->commRank()==0) {
+   if (pv_initObj.getCommunicator()->commRank() == 0) {
       std::string rmrfcommand("rm -rf ");
       rmrfcommand.append(checkpointDirectory);
       int status = system(rmrfcommand.c_str());

--- a/tests/ConnectionRestartTest/input/ConnectionRestartTest.params
+++ b/tests/ConnectionRestartTest/input/ConnectionRestartTest.params
@@ -8,7 +8,7 @@
 //  There is an image as an input layer, and two connections from that
 //  input to two output layers.  The connections both use InitWeightsMethod
 //  to set strength 1, but one of them uses initializeFromCheckpointFlag
-//  to set load from a checkpoint where the strength is two.
+//  to load from a checkpoint where the strength is two.
 //  After the run, the output layers should have value 1 and two, respectively.
 //
 

--- a/tests/ReduceAcrossBatchTest/src/main.cpp
+++ b/tests/ReduceAcrossBatchTest/src/main.cpp
@@ -57,8 +57,8 @@ int checkWeights(HyPerCol *hc, int argc, char *argv[]) {
    for (int k = 0; k < N; k++) {
       if (weights[k] != correctValues[k]) {
          status = PV_FAILURE;
-         ErrorLog() << "Weight index " << k << ": expected " << correctValues[k]
-                         << "; value was " << weights[k] << "\n";
+         ErrorLog() << "Weight index " << k << ": expected " << correctValues[k] << "; value was "
+                    << weights[k] << "\n";
       }
    }
    return PV_SUCCESS;


### PR DESCRIPTION
This pull request rewrites the readStateFromCheckpoint functionality (used when initializeFromCheckpointFlag is set) to use the Checkpointer class, so as to share as much code as possible with readCheckpoint (-c on the command line). In particular, this pull request fixes a bug that arose when using initializeFromCheckpointFlag with MPI batching. checkpointWrite inserts a directory for the batchsweep batchindex into the path, but readStateFromCheckpoint was not taking that into account.
