### PR TITLE
BatchIndexer "random" batchMethod fixes

### DIFF
--- a/src/columns/RandomSeed.cpp
+++ b/src/columns/RandomSeed.cpp
@@ -27,12 +27,10 @@ void RandomSeed::initialize(unsigned int initialSeed) {
                                                   " is too small. Use a seed of at least "
               << minSeed << ".\n";
    }
-
    mInitialized = true;
+   mInitialSeed = initialSeed;
    mNextSeed    = initialSeed;
-   if (mInitialized) {
-      InfoLog() << "RandomSeed initialized to " << mNextSeed << ".\n";
-   }
+   InfoLog() << "RandomSeed initialized to " << mNextSeed << ".\n";
 }
 
 unsigned int RandomSeed::allocate(unsigned int numRequested) {

--- a/src/columns/RandomSeed.hpp
+++ b/src/columns/RandomSeed.hpp
@@ -15,7 +15,7 @@ class RandomSeed {
    static RandomSeed *instance();
    void initialize(unsigned int initialSeed);
    unsigned int allocate(unsigned int numRequested);
-
+   unsigned int getInitialSeed() { return mInitialSeed; }
   private:
    RandomSeed();
    virtual ~RandomSeed() {}
@@ -24,8 +24,9 @@ class RandomSeed {
    static unsigned int constexpr minSeed = 10000000U;
 
   private:
-   unsigned int mNextSeed = 0U;
-   bool mInitialized      = false;
+   unsigned int mNextSeed    = 0U;
+   unsigned int mInitialSeed = 0U;
+   bool mInitialized         = false;
    // minSeed needs to be high enough that for the pseudorandom sequence to be
    // good,
    // but must be less than (and should be much less than) ULONG_MAX/2

--- a/src/components/BatchIndexer.cpp
+++ b/src/components/BatchIndexer.cpp
@@ -77,6 +77,10 @@ void BatchIndexer::initializeBatch(int localBatchIndex) {
    }
    mIndices.at(localBatchIndex) = mStartIndices.at(localBatchIndex);
 }
+void BatchIndexer::setRandomSeed(int seed) {
+   mRandomSeed = seed; 
+   shuffleLookupTable();
+}
 
 // This clears the current file index lookup table and fills it with
 // randomly ordered ints from 0 to mFileCount. The random seed is

--- a/src/components/BatchIndexer.cpp
+++ b/src/components/BatchIndexer.cpp
@@ -77,7 +77,7 @@ void BatchIndexer::initializeBatch(int localBatchIndex) {
    }
    mIndices.at(localBatchIndex) = mStartIndices.at(localBatchIndex);
 }
-void BatchIndexer::setRandomSeed(int seed) {
+void BatchIndexer::setRandomSeed(unsigned int seed) {
    mRandomSeed = seed; 
    shuffleLookupTable();
 }
@@ -108,7 +108,7 @@ int BatchIndexer::registerData(Checkpointer *checkpointer, std::string const &ob
          mIndices.size(),
          false /*do not broadcast*/);
    if (mBatchMethod == RANDOM) {
-      checkpointer->registerCheckpointData<int>(
+      checkpointer->registerCheckpointData<unsigned int>(
             objName, std::string("RandomSeed"), &mRandomSeed, 1, false /*do not broadcast*/);
    }
    return PV_SUCCESS;

--- a/src/components/BatchIndexer.hpp
+++ b/src/components/BatchIndexer.hpp
@@ -21,7 +21,7 @@ class BatchIndexer : public CheckpointerDataInterface {
    void specifyBatching(int localBatchIndex, int startIndex, int skipAmount);
    void initializeBatch(int localBatchIndex);
    void shuffleLookupTable();
-   void setRandomSeed(int seed);
+   void setRandomSeed(unsigned int seed);
    virtual int registerData(Checkpointer *checkpointer, std::string const &objName) override;
    void setIndices(const std::vector<int> &indices) { mIndices = indices; }
    void setWrapToStartIndex(bool value) { mWrapToStartIndex = value; }
@@ -29,12 +29,12 @@ class BatchIndexer : public CheckpointerDataInterface {
    std::vector<int> getIndices() { return mIndices; }
 
   private:
-   int mGlobalBatchCount  = 0;
-   int mFileCount         = 0;
-   int mBatchWidth        = 0;
-   int mBatchWidthIndex   = 0;
-   int mRandomSeed        = 123456789;
-   bool mWrapToStartIndex = true;
+   int mGlobalBatchCount    = 0;
+   int mFileCount           = 0;
+   int mBatchWidth          = 0;
+   int mBatchWidthIndex     = 0;
+   unsigned int mRandomSeed = 123456789;
+   bool mWrapToStartIndex   = true;
    std::vector<int> mIndexLookupTable;
    std::vector<int> mIndices;
    std::vector<int> mStartIndices;

--- a/src/components/BatchIndexer.hpp
+++ b/src/components/BatchIndexer.hpp
@@ -21,7 +21,7 @@ class BatchIndexer : public CheckpointerDataInterface {
    void specifyBatching(int localBatchIndex, int startIndex, int skipAmount);
    void initializeBatch(int localBatchIndex);
    void shuffleLookupTable();
-   void setRandomSeed(int seed) { mRandomSeed = seed; }
+   void setRandomSeed(int seed);
    virtual int registerData(Checkpointer *checkpointer, std::string const &objName) override;
    void setIndices(const std::vector<int> &indices) { mIndices = indices; }
    void setWrapToStartIndex(bool value) { mWrapToStartIndex = value; }

--- a/src/layers/InputLayer.cpp
+++ b/src/layers/InputLayer.cpp
@@ -119,6 +119,7 @@ void InputLayer::initializeBatchIndexer(int fileCount) {
             mSkipFrameIndex.at(globalBatchOffset + b));
       mBatchIndexer->initializeBatch(b);
    }
+   mBatchIndexer->setRandomSeed(mRandomSeed);
 }
 
 // Virtual method used to spend multiple display periods on one file.

--- a/src/layers/InputLayer.cpp
+++ b/src/layers/InputLayer.cpp
@@ -5,6 +5,7 @@
 
 #include "InputLayer.hpp"
 #include "utils/BufferUtilsMPI.hpp"
+#include "columns/RandomSeed.hpp"
 
 #include <algorithm>
 #include <cfloat>
@@ -119,7 +120,7 @@ void InputLayer::initializeBatchIndexer(int fileCount) {
             mSkipFrameIndex.at(globalBatchOffset + b));
       mBatchIndexer->initializeBatch(b);
    }
-   mBatchIndexer->setRandomSeed(mRandomSeed);
+   mBatchIndexer->setRandomSeed(RandomSeed::instance()->getInitialSeed() + mRandomSeed);
 }
 
 // Virtual method used to spend multiple display periods on one file.


### PR DESCRIPTION
This pull request fixes the randomSeed param in InputLayers using batchMethod "random". The seed is now correctly applied. The seed in the inputLayer and the seed in HyPerCol are combined, so changing either one will result in a new order.