### PR TITLE
HyPerConn: Params to decay dWMax over time

### DIFF
--- a/src/connections/HyPerConn.cpp
+++ b/src/connections/HyPerConn.cpp
@@ -706,19 +706,21 @@ void HyPerConn::ioParam_pvpatchAccumulateType(enum ParamsIOFlag ioFlag) {
 
 void HyPerConn::ioParam_dWMaxDecayInterval(enum ParamsIOFlag ioFlag) {
    if (plasticityFlag) {
-      parent->parameters()->ioParamValue(ioFlag, name, "dWMaxDecayInterval", &mDWMaxDecayInterval, mDWMaxDecayInterval, false);
+      parent->parameters()->ioParamValue(
+            ioFlag, name, "dWMaxDecayInterval", &mDWMaxDecayInterval, mDWMaxDecayInterval, false);
    }
 }
 
 void HyPerConn::ioParam_dWMaxDecayFactor(enum ParamsIOFlag ioFlag) {
    if (plasticityFlag) {
-      parent->parameters()->ioParamValue(ioFlag, name, "dWMaxDecayFactor", &mDWMaxDecayFactor, mDWMaxDecayFactor, false);
-      FatalIf(mDWMaxDecayFactor < 0.0f || mDWMaxDecayFactor >= 1.0f,
-            "%s: dWMaxDecayFactor must be in the interval [0.0, 1.0)\n", getName());
+      parent->parameters()->ioParamValue(
+            ioFlag, name, "dWMaxDecayFactor", &mDWMaxDecayFactor, mDWMaxDecayFactor, false);
+      FatalIf(
+            mDWMaxDecayFactor < 0.0f || mDWMaxDecayFactor >= 1.0f,
+            "%s: dWMaxDecayFactor must be in the interval [0.0, 1.0)\n",
+            getName());
    }
 }
-
-
 
 void HyPerConn::unsetAccumulateType() {
    if (parent->columnId() == 0) {
@@ -2321,11 +2323,11 @@ int HyPerConn::updateState(double simTime, double dt) {
 
       if (mDWMaxDecayInterval > 0) {
          if (--mDWMaxDecayTimer < 0) {
-            float oldDWMax = dWMax;
+            float oldDWMax   = dWMax;
             mDWMaxDecayTimer = mDWMaxDecayInterval;
             dWMax *= 1.0f - mDWMaxDecayFactor;
-            InfoLog() << getName()
-               << ": dWMax decayed from " << oldDWMax << " to " << dWMax << "\n";
+            InfoLog() << getName() << ": dWMax decayed from " << oldDWMax << " to " << dWMax
+                      << "\n";
          }
       }
    }

--- a/src/connections/HyPerConn.cpp
+++ b/src/connections/HyPerConn.cpp
@@ -705,13 +705,17 @@ void HyPerConn::ioParam_pvpatchAccumulateType(enum ParamsIOFlag ioFlag) {
 }
 
 void HyPerConn::ioParam_dWMaxDecayInterval(enum ParamsIOFlag ioFlag) {
-   parent->parameters()->ioParamValue(ioFlag, name, "dWMaxDecayInterval", &mDWMaxDecayInterval, mDWMaxDecayInterval, false);
+   if (plasticityFlag) {
+      parent->parameters()->ioParamValue(ioFlag, name, "dWMaxDecayInterval", &mDWMaxDecayInterval, mDWMaxDecayInterval, false);
+   }
 }
 
 void HyPerConn::ioParam_dWMaxDecayFactor(enum ParamsIOFlag ioFlag) {
-   parent->parameters()->ioParamValue(ioFlag, name, "dWMaxDecayFactor", &mDWMaxDecayFactor, mDWMaxDecayFactor, false);
-   FatalIf(mDWMaxDecayFactor < 0.0f || mDWMaxDecayFactor >= 1.0f,
-         "%s: dWMaxDecayFactor must be in the interval [0.0, 1.0)\n", getName());
+   if (plasticityFlag) {
+      parent->parameters()->ioParamValue(ioFlag, name, "dWMaxDecayFactor", &mDWMaxDecayFactor, mDWMaxDecayFactor, false);
+      FatalIf(mDWMaxDecayFactor < 0.0f || mDWMaxDecayFactor >= 1.0f,
+            "%s: dWMaxDecayFactor must be in the interval [0.0, 1.0)\n", getName());
+   }
 }
 
 

--- a/src/connections/HyPerConn.hpp
+++ b/src/connections/HyPerConn.hpp
@@ -500,6 +500,10 @@ class HyPerConn : public BaseConnection {
 
    Random *randState;
 
+   int mDWMaxDecayInterval = 0; // How many weight updates between each dWMax modification
+   int mDWMaxDecayTimer    = 0; // Number of updates left before next dWMax modification
+   float mDWMaxDecayFactor = 0.0f; // Each modification is dWMax = dWMax * (1.0 - decayFactor);
+
   protected:
    HyPerConn();
    virtual int initNumWeightPatches();
@@ -801,6 +805,7 @@ class HyPerConn : public BaseConnection {
     * @brief maskLayerName: If using mask, specifies which feature dim to use for the mask
     * @details Defaults to -1, which means point wise mask
     */
+
    virtual void ioParam_maskFeatureIdx(enum ParamsIOFlag ioFlag);
 
 #ifdef PV_USE_CUDA
@@ -819,6 +824,8 @@ class HyPerConn : public BaseConnection {
     */
    virtual void ioParam_weightSparsity(enum ParamsIOFlag ioFlag);
 
+   virtual void ioParam_dWMaxDecayInterval(enum ParamsIOFlag ioFlag);
+   virtual void ioParam_dWMaxDecayFactor(enum ParamsIOFlag ioFlag);
    /** @} */
 
    int setPreLayerName(const char *pre_name);

--- a/src/layers/RescaleLayer.cpp
+++ b/src/layers/RescaleLayer.cpp
@@ -706,7 +706,7 @@ int RescaleLayer::updateState(double timef, double dt) {
             for (int iX = 0; iX < nx; iX++) {
                float sumexpx  = 0;
                float maxvalue = FLT_MIN; // To prevent overflow, we subtract the max raw value
-                                         // before taking the exponential
+               // before taking the exponential
                for (int iF = 0; iF < nf; iF++) {
                   int kextOrig = kIndex(
                         iX,


### PR DESCRIPTION
This pull request adds "dWMaxDecayInterval" and "dWMaxDecayFactor" params to HyPerConn. If plasticity is enabled, every DecayInterval weight updates the connection will modify dWMax:

    dWMax = dWMax * (1.0 - DecayFactor)

dWMaxDecayFactor must be greater than or equal to zero and less than 1.