### PR TITLE
Addresses several warnings generated by g++ 6.2

### DIFF
--- a/src/connections/IdentConn.cpp
+++ b/src/connections/IdentConn.cpp
@@ -65,7 +65,7 @@ void IdentConn::ioParam_sharedWeights(enum ParamsIOFlag ioFlag) {
 void IdentConn::ioParam_initializeFromCheckpointFlag(enum ParamsIOFlag ioFlag) {
    if (ioFlag == PARAMS_IO_READ) {
       initializeFromCheckpointFlag = false;
-      parent->parameters()->handleUnnecessaryParameter(name, "sharedWeights");
+      parent->parameters()->handleUnnecessaryParameter(name, "initializeFromCheckpointFlag");
    }
 }
 

--- a/src/include/pv_types.h
+++ b/src/include/pv_types.h
@@ -30,7 +30,7 @@ enum PVDataType {
 typedef struct PVPatch_ {
    unsigned int offset;
    unsigned short nx, ny;
-} PVPatch __attribute__((aligned));
+} __attribute__((aligned)) PVPatch;
 
 typedef struct PVPatchStrides_ {
    int sx, sy, sf; // stride in x,y,features

--- a/src/layers/HyPerLayer.cpp
+++ b/src/layers/HyPerLayer.cpp
@@ -384,7 +384,7 @@ int HyPerLayer::setLayerLoc(
 
    float nxglobalfloat = nxScale * parent->getNxGlobal();
    layerLoc->nxGlobal  = (int)nearbyintf(nxglobalfloat);
-   if (fabs(nxglobalfloat - layerLoc->nxGlobal) > 0.0001) {
+   if (std::fabs(nxglobalfloat - layerLoc->nxGlobal) > 0.0001f) {
       if (parent->columnId() == 0) {
          ErrorLog(errorMessage);
          errorMessage.printf(
@@ -399,7 +399,7 @@ int HyPerLayer::setLayerLoc(
 
    float nyglobalfloat = nyScale * parent->getNyGlobal();
    layerLoc->nyGlobal  = (int)nearbyintf(nyglobalfloat);
-   if (fabs(nyglobalfloat - layerLoc->nyGlobal) > 0.0001) {
+   if (std::fabs(nyglobalfloat - layerLoc->nyGlobal) > 0.0001f) {
       if (parent->columnId() == 0) {
          ErrorLog(errorMessage);
          errorMessage.printf(

--- a/src/probes/L1NormProbe.cpp
+++ b/src/probes/L1NormProbe.cpp
@@ -64,7 +64,7 @@ double L1NormProbe::getValueInternal(double timevalue, int index) {
                for (int f = 0; f < nf; f++) {
                   int kex   = kIndexExtended(featureBase++, nx, ny, nf, lt, rt, dn, up);
                   float val = aBuffer[kex];
-                  sum += fabs(val);
+                  sum += (double)std::fabs(val);
                }
             }
          }
@@ -78,7 +78,7 @@ double L1NormProbe::getValueInternal(double timevalue, int index) {
             int kexMask = kIndexExtended(k, nx, ny, nf, maskLt, maskRt, maskDn, maskUp);
             if (maskLayerData[kexMask]) {
                float val = aBuffer[kex];
-               sum += fabs(val);
+               sum += std::fabs((double)val);
             }
          }
       }

--- a/tests/AvgPoolTest/src/GateAvgPoolTestLayer.cpp
+++ b/tests/AvgPoolTest/src/GateAvgPoolTestLayer.cpp
@@ -46,7 +46,7 @@ int GateAvgPoolTestLayer::updateState(double timef, double dt) {
                float expectedvalue;
                expectedvalue = iFeature * 64 + yval * 16 + xval * 2 + 4.5;
 
-               if (fabs(actualvalue - expectedvalue) >= 1e-4) {
+               if (std::fabs(actualvalue - expectedvalue) >= 1e-4f) {
                   ErrorLog() << "Connection " << name << " Mismatch at (" << iX << "," << iY
                              << ") : actual value: " << actualvalue
                              << " Expected value: " << expectedvalue

--- a/tests/BatchSweepTest/src/BatchSweepTestProbe.cpp
+++ b/tests/BatchSweepTest/src/BatchSweepTestProbe.cpp
@@ -50,9 +50,9 @@ int BatchSweepTestProbe::outputState(double timed) {
    }
    for (int b = 0; b < parent->getNBatch(); b++) {
       if (timed >= 3.0) {
-         FatalIf(!(fabs(expectedSum - sum[b]) < 1e-6), "Test failed.\n");
-         FatalIf(!(fabs(expectedMin - fMin[b]) < 1e-6), "Test failed.\n");
-         FatalIf(!(fabs(expectedMax - fMax[b]) < 1e-6), "Test failed.\n");
+         FatalIf(fabs(expectedSum - sum[b]) >= 1e-6, "Test failed.\n");
+         FatalIf(fabs(expectedMin - fMin[b]) >= 1e-6f, "Test failed.\n");
+         FatalIf(fabs(expectedMax - fMax[b]) >= 1e-6f, "Test failed.\n");
       }
    }
    return status;

--- a/tests/BatchWeightUpdateMpiTest/src/main.cpp
+++ b/tests/BatchWeightUpdateMpiTest/src/main.cpp
@@ -170,7 +170,7 @@ int compareFiles(const char *file1, const char *file2) {
                  << " as opposed to 1\n";
       }
       // Floating piont comparison
-      if (fabs(f1 - f2) <= 1e-5) {
+      if (std::fabs(f1 - f2) <= 1e-5f) {
          flag = 1;
          continue;
       }

--- a/tests/ImageSystemTest/src/ImagePvpTestLayer.cpp
+++ b/tests/ImageSystemTest/src/ImagePvpTestLayer.cpp
@@ -27,7 +27,7 @@ int ImagePvpTestLayer::updateState(double time, double dt) {
 
          float expectedVal =
                kIndex(kxGlobal, kyGlobal, kf, loc->nxGlobal, loc->nyGlobal, nf) + frameIdx * 192;
-         if (fabs(checkVal - expectedVal) >= 1e-5) {
+         if (fabs(checkVal - expectedVal) >= 1e-5f) {
             Fatal() << "ImageFileIO " << name << " test Expected: " << expectedVal
                     << " Actual: " << checkVal << "\n";
          }

--- a/tests/ImageSystemTest/src/ImageTestLayer.cpp
+++ b/tests/ImageSystemTest/src/ImageTestLayer.cpp
@@ -25,7 +25,7 @@ int ImageTestLayer::updateState(double time, double dt) {
          int kf       = featureIndex(nkRes, nx, ny, nf);
 
          float expectedVal = kIndex(kxGlobal, kyGlobal, kf, loc->nxGlobal, loc->nyGlobal, nf);
-         if (fabs(checkVal - expectedVal) >= 1e-5) {
+         if (std::fabs(checkVal - expectedVal) >= 1e-5f) {
             Fatal() << "ImageFileIO test Expected: " << expectedVal << " Actual: " << checkVal
                     << "\n";
          }

--- a/tests/ImageSystemTest/src/MoviePvpTestLayer.cpp
+++ b/tests/ImageSystemTest/src/MoviePvpTestLayer.cpp
@@ -38,7 +38,7 @@ int MoviePvpTestLayer::updateState(double time, double dt) {
 
          float expectedVal =
                kIndex(kxGlobal, kyGlobal, kf, loc->nxGlobal, loc->nyGlobal, nf) + frameIdx * 192;
-         if (fabs(checkVal - expectedVal) >= 1e-5) {
+         if (std::fabs(checkVal - expectedVal) >= 1e-5f) {
             ErrorLog() << "ImageFileIO " << name << " test Expected: " << expectedVal
                        << " Actual: " << checkVal << "\n";
          }

--- a/tests/ImageSystemTest/src/MovieTestLayer.cpp
+++ b/tests/ImageSystemTest/src/MovieTestLayer.cpp
@@ -35,7 +35,7 @@ int MovieTestLayer::updateState(double time, double dt) {
 
          float expectedVal =
                kIndex(kxGlobal, kyGlobal, kf, loc->nxGlobal, loc->nyGlobal, nf) + 10 * frameIdx;
-         if (fabs(checkVal - expectedVal) >= 1e-4) {
+         if (std::fabs(checkVal - expectedVal) >= 1e-4f) {
             Fatal() << name << " time: " << time << " batch: " << b << " Expected: " << expectedVal
                     << " Actual: " << checkVal << "\n";
          }

--- a/tests/LayerPhaseTest/src/LayerPhaseTestProbe.cpp
+++ b/tests/LayerPhaseTest/src/LayerPhaseTestProbe.cpp
@@ -48,7 +48,7 @@ int LayerPhaseTestProbe::outputState(double timed) {
    }
    for (int b = 0; b < parent->getNBatch(); b++) {
       if (timed >= equilibriumTime) {
-         double tol = 1e-6;
+         float tol = 1e-6;
          FatalIf(!(fabs(fMin[b] - equilibriumValue) < tol), "Test failed.\n");
          FatalIf(!(fabs(fMax[b] - equilibriumValue) < tol), "Test failed.\n");
          FatalIf(!(fabs(avg[b] - equilibriumValue) < tol), "Test failed.\n");

--- a/tests/ParameterSweepTest/src/ParameterSweepTestProbe.cpp
+++ b/tests/ParameterSweepTest/src/ParameterSweepTestProbe.cpp
@@ -50,9 +50,9 @@ int ParameterSweepTestProbe::outputState(double timed) {
    }
    for (int b = 0; b < parent->getNBatch(); b++) {
       if (timed >= 3.0) {
-         FatalIf(!(fabs(expectedSum - sum[b]) < 1e-6), "Test failed.\n");
-         FatalIf(!(fabs(expectedMin - fMin[b]) < 1e-6), "Test failed.\n");
-         FatalIf(!(fabs(expectedMax - fMax[b]) < 1e-6), "Test failed.\n");
+         FatalIf(fabs(expectedSum - sum[b]) >= 1e-6, "Test failed.\n");
+         FatalIf(fabs(expectedMin - fMin[b]) >= 1e-6f, "Test failed.\n");
+         FatalIf(fabs(expectedMax - fMax[b]) >= 1e-6f, "Test failed.\n");
       }
    }
    return status;

--- a/tests/SumPoolTest/src/GateSumPoolTestLayer.cpp
+++ b/tests/SumPoolTest/src/GateSumPoolTestLayer.cpp
@@ -47,7 +47,7 @@ int GateSumPoolTestLayer::updateState(double timef, double dt) {
                expectedvalue = iFeature * 64 + yval * 16 + xval * 2 + 4.5;
                expectedvalue *= 4;
 
-               if (fabs(actualvalue - expectedvalue) >= 1e-4) {
+               if (fabs(actualvalue - expectedvalue) >= 1e-4f) {
                   ErrorLog() << "Connection " << name << " Mismatch at (" << iX << "," << iY
                              << ") : actual value: " << actualvalue
                              << " Expected value: " << expectedvalue

--- a/tests/SumPoolTest/src/SumPoolTestLayer.cpp
+++ b/tests/SumPoolTest/src/SumPoolTestLayer.cpp
@@ -55,7 +55,7 @@ int SumPoolTestLayer::updateState(double timef, double dt) {
                   expectedvalue = iFeature * nxGlobal * nyGlobal + res_idx;
                   expectedvalue *= 3 * 3;
                }
-               if (fabs(actualvalue - expectedvalue) >= 1e-4) {
+               if (std::fabs(actualvalue - expectedvalue) >= 1e-4f) {
                   ErrorLog() << "Connection " << name << " Mismatch at (" << iX << "," << iY
                              << ") : actual value: " << actualvalue
                              << " Expected value: " << expectedvalue

--- a/tests/test_delta/src/test_delta.cpp
+++ b/tests/test_delta/src/test_delta.cpp
@@ -5,7 +5,7 @@
 #include <cstdlib>
 
 static int zero(float x) {
-   if (fabs(x) < .00001)
+   if (std::fabs(x) < .00001f)
       return 1;
    return 0;
 }


### PR DESCRIPTION
This pull request addresses several minor issues. Most of these edits concern float-double promotion warnings that were somehow not caught by earlier versions of gcc. There is one other warning regarding the aligned attribute used inside the vector template, and a fix to an error message.