### PR TITLE
require-return works on command line when using config file

### DIFF
--- a/src/columns/CommandLineArguments.cpp
+++ b/src/columns/CommandLineArguments.cpp
@@ -15,72 +15,79 @@
 
 namespace PV {
 
-CommandLineArguments::CommandLineArguments(int argc, char *argv[], bool allowUnrecognizedArguments) {
+CommandLineArguments::CommandLineArguments(
+      int argc,
+      char const *const *argv,
+      bool allowUnrecognizedArguments) {
    initialize_base();
    initialize(argc, argv, allowUnrecognizedArguments);
 }
 
-int CommandLineArguments::initialize_base() {
-   return PV_SUCCESS;
-}
+int CommandLineArguments::initialize_base() { return PV_SUCCESS; }
 
-int CommandLineArguments::initialize(int argc, char *argv[], bool allowUnrecognizedArguments) {
+int CommandLineArguments::initialize(
+      int argc,
+      char const *const *argv,
+      bool allowUnrecognizedArguments) {
    resetState(argc, argv, allowUnrecognizedArguments);
    return PV_SUCCESS;
 }
 
-void CommandLineArguments::resetState(int argc, char *argv[], bool allowUnrecognizedArguments) {
+void CommandLineArguments::resetState(
+      int argc,
+      char const *const *argv,
+      bool allowUnrecognizedArguments) {
    bool paramUsage[argc];
-   bool requireReturn = false;
-   char *outputPath = nullptr;
-   char *paramsFile = nullptr;
-   char *logFile = nullptr;
-   char *gpuDevices = nullptr;
-   unsigned int randomSeed = 0U;
-   char *workingDir = nullptr;
-   int restart = 0;
-   char *checkpointReadDir = nullptr;
+   bool requireReturn        = false;
+   char *outputPath          = nullptr;
+   char *paramsFile          = nullptr;
+   char *logFile             = nullptr;
+   char *gpuDevices          = nullptr;
+   unsigned int randomSeed   = 0U;
+   char *workingDir          = nullptr;
+   int restart               = 0;
+   char *checkpointReadDir   = nullptr;
    bool useDefaultNumThreads = false;
-   int numThreads = 0;
-   int numRows = 0;
-   int numColumns = 0;
-   int batchWidth = 0;
-   int dryRun = 0;
+   int numThreads            = 0;
+   int numRows               = 0;
+   int numColumns            = 0;
+   int batchWidth            = 0;
+   int dryRun                = 0;
    parse_options(
-      argc,
-      argv,
-      paramUsage,
-      &requireReturn,
-      &outputPath,
-      &paramsFile,
-      &logFile,
-      &gpuDevices,
-      &randomSeed,
-      &workingDir,
-      &restart,
-      &checkpointReadDir,
-      &useDefaultNumThreads,
-      &numThreads,
-      &numRows,
-      &numColumns,
-      &batchWidth,
-      &dryRun);
+         argc,
+         argv,
+         paramUsage,
+         &requireReturn,
+         &outputPath,
+         &paramsFile,
+         &logFile,
+         &gpuDevices,
+         &randomSeed,
+         &workingDir,
+         &restart,
+         &checkpointReadDir,
+         &useDefaultNumThreads,
+         &numThreads,
+         &numRows,
+         &numColumns,
+         &batchWidth,
+         &dryRun);
    std::string configString = ConfigParser::createString(
-      requireReturn,
-      std::string{outputPath ? outputPath : ""},
-      std::string{paramsFile ? paramsFile : ""},
-      std::string{logFile ? logFile : ""},
-      std::string{gpuDevices ? gpuDevices : ""},
-      randomSeed,
-      std::string{workingDir ? workingDir : ""},
-      (bool) restart,
-      std::string{checkpointReadDir ? checkpointReadDir : ""},
-      useDefaultNumThreads,
-      numThreads,
-      numRows,
-      numColumns,
-      batchWidth,
-      (bool) dryRun);
+         requireReturn,
+         std::string{outputPath ? outputPath : ""},
+         std::string{paramsFile ? paramsFile : ""},
+         std::string{logFile ? logFile : ""},
+         std::string{gpuDevices ? gpuDevices : ""},
+         randomSeed,
+         std::string{workingDir ? workingDir : ""},
+         (bool)restart,
+         std::string{checkpointReadDir ? checkpointReadDir : ""},
+         useDefaultNumThreads,
+         numThreads,
+         numRows,
+         numColumns,
+         batchWidth,
+         (bool)dryRun);
    std::istringstream configStream{configString};
    Arguments::resetState(configStream, allowUnrecognizedArguments);
 }

--- a/src/columns/CommandLineArguments.hpp
+++ b/src/columns/CommandLineArguments.hpp
@@ -28,7 +28,7 @@ class CommandLineArguments : public Arguments {
     * See resetState(int, char **, bool) for details on how the argv array
     * is interpreted.
     */
-   CommandLineArguments(int argc, char *argv[], bool allowUnrecognizedArguments);
+   CommandLineArguments(int argc, char const *const *argv, bool allowUnrecognizedArguments);
 
    /*
     * The destructor for CommandLineArguments.
@@ -81,7 +81,7 @@ class CommandLineArguments : public Arguments {
     * If allowUnrecognizedArguments is set to false, the constructor fails if any
     * string in the argv array is not recoginzed.
     */
-   void resetState(int argc, char *argv[], bool allowUnrecognizedArguments);
+   void resetState(int argc, char const *const *argv, bool allowUnrecognizedArguments);
 
   private:
    /**
@@ -94,7 +94,7 @@ class CommandLineArguments : public Arguments {
     * initialize() is called by the constructor. It calls resetState
     * to set the initial values of the Arguments data members.
     */
-   int initialize(int argc, char *argv[], bool allowUnrecognizedArguments);
+   int initialize(int argc, char const *const *argv, bool allowUnrecognizedArguments);
 };
 
 } /* namespace PV */

--- a/src/columns/PV_Init.cpp
+++ b/src/columns/PV_Init.cpp
@@ -23,12 +23,11 @@ PV_Init::PV_Init(int *argc, char **argv[], bool allowUnrecognizedArguments) {
    commInit(argc, argv);
    initMaxThreads();
    mArgC = *argc;
-   mArgV = (char **)pvMallocError((size_t)(mArgC + 1) * sizeof(char *), "PV_Init failed to allocate memory for %d arguments: %s\n", mArgC, strerror(errno));
+   mArgV.resize(mArgC + 1);
    for (int a=0; a<mArgC; a++) {
       mArgV[a] = strdup(argv[0][a]);
       FatalIf(mArgV[a]==nullptr, "PV_Init unable to copy argument %d: %s\n", a, strerror(errno));
    }
-   mArgV[mArgC]  = nullptr;
    params        = nullptr;
    mCommunicator = nullptr;
    if (mArgC >= 2 && mArgV[1] != nullptr && mArgV[1][0] != '-') {
@@ -38,13 +37,13 @@ PV_Init::PV_Init(int *argc, char **argv[], bool allowUnrecognizedArguments) {
 
       // Check if "--require-return" was set.
       for (int arg = 2; arg < mArgC; arg++) {
-         if (pv_getopt(mArgC, mArgV, "--require-return", nullptr) == 0) {
+         if (pv_getopt(mArgC, mArgV.data(), "--require-return", nullptr) == 0) {
             arguments->setBooleanArgument("RequireReturn", true);
          }
       }
    }
    else {
-      arguments = new CommandLineArguments(mArgC, mArgV, allowUnrecognizedArguments);
+      arguments = new CommandLineArguments(mArgC, mArgV.data(), allowUnrecognizedArguments);
    }
    initLogFile(false /*appendFlag*/);
    initialize(); // must be called after initialization of arguments data member.
@@ -54,7 +53,6 @@ PV_Init::~PV_Init() {
    for (int a=0; a<mArgC; a++) {
       free(mArgV[a]);
    }
-   free(mArgV);
    delete params;
    delete mCommunicator;
    delete arguments;

--- a/src/columns/PV_Init.cpp
+++ b/src/columns/PV_Init.cpp
@@ -35,6 +35,13 @@ PV_Init::PV_Init(int *argc, char **argv[], bool allowUnrecognizedArguments) {
       // Communicator doesn't get set until call to initialize(), which we can't call until rows, columns, etc.
       // are set. We therefore need to use MPI_COMM_WORLD as the MPI communicator.
       arguments = new ConfigFileArguments(std::string{mArgV[1]}, MPI_COMM_WORLD, allowUnrecognizedArguments);
+
+      // Check if "--require-return" was set.
+      for (int arg = 2; arg < mArgC; arg++) {
+         if (pv_getopt(mArgC, mArgV, "--require-return", nullptr) == 0) {
+            arguments->setBooleanArgument("RequireReturn", true);
+         }
+      }
    }
    else {
       arguments = new CommandLineArguments(mArgC, mArgV, allowUnrecognizedArguments);

--- a/src/columns/PV_Init.hpp
+++ b/src/columns/PV_Init.hpp
@@ -282,7 +282,7 @@ class PV_Init {
    int commFinalize();
 
    int mArgC    = 0;
-   char **mArgV = nullptr;
+   std::vector<char *> mArgV;
    PVParams *params;
    Arguments *arguments;
    int maxThreads;

--- a/src/columns/PV_Init.hpp
+++ b/src/columns/PV_Init.hpp
@@ -281,8 +281,8 @@ class PV_Init {
 
    int commFinalize();
 
-   int mArgC    = 0;
-   std::vector<char *> mArgV;
+   int mArgC = 0;
+   std::vector<char const *> mArgV;
    PVParams *params;
    Arguments *arguments;
    int maxThreads;

--- a/src/io/io.cpp
+++ b/src/io/io.cpp
@@ -44,7 +44,7 @@ void usage() {
  */
 int parse_options(
       int argc,
-      char *argv[],
+      char const *const *argv,
       bool *paramusage,
       bool *require_return,
       char **output_path,
@@ -96,7 +96,7 @@ int parse_options(
  * @argv
  * @opt
  */
-int pv_getopt(int argc, char *argv[], const char *opt, bool *paramusage) {
+int pv_getopt(int argc, char const *const *argv, char const *opt, bool *paramusage) {
    int i;
    for (i = 1; i < argc; i++) {
       if (strcmp(argv[i], opt) == 0) {
@@ -115,7 +115,7 @@ int pv_getopt(int argc, char *argv[], const char *opt, bool *paramusage) {
  * @opt
  * @iVal
  */
-int pv_getopt_int(int argc, char *argv[], const char *opt, int *iVal, bool *paramusage) {
+int pv_getopt_int(int argc, char const *const *argv, char const *opt, int *iVal, bool *paramusage) {
    int i;
    for (i = 1; i < argc; i += 1) {
       if (i + 1 < argc && strcmp(argv[i], opt) == 0) {
@@ -133,8 +133,8 @@ int pv_getopt_int(int argc, char *argv[], const char *opt, int *iVal, bool *para
 
 int pv_getoptionalopt_int(
       int argc,
-      char *argv[],
-      const char *opt,
+      char const *const *argv,
+      char const *opt,
       int *iVal,
       bool *useDefaultVal,
       bool *paramusage) {
@@ -183,7 +183,12 @@ int pv_getoptionalopt_int(
  * @opt
  * @iVal
  */
-int pv_getopt_long(int argc, char *argv[], const char *opt, long int *iVal, bool *paramusage) {
+int pv_getopt_long(
+      int argc,
+      char const *const *argv,
+      char const *opt,
+      long int *iVal,
+      bool *paramusage) {
    int i;
    for (i = 1; i < argc; i += 1) {
       if (i + 1 < argc && strcmp(argv[i], opt) == 0) {
@@ -207,8 +212,8 @@ int pv_getopt_long(int argc, char *argv[], const char *opt, long int *iVal, bool
  */
 int pv_getopt_unsigned(
       int argc,
-      char *argv[],
-      const char *opt,
+      char const *const *argv,
+      char const *opt,
       unsigned int *uVal,
       bool *paramusage) {
    int i;
@@ -232,7 +237,12 @@ int pv_getopt_unsigned(
  * @opt
  * @sVal
  */
-int pv_getopt_str(int argc, char *argv[], const char *opt, char **sVal, bool *paramusage) {
+int pv_getopt_str(
+      int argc,
+      char const *const *argv,
+      char const *opt,
+      char **sVal,
+      bool *paramusage) {
    // sVal can be NULL.  If sVal is not null and the option is found,
    // the value of the option is put into sVal and the calling routine is
    // responsible for freeing it.
@@ -257,9 +267,7 @@ int pv_getopt_str(int argc, char *argv[], const char *opt, char **sVal, bool *pa
 
 // Unused function pv_center_image() removed Nov 16, 2016.
 
-std::string expandLeadingTilde(std::string const &path) {
-   return path.c_str();
-}
+std::string expandLeadingTilde(std::string const &path) { return path.c_str(); }
 
 std::string expandLeadingTilde(char const *path) {
    if (path == NULL) {

--- a/src/io/io.hpp
+++ b/src/io/io.hpp
@@ -78,20 +78,30 @@ namespace PV {
 
 enum ParamsIOFlag { PARAMS_IO_READ, PARAMS_IO_WRITE };
 
-int pv_getopt(int argc, char *argv[], const char *opt, bool *paramusage);
-int pv_getopt_int(int argc, char *argv[], const char *opt, int *iVal, bool *paramusage);
+int pv_getopt(int argc, char const *const *argv, const char *opt, bool *paramusage);
+int pv_getopt_int(int argc, char const *const *argv, const char *opt, int *iVal, bool *paramusage);
 int pv_getoptionalopt_int(
       int argc,
-      char *argv[],
+      char const *const *argv,
       const char *opt,
       int *iVal,
       bool *defaultVal,
       bool *paramusage);
-int pv_getopt_str(int argc, char *argv[], const char *opt, char **sVal, bool *paramusage);
-int pv_getopt_long(int argc, char *argv[], const char *opt, long int *ulVal, bool *paramusage);
+int pv_getopt_str(
+      int argc,
+      char const *const *argv,
+      const char *opt,
+      char **sVal,
+      bool *paramusage);
+int pv_getopt_long(
+      int argc,
+      char const *const *argv,
+      const char *opt,
+      long int *ulVal,
+      bool *paramusage);
 int pv_getopt_unsigned(
       int argc,
-      char *argv[],
+      char const *const *argv,
       const char *opt,
       unsigned int *uVal,
       bool *paramusage);
@@ -102,7 +112,7 @@ int readFile(const char *filename, float *buf, int *nx, int *ny);
 
 int parse_options(
       int argc,
-      char *argv[],
+      char const *const *argv,
       bool *paramusage,
       bool *require_return,
       char **output_path,


### PR DESCRIPTION
This pull request allows the RequireReturn flag to be set on the command line even when using a config file.

The rationale is that when debugging, it is still convenient to add `--require-return` on the command line as opposed to adding RequireReturn:true to the config file and then removing it.

This pull request also makes the parsing funcitions in io/io.hpp const-correct. PV_Init declares the data member holding the command line arguments as `vector<char const *>` instead of as `char**`.