### PR TITLE
Separating Checkpointer and HyPerCol parameters

### DIFF
--- a/src/checkpointing/Checkpointer.cpp
+++ b/src/checkpointing/Checkpointer.cpp
@@ -36,7 +36,6 @@ void Checkpointer::initialize() {
 }
 
 void Checkpointer::ioParamsFillGroup(enum ParamsIOFlag ioFlag, PVParams *params) {
-   ioParam_verifyWrites(ioFlag, params);
    ioParam_checkpointWrite(ioFlag, params);
    ioParam_checkpointWriteDir(ioFlag, params);
    ioParam_checkpointWriteTriggerMode(ioFlag, params);
@@ -51,11 +50,6 @@ void Checkpointer::ioParamsFillGroup(enum ParamsIOFlag ioFlag, PVParams *params)
    ioParam_lastCheckpointDir(ioFlag, params);
    ioParam_initializeFromCheckpointDir(ioFlag, params);
    ioParam_defaultInitializeFromCheckpointFlag(ioFlag, params);
-}
-
-void Checkpointer::ioParam_verifyWrites(enum ParamsIOFlag ioFlag, PVParams *params) {
-   params->ioParamValue(
-         ioFlag, mName.c_str(), "verifyWrites", &mVerifyWritesFlag, mVerifyWritesFlag);
 }
 
 void Checkpointer::ioParam_checkpointWrite(enum ParamsIOFlag ioFlag, PVParams *params) {

--- a/src/checkpointing/Checkpointer.hpp
+++ b/src/checkpointing/Checkpointer.hpp
@@ -34,12 +34,16 @@ class Checkpointer : public Subject {
    void ioParam_checkpointWrite(enum ParamsIOFlag ioFlag, PVParams *params);
    void ioParam_checkpointWriteDir(enum ParamsIOFlag ioFlag, PVParams *params);
    void ioParam_checkpointWriteTriggerMode(enum ParamsIOFlag ioFlag, PVParams *params);
+
+   /**
+    * @brief checkpointWriteStepInterval: If checkpointWrite on step, specifies
+    * the number of steps between checkpoints.
+    */
    void ioParam_checkpointWriteStepInterval(enum ParamsIOFlag ioFlag, PVParams *params);
 
    /**
     * @brief checkpointWriteTimeInteval: If checkpointWrite on time, specifies
-    * the amount of
-    * simulation time between checkpoints.
+    * the amount of simulation time between checkpoints.
     */
    void ioParam_checkpointWriteTimeInterval(enum ParamsIOFlag ioFlag, PVParams *params);
 

--- a/src/checkpointing/Checkpointer.hpp
+++ b/src/checkpointing/Checkpointer.hpp
@@ -37,6 +37,11 @@ class Checkpointer : public Subject {
    void ioParam_checkpointWriteStepInterval(enum ParamsIOFlag ioFlag, PVParams *params);
    void ioParam_checkpointWriteTimeInterval(enum ParamsIOFlag ioFlag, PVParams *params);
    void ioParam_checkpointWriteClockInterval(enum ParamsIOFlag ioFlag, PVParams *params);
+
+   /**
+    * @brief checkpointWriteClockInteval: If checkpointWrite on clock, specifies
+    * the units used in checkpointWriteClockInterval.
+    */
    void ioParam_checkpointWriteClockUnit(enum ParamsIOFlag ioFlag, PVParams *params);
 
    /**

--- a/src/checkpointing/Checkpointer.hpp
+++ b/src/checkpointing/Checkpointer.hpp
@@ -32,6 +32,12 @@ class Checkpointer : public Subject {
 
    void ioParam_verifyWrites(enum ParamsIOFlag ioFlag, PVParams *params);
    void ioParam_checkpointWrite(enum ParamsIOFlag ioFlag, PVParams *params);
+
+   /**
+    * @brief checkpointWriteDir: If checkpointWrite is set, specifies the output
+    * checkpoint
+    * directory.
+    */
    void ioParam_checkpointWriteDir(enum ParamsIOFlag ioFlag, PVParams *params);
 
    /**

--- a/src/checkpointing/Checkpointer.hpp
+++ b/src/checkpointing/Checkpointer.hpp
@@ -35,6 +35,12 @@ class Checkpointer : public Subject {
    void ioParam_checkpointWriteDir(enum ParamsIOFlag ioFlag, PVParams *params);
    void ioParam_checkpointWriteTriggerMode(enum ParamsIOFlag ioFlag, PVParams *params);
    void ioParam_checkpointWriteStepInterval(enum ParamsIOFlag ioFlag, PVParams *params);
+
+   /**
+    * @brief checkpointWriteTimeInteval: If checkpointWrite on time, specifies
+    * the amount of
+    * simulation time between checkpoints.
+    */
    void ioParam_checkpointWriteTimeInterval(enum ParamsIOFlag ioFlag, PVParams *params);
 
    /**

--- a/src/checkpointing/Checkpointer.hpp
+++ b/src/checkpointing/Checkpointer.hpp
@@ -30,6 +30,32 @@ class Checkpointer : public Subject {
     * @{
     */
 
+   void ioParam_verifyWrites(enum ParamsIOFlag ioFlag, PVParams *params);
+   void ioParam_checkpointWrite(enum ParamsIOFlag ioFlag, PVParams *params);
+   void ioParam_checkpointWriteDir(enum ParamsIOFlag ioFlag, PVParams *params);
+   void ioParam_checkpointWriteTriggerMode(enum ParamsIOFlag ioFlag, PVParams *params);
+   void ioParam_checkpointWriteStepInterval(enum ParamsIOFlag ioFlag, PVParams *params);
+   void ioParam_checkpointWriteTimeInterval(enum ParamsIOFlag ioFlag, PVParams *params);
+   void ioParam_checkpointWriteClockInterval(enum ParamsIOFlag ioFlag, PVParams *params);
+   void ioParam_checkpointWriteClockUnit(enum ParamsIOFlag ioFlag, PVParams *params);
+
+   /**
+    * @brief If checkpointWrite is true, checkpointIndexWidth specifies the
+    * minimum width for the
+    * step number appearing in the checkpoint directory.
+    * @details If the step number needs fewer digits than checkpointIndexWidth,
+    * it is padded with
+    * zeroes.  If the step number needs more, the full
+    * step number is still printed.  Hence, setting checkpointWrite to zero means
+    * that there are
+    * never any padded zeroes.
+    * If set to a negative number, the width will be inferred from startTime,
+    * stopTime and dt.
+    * The default value is -1 (infer the width).
+    */
+   void ioParam_checkpointIndexWidth(enum ParamsIOFlag ioFlag, PVParams *params);
+   void ioParam_suppressNonplasticCheckpoints(enum ParamsIOFlag ioFlag, PVParams *params);
+
    /**
     * @brief deleteOlderCheckpoints: If checkpointWrite, specifies if the run
     * should delete older checkpoints when writing new ones.
@@ -115,7 +141,6 @@ class Checkpointer : public Subject {
    }
    long int getCheckpointWriteStepInterval() const { return mCheckpointWriteStepInterval; }
    double getCheckpointWriteSimtimeInterval() const { return mCheckpointWriteSimtimeInterval; }
-   int getCheckpointIndexWidth() const { return mCheckpointIndexWidth; }
    bool getSuppressNonplasticCheckpoints() const { return mSuppressNonplasticCheckpoints; }
    std::string const &getCheckpointReadDirectory() const { return mCheckpointReadDirectory; }
    char const *getLastCheckpointDir() const { return mLastCheckpointDir; }
@@ -126,16 +151,6 @@ class Checkpointer : public Subject {
 
   private:
    void initialize();
-   void ioParam_verifyWrites(enum ParamsIOFlag ioFlag, PVParams *params);
-   void ioParam_checkpointWrite(enum ParamsIOFlag ioFlag, PVParams *params);
-   void ioParam_checkpointWriteDir(enum ParamsIOFlag ioFlag, PVParams *params);
-   void ioParam_checkpointWriteTriggerMode(enum ParamsIOFlag ioFlag, PVParams *params);
-   void ioParam_checkpointWriteStepInterval(enum ParamsIOFlag ioFlag, PVParams *params);
-   void ioParam_checkpointWriteTimeInterval(enum ParamsIOFlag ioFlag, PVParams *params);
-   void ioParam_checkpointWriteClockInterval(enum ParamsIOFlag ioFlag, PVParams *params);
-   void ioParam_checkpointWriteClockUnit(enum ParamsIOFlag ioFlag, PVParams *params);
-   void ioParam_checkpointIndexWidth(enum ParamsIOFlag ioFlag, PVParams *params);
-   void ioParam_suppressNonplasticCheckpoints(enum ParamsIOFlag ioFlag, PVParams *params);
    void findWarmStartDirectory();
    bool checkpointWriteSignal();
    void checkpointWriteStep();

--- a/src/checkpointing/Checkpointer.hpp
+++ b/src/checkpointing/Checkpointer.hpp
@@ -54,6 +54,11 @@ class Checkpointer : public Subject {
     * The default value is -1 (infer the width).
     */
    void ioParam_checkpointIndexWidth(enum ParamsIOFlag ioFlag, PVParams *params);
+
+   /**
+    * If checkpointWrite is true and this flag is true,
+    * connections will only checkpoint if plasticityFlag=true.
+    */
    void ioParam_suppressNonplasticCheckpoints(enum ParamsIOFlag ioFlag, PVParams *params);
 
    /**

--- a/src/checkpointing/Checkpointer.hpp
+++ b/src/checkpointing/Checkpointer.hpp
@@ -31,6 +31,10 @@ class Checkpointer : public Subject {
     */
 
    void ioParam_verifyWrites(enum ParamsIOFlag ioFlag, PVParams *params);
+
+   /**
+    * @brief checkpointWrite: Flag to determine if the run writes checkpoints.
+    */
    void ioParam_checkpointWrite(enum ParamsIOFlag ioFlag, PVParams *params);
 
    /**

--- a/src/checkpointing/Checkpointer.hpp
+++ b/src/checkpointing/Checkpointer.hpp
@@ -33,6 +33,16 @@ class Checkpointer : public Subject {
    void ioParam_verifyWrites(enum ParamsIOFlag ioFlag, PVParams *params);
    void ioParam_checkpointWrite(enum ParamsIOFlag ioFlag, PVParams *params);
    void ioParam_checkpointWriteDir(enum ParamsIOFlag ioFlag, PVParams *params);
+
+   /**
+    * @brief mCheckpointWriteTriggerMode: If checkpointWrite is set, specifies
+    * the method to
+    * checkpoint.
+    * @details Possible choices include
+    * - step: Checkpoint off of timesteps
+    * - time: Checkpoint off of simulation time
+    * - clock: Checkpoint off of clock time. Not implemented yet.
+    */
    void ioParam_checkpointWriteTriggerMode(enum ParamsIOFlag ioFlag, PVParams *params);
 
    /**

--- a/src/checkpointing/Checkpointer.hpp
+++ b/src/checkpointing/Checkpointer.hpp
@@ -36,6 +36,13 @@ class Checkpointer : public Subject {
    void ioParam_checkpointWriteTriggerMode(enum ParamsIOFlag ioFlag, PVParams *params);
    void ioParam_checkpointWriteStepInterval(enum ParamsIOFlag ioFlag, PVParams *params);
    void ioParam_checkpointWriteTimeInterval(enum ParamsIOFlag ioFlag, PVParams *params);
+
+   /**
+    * @brief checkpointWriteClockInteval: If checkpointWrite on clock, specifies
+    * the amount of clock
+    * time between checkpoints.  The units are specified using the parameter
+    * checkpointWriteClockUnit
+    */
    void ioParam_checkpointWriteClockInterval(enum ParamsIOFlag ioFlag, PVParams *params);
 
    /**
@@ -46,11 +53,9 @@ class Checkpointer : public Subject {
 
    /**
     * @brief If checkpointWrite is true, checkpointIndexWidth specifies the
-    * minimum width for the
-    * step number appearing in the checkpoint directory.
+    * minimum width for the step number appearing in the checkpoint directory.
     * @details If the step number needs fewer digits than checkpointIndexWidth,
-    * it is padded with
-    * zeroes.  If the step number needs more, the full
+    * it is padded with zeroes.  If the step number needs more, the full
     * step number is still printed.  Hence, setting checkpointWrite to zero means
     * that there are
     * never any padded zeroes.

--- a/src/checkpointing/Checkpointer.hpp
+++ b/src/checkpointing/Checkpointer.hpp
@@ -30,8 +30,6 @@ class Checkpointer : public Subject {
     * @{
     */
 
-   void ioParam_verifyWrites(enum ParamsIOFlag ioFlag, PVParams *params);
-
    /**
     * @brief checkpointWrite: Flag to determine if the run writes checkpoints.
     */
@@ -168,6 +166,7 @@ class Checkpointer : public Subject {
    void registerTimer(Timer const *timer);
    virtual void addObserver(Observer *observer, BaseMessage const &message) override;
 
+   void setVerifyWrites(bool verifyWritesFlag) { mVerifyWritesFlag = verifyWritesFlag; }
    void setCheckpointReadDirectory();
    void setCheckpointReadDirectory(std::string const &checkpointReadDirectory);
    void readNamedCheckpointEntry(std::string const &objName, std::string const &dataName) const;

--- a/src/checkpointing/Checkpointer.hpp
+++ b/src/checkpointing/Checkpointer.hpp
@@ -80,7 +80,6 @@ class Checkpointer : public Subject {
    Checkpointer(std::string const &name, Communicator *comm);
    ~Checkpointer();
 
-   void setOutputPath(std::string const &outputPath);
    void ioParamsFillGroup(enum ParamsIOFlag ioFlag, PVParams *params);
    void provideFinalStep(long int finalStep);
 
@@ -109,7 +108,6 @@ class Checkpointer : public Subject {
 
    Communicator *getCommunicator() { return mCommunicator; }
    bool doesVerifyWrites() { return mVerifyWritesFlag; }
-   char const *getOutputPath() const { return mOutputPath; }
    bool getCheckpointWriteFlag() const { return mCheckpointWriteFlag; }
    char const *getcheckpointWriteDir() const { return mCheckpointWriteDir; }
    enum CheckpointWriteTriggerMode getCheckpointWriteTriggerMode() const {
@@ -129,7 +127,6 @@ class Checkpointer : public Subject {
   private:
    void initialize();
    void ioParam_verifyWrites(enum ParamsIOFlag ioFlag, PVParams *params);
-   void ioParam_outputPath(enum ParamsIOFlag ioFlag, PVParams *params);
    void ioParam_checkpointWrite(enum ParamsIOFlag ioFlag, PVParams *params);
    void ioParam_checkpointWriteDir(enum ParamsIOFlag ioFlag, PVParams *params);
    void ioParam_checkpointWriteTriggerMode(enum ParamsIOFlag ioFlag, PVParams *params);
@@ -160,7 +157,6 @@ class Checkpointer : public Subject {
    TimeInfo mTimeInfo;
    std::shared_ptr<CheckpointEntryData<TimeInfo>> mTimeInfoCheckpointEntry = nullptr;
    bool mVerifyWritesFlag                                                  = true;
-   char *mOutputPath                                                       = nullptr;
    bool mCheckpointWriteFlag                                               = false;
    char *mCheckpointWriteDir                                               = nullptr;
    char *mCheckpointWriteTriggerModeString                                 = nullptr;

--- a/src/columns/HyPerCol.cpp
+++ b/src/columns/HyPerCol.cpp
@@ -110,7 +110,6 @@ int HyPerCol::initialize_base() {
    mCpWriteClockInterval          = -1.0;
    mDeleteOlderCheckpoints        = false;
    mSuppressNonplasticCheckpoints = false;
-   mCheckpointIndexWidth          = -1; // defaults to automatically determine index width
    mStartTime                     = 0.0;
    mStopTime                      = 0.0;
    mDeltaTime                     = DEFAULT_DELTA_T;
@@ -336,7 +335,6 @@ int HyPerCol::ioParamsFillGroup(enum ParamsIOFlag ioFlag) {
       ioParam_checkpointWriteTimeInterval(ioFlag);
       ioParam_checkpointWriteClockInterval(ioFlag);
       ioParam_checkpointWriteClockUnit(ioFlag);
-      ioParam_checkpointIndexWidth(ioFlag);
       ioParam_suppressNonplasticCheckpoints(ioFlag);
    }
    ioParam_printParamsFilename(ioFlag);
@@ -882,14 +880,6 @@ void HyPerCol::ioParam_suppressNonplasticCheckpoints(enum ParamsIOFlag ioFlag) {
             "suppressNonplasticCheckpoints",
             &mSuppressNonplasticCheckpoints,
             mSuppressNonplasticCheckpoints);
-   }
-}
-
-void HyPerCol::ioParam_checkpointIndexWidth(enum ParamsIOFlag ioFlag) {
-   assert(!mParams->presentAndNotBeenRead(mName, "checkpointWrite"));
-   if (mCheckpointWriteFlag) {
-      parameters()->ioParamValue(
-            ioFlag, mName, "checkpointIndexWidth", &mCheckpointIndexWidth, mCheckpointIndexWidth);
    }
 }
 

--- a/src/columns/HyPerCol.cpp
+++ b/src/columns/HyPerCol.cpp
@@ -105,8 +105,6 @@ int HyPerCol::initialize_base() {
    mCheckpointWriteTriggerMode    = CPWRITE_TRIGGER_STEP;
    mCpWriteStepInterval           = -1L;
    mNextCpWriteStep               = 0L;
-   mCpWriteTimeInterval           = -1.0;
-   mNextCpWriteTime               = 0.0;
    mDeleteOlderCheckpoints        = false;
    mStartTime                     = 0.0;
    mStopTime                      = 0.0;
@@ -227,16 +225,12 @@ int HyPerCol::initialize(const char *name, PV_Init *initObj) {
       switch (mCheckpointWriteTriggerMode) {
          case CPWRITE_TRIGGER_STEP:
             mNextCpWriteStep      = mInitialStep;
-            mNextCpWriteTime      = mStartTime; // Should be unnecessary
-            mCpWriteTimeInterval  = -1;
             break;
          case CPWRITE_TRIGGER_TIME:
             mNextCpWriteStep      = mInitialStep; // Should be unnecessary
-            mNextCpWriteTime      = mStartTime;
             mCpWriteStepInterval  = -1;
             break;
          case CPWRITE_TRIGGER_CLOCK:
-            mCpWriteTimeInterval = -1;
             mCpWriteStepInterval = -1;
             break;
          default:
@@ -327,7 +321,6 @@ int HyPerCol::ioParamsFillGroup(enum ParamsIOFlag ioFlag) {
       ioParam_checkpointWriteDir(ioFlag);
       ioParam_checkpointWriteTriggerMode(ioFlag);
       ioParam_checkpointWriteStepInterval(ioFlag);
-      ioParam_checkpointWriteTimeInterval(ioFlag);
    }
    ioParam_printParamsFilename(ioFlag);
    ioParam_randomSeed(ioFlag);
@@ -769,17 +762,6 @@ void HyPerCol::ioParam_checkpointWriteStepInterval(enum ParamsIOFlag ioFlag) {
       if (mCheckpointWriteTriggerMode == CPWRITE_TRIGGER_STEP) {
          parameters()->ioParamValue(
                ioFlag, mName, "checkpointWriteStepInterval", &mCpWriteStepInterval, 1L);
-      }
-   }
-}
-
-void HyPerCol::ioParam_checkpointWriteTimeInterval(enum ParamsIOFlag ioFlag) {
-   assert(!mParams->presentAndNotBeenRead(mName, "checkpointWrite"));
-   if (mCheckpointWriteFlag) {
-      pvAssert(!mParams->presentAndNotBeenRead(mName, "checkpointWriteTriggerMode"));
-      if (mCheckpointWriteTriggerMode == CPWRITE_TRIGGER_TIME) {
-         parameters()->ioParamValue(
-               ioFlag, mName, "checkpointWriteTimeInterval", &mCpWriteTimeInterval, mDeltaTime);
       }
    }
 }

--- a/src/columns/HyPerCol.cpp
+++ b/src/columns/HyPerCol.cpp
@@ -1271,30 +1271,7 @@ int HyPerCol::outputParamsHeadComments(FILE *fp, char const *commentToken) {
    return PV_SUCCESS;
 }
 
-// Uses the arguments cpDir, objectName, and suffix to create a path of the form
-// [cpDir]/[objectName][suffix]
-// (the brackets are not in the created path, but the slash is)
-// The string returned is allocated with malloc, and the calling routine is
-// responsible for freeing
-// the string.
-char *HyPerCol::pathInCheckpoint(const char *cpDir, const char *objectName, const char *suffix) {
-   assert(cpDir != nullptr && suffix != nullptr);
-   size_t n = strlen(cpDir) + strlen("/") + strlen(objectName) + strlen(suffix)
-              + (size_t)1; // the +1 leaves room for the terminating null
-   char *filename = (char *)malloc(n);
-   if (filename == nullptr) {
-      Fatal().printf(
-            "Error: rank %d process unable to allocate filename \"%s/%s%s\": %s\n",
-            columnId(),
-            cpDir,
-            objectName,
-            suffix,
-            strerror(errno));
-   }
-   int chars_needed = snprintf(filename, n, "%s/%s%s", cpDir, objectName, suffix);
-   assert(chars_needed < n);
-   return filename;
-}
+// Nov 22, 2016: pathInCheckpoint removed. Made unnecessary by the Checkpointer refactor.
 
 int HyPerCol::getAutoGPUDevice() {
    int returnGpuIdx = -1;

--- a/src/columns/HyPerCol.cpp
+++ b/src/columns/HyPerCol.cpp
@@ -107,7 +107,6 @@ int HyPerCol::initialize_base() {
    mNextCpWriteStep               = 0L;
    mCpWriteTimeInterval           = -1.0;
    mNextCpWriteTime               = 0.0;
-   mCpWriteClockInterval          = -1.0;
    mDeleteOlderCheckpoints        = false;
    mStartTime                     = 0.0;
    mStopTime                      = 0.0;
@@ -230,13 +229,11 @@ int HyPerCol::initialize(const char *name, PV_Init *initObj) {
             mNextCpWriteStep      = mInitialStep;
             mNextCpWriteTime      = mStartTime; // Should be unnecessary
             mCpWriteTimeInterval  = -1;
-            mCpWriteClockInterval = -1.0;
             break;
          case CPWRITE_TRIGGER_TIME:
             mNextCpWriteStep      = mInitialStep; // Should be unnecessary
             mNextCpWriteTime      = mStartTime;
             mCpWriteStepInterval  = -1;
-            mCpWriteClockInterval = -1.0;
             break;
          case CPWRITE_TRIGGER_CLOCK:
             mCpWriteTimeInterval = -1;
@@ -331,7 +328,6 @@ int HyPerCol::ioParamsFillGroup(enum ParamsIOFlag ioFlag) {
       ioParam_checkpointWriteTriggerMode(ioFlag);
       ioParam_checkpointWriteStepInterval(ioFlag);
       ioParam_checkpointWriteTimeInterval(ioFlag);
-      ioParam_checkpointWriteClockInterval(ioFlag);
    }
    ioParam_printParamsFilename(ioFlag);
    ioParam_randomSeed(ioFlag);
@@ -784,17 +780,6 @@ void HyPerCol::ioParam_checkpointWriteTimeInterval(enum ParamsIOFlag ioFlag) {
       if (mCheckpointWriteTriggerMode == CPWRITE_TRIGGER_TIME) {
          parameters()->ioParamValue(
                ioFlag, mName, "checkpointWriteTimeInterval", &mCpWriteTimeInterval, mDeltaTime);
-      }
-   }
-}
-
-void HyPerCol::ioParam_checkpointWriteClockInterval(enum ParamsIOFlag ioFlag) {
-   assert(!mParams->presentAndNotBeenRead(mName, "checkpointWrite"));
-   if (mCheckpointWriteFlag) {
-      pvAssert(!mParams->presentAndNotBeenRead(mName, "checkpointWriteTriggerMode"));
-      if (mCheckpointWriteTriggerMode == CPWRITE_TRIGGER_CLOCK) {
-         parameters()->ioParamValueRequired(
-               ioFlag, mName, "checkpointWriteClockInterval", &mCpWriteClockInterval);
       }
    }
 }

--- a/src/columns/HyPerCol.cpp
+++ b/src/columns/HyPerCol.cpp
@@ -109,7 +109,6 @@ int HyPerCol::initialize_base() {
    mNextCpWriteTime               = 0.0;
    mCpWriteClockInterval          = -1.0;
    mDeleteOlderCheckpoints        = false;
-   mSuppressNonplasticCheckpoints = false;
    mStartTime                     = 0.0;
    mStopTime                      = 0.0;
    mDeltaTime                     = DEFAULT_DELTA_T;
@@ -335,7 +334,6 @@ int HyPerCol::ioParamsFillGroup(enum ParamsIOFlag ioFlag) {
       ioParam_checkpointWriteTimeInterval(ioFlag);
       ioParam_checkpointWriteClockInterval(ioFlag);
       ioParam_checkpointWriteClockUnit(ioFlag);
-      ioParam_suppressNonplasticCheckpoints(ioFlag);
    }
    ioParam_printParamsFilename(ioFlag);
    ioParam_randomSeed(ioFlag);
@@ -868,18 +866,6 @@ void HyPerCol::ioParam_checkpointWriteClockUnit(enum ParamsIOFlag ioFlag) {
                   strerror(errno));
          }
       }
-   }
-}
-
-void HyPerCol::ioParam_suppressNonplasticCheckpoints(enum ParamsIOFlag ioFlag) {
-   assert(!mParams->presentAndNotBeenRead(mName, "checkpointWrite"));
-   if (mCheckpointWriteFlag) {
-      parameters()->ioParamValue(
-            ioFlag,
-            mName,
-            "suppressNonplasticCheckpoints",
-            &mSuppressNonplasticCheckpoints,
-            mSuppressNonplasticCheckpoints);
    }
 }
 

--- a/src/columns/HyPerCol.cpp
+++ b/src/columns/HyPerCol.cpp
@@ -89,7 +89,6 @@ int HyPerCol::initialize_base() {
    // Initialize all member variables to safe values.  They will be set to their
    // actual values in
    // initialize()
-   mWarmStart                     = false;
    mReadyFlag                     = false;
    mParamsProcessedFlag           = false;
    mNumPhases                     = 0;
@@ -151,7 +150,6 @@ int HyPerCol::initialize(const char *name, PV_Init *initObj) {
    int rank                = mCommunicator->globalCommRank();
    const char *gpu_devices = mPVInitObj->getGPUDevices();
    std::string working_dir = expandLeadingTilde(mPVInitObj->getWorkingDir());
-   mWarmStart              = mPVInitObj->getRestartFlag();
 
    // Sep 27, 2016: handling --require-return has been moved to the Communicator
    // constructor.
@@ -213,11 +211,11 @@ int HyPerCol::initialize(const char *name, PV_Init *initObj) {
    mCheckpointer->registerCheckpointData(
          mName, "nextProgressTime", &mNextProgressTime, (std::size_t)1, true /*broadcast*/);
 
-   // mWarmStart is set if command line sets the -r option.  PV_Arguments should
-   // prevent -r and -c from being both set.
+   // PV_Arguments should prevent -r and -c from both being set.
+   bool warmStart = mPVInitObj->getRestartFlag();
    char const *checkpoint_read_dir = mPVInitObj->getCheckpointReadDir();
-   pvAssert(!(mWarmStart && checkpoint_read_dir));
-   if (mWarmStart) {
+   pvAssert(!(warmStart && checkpoint_read_dir));
+   if (warmStart) {
       mCheckpointer->setCheckpointReadDirectory();
    }
    if (checkpoint_read_dir) {

--- a/src/columns/HyPerCol.cpp
+++ b/src/columns/HyPerCol.cpp
@@ -103,8 +103,6 @@ int HyPerCol::initialize_base() {
    mCheckpointWriteFlag           = false;
    mCheckpointWriteDir            = nullptr;
    mCheckpointWriteTriggerMode    = CPWRITE_TRIGGER_STEP;
-   mCpWriteStepInterval           = -1L;
-   mNextCpWriteStep               = 0L;
    mDeleteOlderCheckpoints        = false;
    mStartTime                     = 0.0;
    mStopTime                      = 0.0;
@@ -224,14 +222,10 @@ int HyPerCol::initialize(const char *name, PV_Init *initObj) {
    if (mCheckpointWriteFlag) {
       switch (mCheckpointWriteTriggerMode) {
          case CPWRITE_TRIGGER_STEP:
-            mNextCpWriteStep      = mInitialStep;
             break;
          case CPWRITE_TRIGGER_TIME:
-            mNextCpWriteStep      = mInitialStep; // Should be unnecessary
-            mCpWriteStepInterval  = -1;
             break;
          case CPWRITE_TRIGGER_CLOCK:
-            mCpWriteStepInterval = -1;
             break;
          default:
             assert(0); // All cases of mCheckpointWriteTriggerMode should have been
@@ -320,7 +314,6 @@ int HyPerCol::ioParamsFillGroup(enum ParamsIOFlag ioFlag) {
       ioParam_checkpointWrite(ioFlag);
       ioParam_checkpointWriteDir(ioFlag);
       ioParam_checkpointWriteTriggerMode(ioFlag);
-      ioParam_checkpointWriteStepInterval(ioFlag);
    }
    ioParam_printParamsFilename(ioFlag);
    ioParam_randomSeed(ioFlag);
@@ -751,17 +744,6 @@ void HyPerCol::ioParam_checkpointWriteTriggerMode(enum ParamsIOFlag ioFlag) {
             MPI_Barrier(getCommunicator()->globalCommunicator());
             exit(EXIT_FAILURE);
          }
-      }
-   }
-}
-
-void HyPerCol::ioParam_checkpointWriteStepInterval(enum ParamsIOFlag ioFlag) {
-   assert(!mParams->presentAndNotBeenRead(mName, "checkpointWrite"));
-   if (mCheckpointWriteFlag) {
-      pvAssert(!mParams->presentAndNotBeenRead(mName, "checkpointWriteTriggerMode"));
-      if (mCheckpointWriteTriggerMode == CPWRITE_TRIGGER_STEP) {
-         parameters()->ioParamValue(
-               ioFlag, mName, "checkpointWriteStepInterval", &mCpWriteStepInterval, 1L);
       }
    }
 }

--- a/src/columns/HyPerCol.cpp
+++ b/src/columns/HyPerCol.cpp
@@ -94,7 +94,6 @@ int HyPerCol::initialize_base() {
    mParamsProcessedFlag           = false;
    mNumPhases                     = 0;
    mCheckpointReadFlag            = false;
-   mDeleteOlderCheckpoints        = false;
    mStartTime                     = 0.0;
    mStopTime                      = 0.0;
    mDeltaTime                     = DEFAULT_DELTA_T;
@@ -200,7 +199,6 @@ int HyPerCol::initialize(const char *name, PV_Init *initObj) {
    mCheckpointer = new Checkpointer(std::string(mName), mCommunicator);
    mCheckpointer->addObserver(this, BaseMessage{});
    ioParams(PARAMS_IO_READ);
-   mCheckpointSignal = 0;
    mSimTime          = mStartTime;
    mInitialStep      = (long int)nearbyint(mStartTime / mDeltaTime);
    mCurrentStep      = mInitialStep;

--- a/src/columns/HyPerCol.cpp
+++ b/src/columns/HyPerCol.cpp
@@ -83,10 +83,6 @@ HyPerCol::~HyPerCol() {
    // TODO: Change these old C strings into std::string
    free(mPrintParamsFilename);
    free(mOutputPath);
-   if (mCheckpointWriteFlag) {
-      free(mCheckpointWriteDir);
-      mCheckpointWriteDir = nullptr;
-   }
 }
 
 int HyPerCol::initialize_base() {
@@ -99,7 +95,6 @@ int HyPerCol::initialize_base() {
    mNumPhases                     = 0;
    mCheckpointReadFlag            = false;
    mCheckpointWriteFlag           = false;
-   mCheckpointWriteDir            = nullptr;
    mDeleteOlderCheckpoints        = false;
    mStartTime                     = 0.0;
    mStopTime                      = 0.0;
@@ -294,7 +289,6 @@ int HyPerCol::ioParamsFillGroup(enum ParamsIOFlag ioFlag) {
       // HyPerCol will redundantly read these parameters but not write them.
       ioParam_verifyWrites(ioFlag);
       ioParam_checkpointWrite(ioFlag);
-      ioParam_checkpointWriteDir(ioFlag);
    }
    ioParam_printParamsFilename(ioFlag);
    ioParam_randomSeed(ioFlag);
@@ -673,17 +667,6 @@ void HyPerCol::ioParam_checkpointRead(enum ParamsIOFlag ioFlag) {
 
 void HyPerCol::ioParam_checkpointWrite(enum ParamsIOFlag ioFlag) {
    parameters()->ioParamValue(ioFlag, mName, "checkpointWrite", &mCheckpointWriteFlag, false);
-}
-
-void HyPerCol::ioParam_checkpointWriteDir(enum ParamsIOFlag ioFlag) {
-   pvAssert(!mParams->presentAndNotBeenRead(mName, "checkpointWrite"));
-   if (mCheckpointWriteFlag) {
-      parameters()->ioParamStringRequired(
-            ioFlag, mName, "checkpointWriteDir", &mCheckpointWriteDir);
-   }
-   else {
-      mCheckpointWriteDir = nullptr;
-   }
 }
 
 void HyPerCol::ioParam_errorOnNotANumber(enum ParamsIOFlag ioFlag) {

--- a/src/columns/HyPerCol.cpp
+++ b/src/columns/HyPerCol.cpp
@@ -215,9 +215,6 @@ int HyPerCol::initialize(const char *name, PV_Init *initObj) {
 
    mCheckpointer = new Checkpointer(std::string(mName), mCommunicator);
    mCheckpointer->addObserver(this, BaseMessage{});
-   if (mOutputPath) {
-      mCheckpointer->setOutputPath(mOutputPath);
-   }
    ioParams(PARAMS_IO_READ);
    mCheckpointSignal = 0;
    mSimTime          = mStartTime;
@@ -325,13 +322,13 @@ int HyPerCol::ioParamsFillGroup(enum ParamsIOFlag ioFlag) {
    ioParam_stopTime(ioFlag);
    ioParam_progressInterval(ioFlag);
    ioParam_writeProgressToErr(ioFlag);
+   ioParam_outputPath(ioFlag);
    mCheckpointer->ioParamsFillGroup(ioFlag, parameters());
    if (ioFlag == PARAMS_IO_READ) {
       // These parameters are read and written by mCheckpointer.
       // During the transition of checkpointing from HyPerCol to Checkpointer,
       // HyPerCol will redundantly read these parameters but not write them.
       ioParam_verifyWrites(ioFlag);
-      ioParam_outputPath(ioFlag);
       ioParam_checkpointWrite(ioFlag);
       ioParam_checkpointWriteDir(ioFlag);
       ioParam_checkpointWriteTriggerMode(ioFlag);

--- a/src/columns/HyPerCol.cpp
+++ b/src/columns/HyPerCol.cpp
@@ -94,7 +94,6 @@ int HyPerCol::initialize_base() {
    mParamsProcessedFlag           = false;
    mNumPhases                     = 0;
    mCheckpointReadFlag            = false;
-   mCheckpointWriteFlag           = false;
    mDeleteOlderCheckpoints        = false;
    mStartTime                     = 0.0;
    mStopTime                      = 0.0;
@@ -288,7 +287,6 @@ int HyPerCol::ioParamsFillGroup(enum ParamsIOFlag ioFlag) {
       // During the transition of checkpointing from HyPerCol to Checkpointer,
       // HyPerCol will redundantly read these parameters but not write them.
       ioParam_verifyWrites(ioFlag);
-      ioParam_checkpointWrite(ioFlag);
    }
    ioParam_printParamsFilename(ioFlag);
    ioParam_randomSeed(ioFlag);
@@ -664,10 +662,6 @@ void HyPerCol::ioParam_checkpointRead(enum ParamsIOFlag ioFlag) {
 
 // athresher, July 20th
 // Removed ioParam_checkpointRead(). It was marked obsolete.
-
-void HyPerCol::ioParam_checkpointWrite(enum ParamsIOFlag ioFlag) {
-   parameters()->ioParamValue(ioFlag, mName, "checkpointWrite", &mCheckpointWriteFlag, false);
-}
 
 void HyPerCol::ioParam_errorOnNotANumber(enum ParamsIOFlag ioFlag) {
    parameters()->ioParamValue(

--- a/src/columns/HyPerCol.cpp
+++ b/src/columns/HyPerCol.cpp
@@ -277,13 +277,9 @@ int HyPerCol::ioParamsFillGroup(enum ParamsIOFlag ioFlag) {
    ioParam_progressInterval(ioFlag);
    ioParam_writeProgressToErr(ioFlag);
    ioParam_outputPath(ioFlag);
+   ioParam_verifyWrites(ioFlag);
+   mCheckpointer->setVerifyWrites(mVerifyWrites);
    mCheckpointer->ioParamsFillGroup(ioFlag, parameters());
-   if (ioFlag == PARAMS_IO_READ) {
-      // These parameters are read and written by mCheckpointer.
-      // During the transition of checkpointing from HyPerCol to Checkpointer,
-      // HyPerCol will redundantly read these parameters but not write them.
-      ioParam_verifyWrites(ioFlag);
-   }
    ioParam_printParamsFilename(ioFlag);
    ioParam_randomSeed(ioFlag);
    ioParam_nx(ioFlag);

--- a/src/columns/HyPerCol.hpp
+++ b/src/columns/HyPerCol.hpp
@@ -39,14 +39,6 @@
 
 namespace PV {
 
-enum CheckpointWriteTriggerMode {
-   CPWRITE_TRIGGER_STEP,
-   CPWRITE_TRIGGER_TIME,
-   CPWRITE_TRIGGER_CLOCK
-};
-
-enum TimeUnit { CLOCK_SECOND, CLOCK_MINUTE, CLOCK_HOUR, CLOCK_DAY };
-
 class ColProbe;
 class BaseProbe;
 class PVParams;
@@ -247,17 +239,6 @@ class HyPerCol : public Subject, Observer {
    virtual void ioParam_checkpointWriteDir(enum ParamsIOFlag ioFlag);
 
    /**
-    * @brief mCheckpointWriteTriggerMode: If checkpointWrite is set, specifies
-    * the method to
-    * checkpoint.
-    * @details Possible choices include
-    * - step: Checkpoint off of timesteps
-    * - time: Checkpoint off of simulation time
-    * - clock: Checkpoint off of clock time. Not implemented yet.
-    */
-   virtual void ioParam_checkpointWriteTriggerMode(enum ParamsIOFlag ioFlag);
-
-   /**
     * @brief writeTimescales:  Obsolete.  This parameter is now handled by
     * AdaptiveTimeScaleProbe,
     * as writeTimeScales.
@@ -454,7 +435,6 @@ class HyPerCol : public Subject, Observer {
    // constructor
    bool mWriteTimescales;
    char *mCheckpointWriteDir; // name of the directory to write checkpoints to
-   char *mCheckpointWriteTriggerModeString;
    char *mName;
    char *mOutputPath; // path to output file directory
    char *mPrintParamsFilename; // filename for outputting the mParams, including
@@ -471,7 +451,6 @@ class HyPerCol : public Subject, Observer {
    // Sep 26, 2016: Adaptive timestep routines and member variables have been
    // moved to
    // AdaptiveTimeScaleProbe.
-   enum CheckpointWriteTriggerMode mCheckpointWriteTriggerMode;
    std::vector<HyPerLayer *> mLayers; // HyPerLayer ** mLayers;
    int mNumPhases;
    int mCheckpointSignal; // whether the process should checkpoint in response to

--- a/src/columns/HyPerCol.hpp
+++ b/src/columns/HyPerCol.hpp
@@ -250,7 +250,6 @@ class HyPerCol : public Subject, Observer {
    virtual int respond(std::shared_ptr<BaseMessage const> message) override;
    BaseConnection *getConnFromName(const char *connectionName);
    BaseProbe *getBaseProbeFromName(const char *probeName);
-   char *pathInCheckpoint(const char *cpDir, const char *objectName, const char *suffix);
    ColProbe *getColProbeFromName(const char *probeName);
    HyPerLayer *getLayerFromName(const char *layerName);
 

--- a/src/columns/HyPerCol.hpp
+++ b/src/columns/HyPerCol.hpp
@@ -227,11 +227,6 @@ class HyPerCol : public Subject, Observer {
    virtual void ioParam_checkpointRead(enum ParamsIOFlag ioFlag);
 
    /**
-    * @brief checkpointWrite: Flag to determine if the run writes checkpoints.
-    */
-   virtual void ioParam_checkpointWrite(enum ParamsIOFlag ioFlag);
-
-   /**
     * @brief writeTimescales:  Obsolete.  This parameter is now handled by
     * AdaptiveTimeScaleProbe,
     * as writeTimeScales.
@@ -300,7 +295,7 @@ class HyPerCol : public Subject, Observer {
       return mCheckpointer->getDefaultInitializeFromCheckpointFlag();
    }
    bool getCheckpointReadFlag() const { return mCheckpointReadFlag; }
-   bool getCheckpointWriteFlag() const { return mCheckpointWriteFlag; }
+   bool getCheckpointWriteFlag() const { return mCheckpointer->getCheckpointWriteFlag(); }
    char const *getLastCheckpointDir() const { return mCheckpointer->getLastCheckpointDir(); }
    bool getWriteTimescales() const { return mWriteTimescales; }
    const char *getName() { return mName; }
@@ -408,7 +403,6 @@ class HyPerCol : public Subject, Observer {
    // exit with an error if any appear
    bool mWarmStart; // whether to start from a checkpoint
    bool mCheckpointReadFlag; // whether to load from a checkpoint directory
-   bool mCheckpointWriteFlag; // whether to write from a checkpoint directory
    bool mDeleteOlderCheckpoints; // If true, whenever a checkpoint other than the
    // first is written,
    // the preceding checkpoint is deleted. Default is false.

--- a/src/columns/HyPerCol.hpp
+++ b/src/columns/HyPerCol.hpp
@@ -258,13 +258,6 @@ class HyPerCol : public Subject, Observer {
    virtual void ioParam_checkpointWriteTriggerMode(enum ParamsIOFlag ioFlag);
 
    /**
-    * @brief checkpointWriteStepInterval: If checkpointWrite on step, specifies
-    * the number of steps
-    * between checkpoints.
-    */
-   virtual void ioParam_checkpointWriteStepInterval(enum ParamsIOFlag ioFlag);
-
-   /**
     * @brief writeTimescales:  Obsolete.  This parameter is now handled by
     * AdaptiveTimeScaleProbe,
     * as writeTimeScales.
@@ -502,8 +495,6 @@ class HyPerCol : public Subject, Observer {
 
    Checkpointer *mCheckpointer = nullptr; // manages checkpointing and, eventually,
    // will manage outputState output.
-   long int mCpWriteStepInterval;
-   long int mNextCpWriteStep;
    long int mInitialStep;
    long int mCurrentStep;
    long int mFinalStep;

--- a/src/columns/HyPerCol.hpp
+++ b/src/columns/HyPerCol.hpp
@@ -294,22 +294,6 @@ class HyPerCol : public Subject, Observer {
    virtual void ioParam_suppressNonplasticCheckpoints(enum ParamsIOFlag ioFlag);
 
    /**
-    * @brief If checkpointWrite is true, checkpointIndexWidth specifies the
-    * minimum width for the
-    * step number appearing in the checkpoint directory.
-    * @details If the step number needs fewer digits than checkpointIndexWidth,
-    * it is padded with
-    * zeroes.  If the step number needs more, the full
-    * step number is still printed.  Hence, setting checkpointWrite to zero means
-    * that there are
-    * never any padded zeroes.
-    * If set to a negative number, the width will be inferred from startTime,
-    * stopTime and dt.
-    * The default value is -1 (infer the width).
-    */
-   virtual void ioParam_checkpointIndexWidth(enum ParamsIOFlag ioFlag);
-
-   /**
     * @brief writeTimescales:  Obsolete.  This parameter is now handled by
     * AdaptiveTimeScaleProbe,
     * as writeTimeScales.
@@ -545,9 +529,6 @@ class HyPerCol : public Subject, Observer {
    // delete a checkpoint
    // until the specified number of more recent checkpoints have been
    // written.  Default is 2.
-   int mCheckpointIndexWidth; // minimum width of the step number field in the
-   // name of a checkpoint
-   // directory; if needed the step number is padded with zeros.
    int mNumXGlobal;
    int mNumYGlobal;
    int mNumBatch;

--- a/src/columns/HyPerCol.hpp
+++ b/src/columns/HyPerCol.hpp
@@ -403,9 +403,6 @@ class HyPerCol : public Subject, Observer {
    // exit with an error if any appear
    bool mWarmStart; // whether to start from a checkpoint
    bool mCheckpointReadFlag; // whether to load from a checkpoint directory
-   bool mDeleteOlderCheckpoints; // If true, whenever a checkpoint other than the
-   // first is written,
-   // the preceding checkpoint is deleted. Default is false.
    bool mReadyFlag; // Initially false; set to true when communicateInitInfo,
    // allocateDataStructures, and setInitialValues stages are completed
    bool mParamsProcessedFlag; // Initially false; set to true when processParams
@@ -439,12 +436,6 @@ class HyPerCol : public Subject, Observer {
    // AdaptiveTimeScaleProbe.
    std::vector<HyPerLayer *> mLayers; // HyPerLayer ** mLayers;
    int mNumPhases;
-   int mCheckpointSignal; // whether the process should checkpoint in response to
-   // an external signal
-   int mNumCheckpointsKept; // If mDeleteOlderCheckpoints is true, does not
-   // delete a checkpoint
-   // until the specified number of more recent checkpoints have been
-   // written.  Default is 2.
    int mNumXGlobal;
    int mNumYGlobal;
    int mNumBatch;
@@ -472,8 +463,6 @@ class HyPerCol : public Subject, Observer {
    size_t mLayerArraySize;
    size_t mConnectionArraySize;
    size_t mNormalizerArraySize;
-   std::vector<std::string> mOldCheckpointDirectories; // A ring buffer of existing checkpoints,
-   // used if mDeleteOlderCheckpoints is true.
    std::ofstream mTimeScaleStream;
    std::vector<HyPerLayer *> mRecvLayerBuffer;
    std::vector<HyPerLayer *> mUpdateLayerBufferGpu;

--- a/src/columns/HyPerCol.hpp
+++ b/src/columns/HyPerCol.hpp
@@ -289,7 +289,6 @@ class HyPerCol : public Subject, Observer {
    BaseConnection *getConnection(int which) { return mConnections.at(which); }
    BaseProbe *getBaseProbe(int which) { return mBaseProbes.at(which); }
    bool getVerifyWrites() { return mVerifyWrites; }
-   bool warmStartup() const { return mWarmStart; }
    bool getDefaultInitializeFromCheckpointFlag() {
       return mCheckpointer->getDefaultInitializeFromCheckpointFlag();
    }
@@ -400,7 +399,6 @@ class HyPerCol : public Subject, Observer {
    bool mErrorOnNotANumber; // If true, check each layer's activity buffer for
    // not-a-numbers and
    // exit with an error if any appear
-   bool mWarmStart; // whether to start from a checkpoint
    bool mCheckpointReadFlag; // whether to load from a checkpoint directory
    bool mReadyFlag; // Initially false; set to true when communicateInitInfo,
    // allocateDataStructures, and setInitialValues stages are completed

--- a/src/columns/HyPerCol.hpp
+++ b/src/columns/HyPerCol.hpp
@@ -232,13 +232,6 @@ class HyPerCol : public Subject, Observer {
    virtual void ioParam_checkpointWrite(enum ParamsIOFlag ioFlag);
 
    /**
-    * @brief checkpointWriteDir: If checkpointWrite is set, specifies the output
-    * checkpoint
-    * directory.
-    */
-   virtual void ioParam_checkpointWriteDir(enum ParamsIOFlag ioFlag);
-
-   /**
     * @brief writeTimescales:  Obsolete.  This parameter is now handled by
     * AdaptiveTimeScaleProbe,
     * as writeTimeScales.
@@ -434,7 +427,6 @@ class HyPerCol : public Subject, Observer {
    // passed in the
    // constructor
    bool mWriteTimescales;
-   char *mCheckpointWriteDir; // name of the directory to write checkpoints to
    char *mName;
    char *mOutputPath; // path to output file directory
    char *mPrintParamsFilename; // filename for outputting the mParams, including

--- a/src/columns/HyPerCol.hpp
+++ b/src/columns/HyPerCol.hpp
@@ -468,9 +468,6 @@ class HyPerCol : public Subject, Observer {
    std::vector<HyPerLayer *> mUpdateLayerBuffer;
    Timer *mRunTimer;
    std::vector<Timer *> mPhaseRecvTimers; // Timer ** mPhaseRecvTimers;
-   time_t mCpWriteClockSeconds; // If checkpoint mode is clock, the clock time
-   // between checkpoints,
-   // in seconds
    unsigned int mRandomSeed;
 #ifdef PV_USE_CUDA
    // The list of GPU group showing which connection's buffer to use

--- a/src/columns/HyPerCol.hpp
+++ b/src/columns/HyPerCol.hpp
@@ -272,14 +272,6 @@ class HyPerCol : public Subject, Observer {
    virtual void ioParam_checkpointWriteTimeInterval(enum ParamsIOFlag ioFlag);
 
    /**
-    * @brief checkpointWriteClockInteval: If checkpointWrite on clock, specifies
-    * the amount of clock
-    * time between checkpoints.  The units are specified using the parameter
-    * checkpointWriteClockUnit
-    */
-   virtual void ioParam_checkpointWriteClockInterval(enum ParamsIOFlag ioFlag);
-
-   /**
     * @brief writeTimescales:  Obsolete.  This parameter is now handled by
     * AdaptiveTimeScaleProbe,
     * as writeTimeScales.
@@ -489,8 +481,6 @@ class HyPerCol : public Subject, Observer {
    double mDeltaTime; // time step interval
    double mCpWriteTimeInterval;
    double mNextCpWriteTime;
-   double mCpWriteClockInterval; // If checkpoint mode is clock, the clock time
-   // between checkpoints,
    // in the units specified by checkpointWriteClockUnit
    double mProgressInterval; // Output progress after mSimTime increases by this
    // amount.

--- a/src/columns/HyPerCol.hpp
+++ b/src/columns/HyPerCol.hpp
@@ -287,13 +287,6 @@ class HyPerCol : public Subject, Observer {
    virtual void ioParam_checkpointWriteClockUnit(enum ParamsIOFlag ioFlag);
 
    /**
-    * If checkpointWrite is true and this flag is true, connections'
-    * checkpointWrite method will
-    * only be called for connections with plasticityFlag=false.
-    */
-   virtual void ioParam_suppressNonplasticCheckpoints(enum ParamsIOFlag ioFlag);
-
-   /**
     * @brief writeTimescales:  Obsolete.  This parameter is now handled by
     * AdaptiveTimeScaleProbe,
     * as writeTimeScales.
@@ -364,7 +357,6 @@ class HyPerCol : public Subject, Observer {
    bool getCheckpointReadFlag() const { return mCheckpointReadFlag; }
    bool getCheckpointWriteFlag() const { return mCheckpointWriteFlag; }
    char const *getLastCheckpointDir() const { return mCheckpointer->getLastCheckpointDir(); }
-   bool getSuppressNonplasticCheckpoints() const { return mSuppressNonplasticCheckpoints; }
    bool getWriteTimescales() const { return mWriteTimescales; }
    const char *getName() { return mName; }
    const char *getOutputPath() { return mOutputPath; }
@@ -475,10 +467,6 @@ class HyPerCol : public Subject, Observer {
    bool mDeleteOlderCheckpoints; // If true, whenever a checkpoint other than the
    // first is written,
    // the preceding checkpoint is deleted. Default is false.
-   bool mSuppressNonplasticCheckpoints; // If mSuppressNonplasticCheckpoints is
-   // true, only weights
-   // with plasticityFlag true will be checkpointed.  If false,
-   // all weights will be checkpointed.
    bool mReadyFlag; // Initially false; set to true when communicateInitInfo,
    // allocateDataStructures, and setInitialValues stages are completed
    bool mParamsProcessedFlag; // Initially false; set to true when processParams

--- a/src/columns/HyPerCol.hpp
+++ b/src/columns/HyPerCol.hpp
@@ -280,13 +280,6 @@ class HyPerCol : public Subject, Observer {
    virtual void ioParam_checkpointWriteClockInterval(enum ParamsIOFlag ioFlag);
 
    /**
-    * @brief checkpointWriteClockInteval: If checkpointWrite on clock, specifies
-    * the units used in
-    * checkpointWriteClockInterval.
-    */
-   virtual void ioParam_checkpointWriteClockUnit(enum ParamsIOFlag ioFlag);
-
-   /**
     * @brief writeTimescales:  Obsolete.  This parameter is now handled by
     * AdaptiveTimeScaleProbe,
     * as writeTimeScales.
@@ -484,9 +477,6 @@ class HyPerCol : public Subject, Observer {
    bool mWriteTimescales;
    char *mCheckpointWriteDir; // name of the directory to write checkpoints to
    char *mCheckpointWriteTriggerModeString;
-   char *mCheckpointWriteClockUnit; // If checkpoint mode is clock, the string
-   // that specifies the
-   // units.  "seconds", "minutes", "hours", or "days".
    char *mName;
    char *mOutputPath; // path to output file directory
    char *mPrintParamsFilename; // filename for outputting the mParams, including
@@ -557,7 +547,6 @@ class HyPerCol : public Subject, Observer {
    time_t mCpWriteClockSeconds; // If checkpoint mode is clock, the clock time
    // between checkpoints,
    // in seconds
-   time_t mNextCpWriteClock;
    unsigned int mRandomSeed;
 #ifdef PV_USE_CUDA
    // The list of GPU group showing which connection's buffer to use

--- a/src/columns/HyPerCol.hpp
+++ b/src/columns/HyPerCol.hpp
@@ -265,13 +265,6 @@ class HyPerCol : public Subject, Observer {
    virtual void ioParam_checkpointWriteStepInterval(enum ParamsIOFlag ioFlag);
 
    /**
-    * @brief checkpointWriteTimeInteval: If checkpointWrite on time, specifies
-    * the amount of
-    * simulation time between checkpoints.
-    */
-   virtual void ioParam_checkpointWriteTimeInterval(enum ParamsIOFlag ioFlag);
-
-   /**
     * @brief writeTimescales:  Obsolete.  This parameter is now handled by
     * AdaptiveTimeScaleProbe,
     * as writeTimeScales.
@@ -479,9 +472,6 @@ class HyPerCol : public Subject, Observer {
    double mSimTime;
    double mStopTime; // time to stop time
    double mDeltaTime; // time step interval
-   double mCpWriteTimeInterval;
-   double mNextCpWriteTime;
-   // in the units specified by checkpointWriteClockUnit
    double mProgressInterval; // Output progress after mSimTime increases by this
    // amount.
    double mNextProgressTime; // Next time to output a progress message

--- a/src/layers/HyPerLayer.hpp
+++ b/src/layers/HyPerLayer.hpp
@@ -262,7 +262,6 @@ class HyPerLayer : public BaseLayer {
 #ifdef PV_USE_CUDA
    virtual int copyInitialStateToGPU();
 #endif // PV_USE_CUDA
-   char *pathInCheckpoint(const char *cpDir, const char *suffix);
    int readDataStoreFromFile(const char *filename, Communicator *comm, double *timed);
    int incrementNBands(int *numCalls);
    void calcNumExtended();


### PR DESCRIPTION
In the current develop branch, there are several parameters that are read by both HyPerCol and Checkpointer, with only Checkpointer writing them to the generated params file.

This pull request assigns each of these parameters to only one class. Most of these parameters are in Checkpointer, with HyPerCol having a get-method that retrieves the Checkpointer data member if necessary. outputState is read by HyPerCol, as it is no longer needed by Checkpointer. verifyWrites is read by HyPerCol, and Checkpointer::setVerifyWrites() has been added, to remove the need for Checkpointer to read the verifyWrites param separately.

There is still some refactoring to be done before Checkpointer and HyPerCol are properly disentangled. Ideally, there would be no need for any of the following HyPerCol methods, but for now they remain:
getDefaultInitializeFromCheckpointFlag()
getCheckpointReadFlag()
getCheckpointWriteFlag()
getInitializeFromCheckpointDir()
getLastCheckpointDir()