### PR TITLE
Datastore checkpointing bug

### DIFF
--- a/src/checkpointing/CheckpointEntryDataStore.cpp
+++ b/src/checkpointing/CheckpointEntryDataStore.cpp
@@ -44,6 +44,7 @@ void CheckpointEntryDataStore::write(
          Buffer<float> globalPvpBuffer = BufferUtils::gather<float>(
                getCommunicator(), localPvpBuffer, mLayerLoc->nx, mLayerLoc->ny);
          if (fileStream) {
+            globalPvpBuffer.crop(mLayerLoc->nxGlobal, mLayerLoc->nyGlobal, Buffer<float>::CENTER);
             BufferUtils::writeFrame(*fileStream, &globalPvpBuffer, lastUpdateTime);
          }
       }
@@ -78,8 +79,9 @@ void CheckpointEntryDataStore::read(std::string const &checkpointDirectory, doub
    for (int b = 0; b < numBuffers; b++) {
       for (int l = 0; l < numLevels; l++) {
          if (fileStream) {
-            pvpBuffer.resize(nxExtGlobal, nyExtGlobal, nf);
-            double updateTime                 = BufferUtils::readFrame(*fileStream, &pvpBuffer);
+            pvpBuffer.resize(mLayerLoc->nxGlobal, mLayerLoc->nyGlobal, nf);
+            double updateTime = BufferUtils::readFrame(*fileStream, &pvpBuffer);
+            pvpBuffer.grow(nxExtGlobal, nyExtGlobal, Buffer<float>::CENTER);
             updateTimes.at(b * numLevels + l) = updateTime;
          }
          else {

--- a/src/checkpointing/Checkpointer.cpp
+++ b/src/checkpointing/Checkpointer.cpp
@@ -748,7 +748,7 @@ void Checkpointer::rotateOldCheckpoints(std::string const &newCheckpointDirector
          if (statstatus == 0 && (oldcp_stat.st_mode & S_IFDIR)) {
             int rmdirstatus = rmdir(oldestCheckpointDir.c_str());
             if (rmdirstatus) {
-               ErrorLog().printf("Unable to delete older checkpoint \"%s\": rmdir command returned %d (%s)\n", oldestCheckpointDir, errno, std::strerror(errno));
+               ErrorLog().printf("Unable to delete older checkpoint \"%s\": rmdir command returned %d (%s)\n", oldestCheckpointDir.c_str(), errno, std::strerror(errno));
             }
          }
       }

--- a/src/layers/InputLayer.cpp
+++ b/src/layers/InputLayer.cpp
@@ -792,8 +792,14 @@ void InputLayer::ioParam_skip_frame_index(enum ParamsIOFlag ioFlag) {
 }
 
 void InputLayer::ioParam_writeFrameToTimestamp(enum ParamsIOFlag ioFlag) {
-   parent->parameters()->ioParamValue(
-         ioFlag, name, "writeFrameToTimestamp", &mWriteFrameToTimestamp, mWriteFrameToTimestamp);
+   assert(!parent->parameters()->presentAndNotBeenRead(name, "displayPeriod"));
+   if (mDisplayPeriod > 0) {
+      parent->parameters()->ioParamValue(
+            ioFlag, name, "writeFrameToTimestamp", &mWriteFrameToTimestamp, mWriteFrameToTimestamp);
+   }
+   else {
+      mWriteFrameToTimestamp = false;
+   }
 }
 
 void InputLayer::ioParam_resetToStartOnLoop(enum ParamsIOFlag ioFlag) {

--- a/tests/BasicSystemTest/input/BasicSystemTest.params
+++ b/tests/BasicSystemTest/input/BasicSystemTest.params
@@ -42,6 +42,8 @@ PvpLayer "Input" = {
     nxScale = 1;  // this must be 2^n, n = ...,-2,-1,0,1,2,... 
     nyScale = 1;  // the scale is to decide how much area will be used as input. For exampel, nx * nxScale = 32. The size of input
     	      	  // cannot be larger than the input image size.
+    displayPeriod = 0; // If display period is zero, same image every timestep.
+                       // Otherwise, indicates the time interval between image flips.
     inputPath = "input/sampleimage.pvp"; // it's a 32*32 image
     nf = 1; //number of features. For a grey image, it's 1. For a color image, it could be either 1 or 3.
     phase = 0; //phase defines an order in which layers should be executed.

--- a/tests/DryRunFlagTest/input/correct.params
+++ b/tests/DryRunFlagTest/input/correct.params
@@ -43,7 +43,6 @@ PvpLayer "Input" = {
     padValue                            = 0;
     batchMethod                         = "byFile";
     start_frame_index                   = [0.000000];
-    writeFrameToTimestamp               = true;
     resetToStartOnLoop                  = false;
 };
 


### PR DESCRIPTION
This pull request does the following:

- fixes a bug in checkpointing the DataStore. The _Delays.pvp file now stores the restricted part of the data store properly.

- fixes a gcc version problem in an error statement in Checkpointer. In some cases newer versions of gcc can  implicitly add a .c_str() where needed for std::string arguments, but older versions cannot. This bugfix adds the .c_str().

- changes InputLayer so that the writeFrameToTimestamp parameter is only read if displayPeriod is positive. If displayPeriod is set to zero, writeFrameToTimestamp is set to false and there is no file in the timestamps directory for the layer.