### PR TITLE
FilenameParsingGroundTruthLayer: Param to specify path for classes.txt

### DIFF
--- a/src/layers/FilenameParsingGroundTruthLayer.cpp
+++ b/src/layers/FilenameParsingGroundTruthLayer.cpp
@@ -80,7 +80,7 @@ int FilenameParsingGroundTruthLayer::allocateDataStructures() {
       mClasses.push_back(line);
    }
    mInputFile.close();
-   return status; 
+   return status;
 }
 
 int FilenameParsingGroundTruthLayer::communicateInitInfo() {

--- a/src/layers/FilenameParsingGroundTruthLayer.cpp
+++ b/src/layers/FilenameParsingGroundTruthLayer.cpp
@@ -49,9 +49,11 @@ void FilenameParsingGroundTruthLayer::ioParam_inputLayerName(enum ParamsIOFlag i
 }
 
 void FilenameParsingGroundTruthLayer::ioParam_classList(enum ParamsIOFlag ioFlag) {
-   parent->parameters()->ioParamString(ioFlag, name, "classList", &mClassListFileName, mClassListFileName, false);
+   parent->parameters()->ioParamString(
+         ioFlag, name, "classList", &mClassListFileName, mClassListFileName, false);
    if (mClassListFileName == nullptr) {
-      WarnLog() << getName() << ": No classList specified. Looking for classes.txt in output directory.\n";
+      WarnLog() << getName()
+                << ": No classList specified. Looking for classes.txt in output directory.\n";
    }
 }
 
@@ -61,7 +63,7 @@ int FilenameParsingGroundTruthLayer::allocateDataStructures() {
    std::ifstream mInputFile;
    std::string outPath("");
 
-   if (mClassListFileName != nullptr) {   
+   if (mClassListFileName != nullptr) {
       outPath += std::string(mClassListFileName);
    }
    else {

--- a/src/layers/FilenameParsingGroundTruthLayer.cpp
+++ b/src/layers/FilenameParsingGroundTruthLayer.cpp
@@ -20,11 +20,14 @@ FilenameParsingGroundTruthLayer::FilenameParsingGroundTruthLayer(const char *nam
    initialize(name, hc);
 }
 
-FilenameParsingGroundTruthLayer::~FilenameParsingGroundTruthLayer() { free(mInputLayerName); }
+FilenameParsingGroundTruthLayer::~FilenameParsingGroundTruthLayer() {
+   free(mInputLayerName);
+   free(mClassListFileName);
+}
 
 int FilenameParsingGroundTruthLayer::ioParamsFillGroup(enum ParamsIOFlag ioFlag) {
    int status = ANNLayer::ioParamsFillGroup(ioFlag);
-   ioParam_classes(ioFlag);
+   ioParam_classList(ioFlag);
    ioParam_inputLayerName(ioFlag);
    ioParam_gtClassTrueValue(ioFlag);
    ioParam_gtClassFalseValue(ioFlag);
@@ -45,9 +48,27 @@ void FilenameParsingGroundTruthLayer::ioParam_inputLayerName(enum ParamsIOFlag i
    parent->parameters()->ioParamStringRequired(ioFlag, name, "inputLayerName", &mInputLayerName);
 }
 
-void FilenameParsingGroundTruthLayer::ioParam_classes(enum ParamsIOFlag ioFlag) {
-   std::string outPath = parent->getOutputPath();
-   outPath             = outPath + "/classes.txt";
+void FilenameParsingGroundTruthLayer::ioParam_classList(enum ParamsIOFlag ioFlag) {
+   parent->parameters()->ioParamString(ioFlag, name, "classList", &mClassListFileName, mClassListFileName, false);
+   if (mClassListFileName == nullptr) {
+      WarnLog() << getName() << ": No classList specified. Looking for classes.txt in output directory.\n";
+   }
+}
+
+int FilenameParsingGroundTruthLayer::allocateDataStructures() {
+   ANNLayer::allocateDataStructures();
+
+   std::ifstream mInputFile;
+   std::string outPath("");
+
+   if (mClassListFileName != nullptr) {   
+      outPath += std::string(mClassListFileName);
+   }
+   else {
+      outPath += parent->getOutputPath();
+      outPath += "/classes.txt";
+   }
+
    mInputFile.open(outPath.c_str(), std::ifstream::in);
    FatalIf(!mInputFile.is_open(), "%s: Unable to open file %s\n", getName(), outPath.c_str());
 

--- a/src/layers/FilenameParsingGroundTruthLayer.cpp
+++ b/src/layers/FilenameParsingGroundTruthLayer.cpp
@@ -58,7 +58,7 @@ void FilenameParsingGroundTruthLayer::ioParam_classList(enum ParamsIOFlag ioFlag
 }
 
 int FilenameParsingGroundTruthLayer::allocateDataStructures() {
-   ANNLayer::allocateDataStructures();
+   int status = ANNLayer::allocateDataStructures();
 
    std::ifstream mInputFile;
    std::string outPath("");
@@ -80,6 +80,7 @@ int FilenameParsingGroundTruthLayer::allocateDataStructures() {
       mClasses.push_back(line);
    }
    mInputFile.close();
+   return status; 
 }
 
 int FilenameParsingGroundTruthLayer::communicateInitInfo() {

--- a/src/layers/FilenameParsingGroundTruthLayer.hpp
+++ b/src/layers/FilenameParsingGroundTruthLayer.hpp
@@ -23,7 +23,6 @@ class FilenameParsingGroundTruthLayer : public ANNLayer {
    int ioParamsFillGroup(enum ParamsIOFlag ioFlag);
 
   private:
-
    std::vector<std::string> mClasses;
    char *mInputLayerName    = nullptr;
    char *mClassListFileName = nullptr;

--- a/src/layers/FilenameParsingGroundTruthLayer.hpp
+++ b/src/layers/FilenameParsingGroundTruthLayer.hpp
@@ -12,7 +12,7 @@
 
 namespace PV {
 
-class FilenameParsingGroundTruthLayer : public PV::ANNLayer {
+class FilenameParsingGroundTruthLayer : public ANNLayer {
 
   public:
    FilenameParsingGroundTruthLayer(const char *name, HyPerCol *hc);
@@ -23,14 +23,17 @@ class FilenameParsingGroundTruthLayer : public PV::ANNLayer {
    int ioParamsFillGroup(enum ParamsIOFlag ioFlag);
 
   private:
-   std::ifstream mInputFile;
+
    std::vector<std::string> mClasses;
    char *mInputLayerName    = nullptr;
+   char *mClassListFileName = nullptr;
    InputLayer *mInputLayer  = nullptr;
    float mGtClassTrueValue  = 1.0f;
    float mGtClassFalseValue = 0.0f;
 
   protected:
+   virtual int allocateDataStructures() override;
+
    /**
     * List of protected paramters needed from FilenameParsingGroundTruthLayer
     * @name FilenameParsingGroundTruthLayer Paramters
@@ -38,10 +41,10 @@ class FilenameParsingGroundTruthLayer : public PV::ANNLayer {
     */
 
    /**
-    * @brief classes: list the name of the .txt file that holds the list of imageListPath features
+    * @brief clasList: path to the .txt file that holds the list of imageListPath features
     * that will parse to different classifications
-    * @details classes.txt must be located in the output directory, the classifers separated by a
-    * new line, and must be discerning
+    * @details If this is not specified, the layer will attempt to use "classes.txt" in the output
+    * directory. The identifying strings must be separated by a new line, and mutually exclusive.
     * In the case of CIFAR images, the pictures are organized in folders /0/ /1/ /2/ ... etc,
     * therefore those are the classifers
     * When an image is passed to the movie layer, the classification is parsed and a corresponding
@@ -49,7 +52,7 @@ class FilenameParsingGroundTruthLayer : public PV::ANNLayer {
     * gtClassTrueValue and the remaining neurons are set to the value set by gtClassFalseValue
     */
 
-   virtual void ioParam_classes(enum ParamsIOFlag ioFlag);
+   virtual void ioParam_classList(enum ParamsIOFlag ioFlag);
 
    /**
     * @brief movieLayerName: lists name of the movie layer from which the imageListPath is used to

--- a/src/layers/RescaleLayer.cpp
+++ b/src/layers/RescaleLayer.cpp
@@ -704,9 +704,9 @@ int RescaleLayer::updateState(double timef, double dt) {
 #endif
          for (int iY = 0; iY < ny; iY++) {
             for (int iX = 0; iX < nx; iX++) {
-               float sumexpx  = 0;
-               float maxvalue = FLT_MIN; // To prevent overflow, we subtract the max raw value
-                                         // before taking the exponential
+               float sumexpx = 0;
+               // To prevent overflow, we subtract the max raw value before taking the exponential
+               float maxvalue = FLT_MIN;
                for (int iF = 0; iF < nf; iF++) {
                   int kextOrig = kIndex(
                         iX,


### PR DESCRIPTION
This pull request adds a "classList" param to FilenameParsingGroundTruthLayer that specifies a path to a text file. If present, the layer will use the file given to determine class labels. If the param is not present, it will fall back to the old behavior of looking for "classes.txt" in the output directory.