### PR TITLE
Fixes checkpoint bugs

### DIFF
--- a/src/checkpointing/CheckpointEntry.cpp
+++ b/src/checkpointing/CheckpointEntry.cpp
@@ -18,20 +18,7 @@ namespace PV {
 std::string CheckpointEntry::generatePath(
       std::string const &checkpointDirectory,
       std::string const &extension) const {
-   std::string path(checkpointDirectory);
-   int batchWidth = getCommunicator()->numCommBatches();
-   if (batchWidth > 1) {
-      path.append("/batchsweep_");
-      std::size_t lengthLargestBatchIndex = std::to_string(batchWidth - 1).size();
-      std::string batchIndexAsString      = std::to_string(getCommunicator()->commBatch());
-      std::size_t lengthBatchIndex        = batchIndexAsString.size();
-      if (lengthBatchIndex < lengthLargestBatchIndex) {
-         path.append(lengthLargestBatchIndex - lengthBatchIndex, '0');
-      }
-      path.append(batchIndexAsString);
-      path.append("/");
-   }
-   ensureDirExists(getCommunicator(), path.c_str());
+   std::string path{checkpointDirectory};
    path.append("/").append(getName()).append(".").append(extension);
    return path;
 }

--- a/src/checkpointing/Checkpointer.hpp
+++ b/src/checkpointing/Checkpointer.hpp
@@ -169,8 +169,8 @@ class Checkpointer : public Subject {
    void setVerifyWrites(bool verifyWritesFlag) { mVerifyWritesFlag = verifyWritesFlag; }
    void setCheckpointReadDirectory();
    void setCheckpointReadDirectory(std::string const &checkpointReadDirectory);
-   void readNamedCheckpointEntry(std::string const &objName, std::string const &dataName) const;
-   void readNamedCheckpointEntry(std::string const &checkpointEntryName) const;
+   void readNamedCheckpointEntry(std::string const &objName, std::string const &dataName);
+   void readNamedCheckpointEntry(std::string const &checkpointEntryName);
    void checkpointRead(double *simTimePointer, long int *currentStepPointer);
    void checkpointWrite(double simTime);
    void finalCheckpoint(double simTime);
@@ -204,6 +204,7 @@ class Checkpointer : public Subject {
    void checkpointToDirectory(std::string const &checkpointDirectory);
    void rotateOldCheckpoints(std::string const &newCheckpointDirectory);
    void writeTimers(std::string const &directory);
+   std::string generateDirectory(std::string const &baseDirectory);
 
   private:
    std::string mName;


### PR DESCRIPTION
This pull request addresses some bugs in checkpointing:

When using batchsweeps, all checkpointing info is now written to the individual batchsweep folders. Previously, some files where written to the enclosing Checkpoint[_nnn_] folder instead.

Problems with deleting older checkpoints when batchsweeps now be fixed as well.