### PR TITLE
Add missing cmath includes

### DIFF
--- a/src/columns/HyPerCol.cpp
+++ b/src/columns/HyPerCol.cpp
@@ -20,13 +20,13 @@
 #include "utils/Clock.hpp"
 
 #include <assert.h>
+#include <cmath>
 #include <csignal>
 #include <float.h>
 #include <fstream>
 #include <fts.h>
 #include <libgen.h>
 #include <limits>
-#include <math.h>
 #include <memory.h>
 #include <stdio.h>
 #include <stdlib.h>

--- a/src/include/pv_types.h
+++ b/src/include/pv_types.h
@@ -30,7 +30,7 @@ enum PVDataType {
 typedef struct PVPatch_ {
    unsigned int offset;
    unsigned short nx, ny;
-} __attribute__((aligned)) PVPatch;
+} PVPatch __attribute__((aligned));
 
 typedef struct PVPatchStrides_ {
    int sx, sy, sf; // stride in x,y,features

--- a/src/io/io.cpp
+++ b/src/io/io.cpp
@@ -10,8 +10,8 @@
 #include "io.hpp"
 
 #include <assert.h>
+#include <cmath>
 #include <float.h> // FLT_MAX/MIN
-#include <math.h>
 #include <string.h> // memcpy
 #include <string>
 

--- a/src/layers/LCALIFLayer.cpp
+++ b/src/layers/LCALIFLayer.cpp
@@ -7,8 +7,8 @@
 
 #include "LCALIFLayer.hpp"
 
+#include <cmath>
 #include <float.h>
-#include <math.h>
 #include <stdbool.h>
 #include <stdio.h>
 #include <stdlib.h>

--- a/src/layers/LIFGap.cpp
+++ b/src/layers/LIFGap.cpp
@@ -13,8 +13,8 @@
 #include "utils/cl_random.h"
 
 #include <assert.h>
+#include <cmath>
 #include <float.h>
-#include <math.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>

--- a/src/layers/Retina.cpp
+++ b/src/layers/Retina.cpp
@@ -13,7 +13,7 @@
 #include "utils/cl_random.h"
 
 #include <assert.h>
-#include <math.h>
+#include <cmath>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>

--- a/src/probes/L1NormProbe.cpp
+++ b/src/probes/L1NormProbe.cpp
@@ -5,6 +5,8 @@
  *      Author: pschultz
  */
 
+#include <cmath>
+
 #include "L1NormProbe.hpp"
 #include "../columns/HyPerCol.hpp"
 

--- a/tests/AvgPoolTest/src/GateAvgPoolTestLayer.cpp
+++ b/tests/AvgPoolTest/src/GateAvgPoolTestLayer.cpp
@@ -1,3 +1,5 @@
+#include <cmath>
+
 #include "GateAvgPoolTestLayer.hpp"
 
 namespace PV {

--- a/tests/BatchSweepTest/src/BatchSweepTestProbe.cpp
+++ b/tests/BatchSweepTest/src/BatchSweepTestProbe.cpp
@@ -50,9 +50,9 @@ int BatchSweepTestProbe::outputState(double timed) {
    }
    for (int b = 0; b < parent->getNBatch(); b++) {
       if (timed >= 3.0) {
-         FatalIf(fabs(expectedSum - sum[b]) >= 1e-6, "Test failed.\n");
-         FatalIf(fabs(expectedMin - fMin[b]) >= 1e-6f, "Test failed.\n");
-         FatalIf(fabs(expectedMax - fMax[b]) >= 1e-6f, "Test failed.\n");
+         FatalIf(std::fabs(expectedSum - sum[b]) >= 1e-6, "Test failed.\n");
+         FatalIf(std::fabs(expectedMin - fMin[b]) >= 1e-6f, "Test failed.\n");
+         FatalIf(std::fabs(expectedMax - fMax[b]) >= 1e-6f, "Test failed.\n");
       }
    }
    return status;

--- a/tests/BatchSweepTest/src/BatchSweepTestProbe.hpp
+++ b/tests/BatchSweepTest/src/BatchSweepTestProbe.hpp
@@ -11,7 +11,7 @@
 #include "layers/HyPerLayer.hpp"
 #include "probes/StatsProbe.hpp"
 #include "utils/PVLog.hpp"
-#include <math.h>
+#include <cmath>
 
 namespace PV {
 

--- a/tests/BatchWeightUpdateMpiTest/src/main.cpp
+++ b/tests/BatchWeightUpdateMpiTest/src/main.cpp
@@ -2,7 +2,7 @@
  * main .cpp file for CheckpointSystemTest
  *
  */
-
+#include <cmath>
 #include <columns/buildandrun.hpp>
 
 int customexit(HyPerCol *hc, int argc, char *argv[]);

--- a/tests/ImageSystemTest/src/ImagePvpTestLayer.cpp
+++ b/tests/ImageSystemTest/src/ImagePvpTestLayer.cpp
@@ -27,7 +27,7 @@ int ImagePvpTestLayer::updateState(double time, double dt) {
 
          float expectedVal =
                kIndex(kxGlobal, kyGlobal, kf, loc->nxGlobal, loc->nyGlobal, nf) + frameIdx * 192;
-         if (fabs(checkVal - expectedVal) >= 1e-5f) {
+         if (std::fabs(checkVal - expectedVal) >= 1e-5f) {
             Fatal() << "ImageFileIO " << name << " test Expected: " << expectedVal
                     << " Actual: " << checkVal << "\n";
          }

--- a/tests/LayerPhaseTest/src/LayerPhaseTestProbe.cpp
+++ b/tests/LayerPhaseTest/src/LayerPhaseTestProbe.cpp
@@ -48,10 +48,14 @@ int LayerPhaseTestProbe::outputState(double timed) {
    }
    for (int b = 0; b < parent->getNBatch(); b++) {
       if (timed >= equilibriumTime) {
-         float tol = 1e-6;
-         FatalIf(!(fabs(fMin[b] - equilibriumValue) < tol), "Test failed.\n");
-         FatalIf(!(fabs(fMax[b] - equilibriumValue) < tol), "Test failed.\n");
-         FatalIf(!(fabs(avg[b] - equilibriumValue) < tol), "Test failed.\n");
+         float const tol = 1e-6f;
+         // TODO: std::fabs is preferred to fabsf. But we implicitly include
+         // math.h because the header includes HyPerLayer.hpp, which eventually
+         // includes cl_random.h. It seems iffy to include both math.h and cmath.
+         // We should convert cl_random.{c,h} to .cpp and .hpp.
+         FatalIf(fabsf(fMin[b] - equilibriumValue) >= tol, "Test failed.\n");
+         FatalIf(fabsf(fMax[b] - equilibriumValue) >= tol, "Test failed.\n");
+         FatalIf(fabsf(avg[b] - equilibriumValue) >= tol, "Test failed.\n");
       }
    }
 

--- a/tests/ParameterSweepTest/src/ParameterSweepTestProbe.cpp
+++ b/tests/ParameterSweepTest/src/ParameterSweepTestProbe.cpp
@@ -50,9 +50,9 @@ int ParameterSweepTestProbe::outputState(double timed) {
    }
    for (int b = 0; b < parent->getNBatch(); b++) {
       if (timed >= 3.0) {
-         FatalIf(fabs(expectedSum - sum[b]) >= 1e-6, "Test failed.\n");
-         FatalIf(fabs(expectedMin - fMin[b]) >= 1e-6f, "Test failed.\n");
-         FatalIf(fabs(expectedMax - fMax[b]) >= 1e-6f, "Test failed.\n");
+         FatalIf(std::fabs(expectedSum - sum[b]) >= 1e-6, "Test failed.\n");
+         FatalIf(std::fabs(expectedMin - fMin[b]) >= 1e-6f, "Test failed.\n");
+         FatalIf(std::fabs(expectedMax - fMax[b]) >= 1e-6f, "Test failed.\n");
       }
    }
    return status;

--- a/tests/ParameterSweepTest/src/ParameterSweepTestProbe.hpp
+++ b/tests/ParameterSweepTest/src/ParameterSweepTestProbe.hpp
@@ -11,7 +11,7 @@
 #include "layers/HyPerLayer.hpp"
 #include "probes/StatsProbe.hpp"
 #include "utils/PVLog.hpp"
-#include <math.h>
+#include <cmath>
 
 namespace PV {
 

--- a/tests/StochasticReleaseTest/src/StochasticReleaseTestProbe.hpp
+++ b/tests/StochasticReleaseTest/src/StochasticReleaseTestProbe.hpp
@@ -11,7 +11,7 @@
 #include "columns/HyPerCol.hpp"
 #include "columns/buildandrun.hpp"
 #include "probes/StatsProbe.hpp"
-#include <math.h>
+#include <cmath>
 #include <stdlib.h>
 
 namespace PV {

--- a/tests/SumPoolTest/src/GateSumPoolTestLayer.cpp
+++ b/tests/SumPoolTest/src/GateSumPoolTestLayer.cpp
@@ -47,7 +47,7 @@ int GateSumPoolTestLayer::updateState(double timef, double dt) {
                expectedvalue = iFeature * 64 + yval * 16 + xval * 2 + 4.5;
                expectedvalue *= 4;
 
-               if (fabs(actualvalue - expectedvalue) >= 1e-4f) {
+               if (fabsf(actualvalue - expectedvalue) >= 1e-4f) {
                   ErrorLog() << "Connection " << name << " Mismatch at (" << iX << "," << iY
                              << ") : actual value: " << actualvalue
                              << " Expected value: " << expectedvalue

--- a/tests/SumPoolTest/src/SumPoolTestLayer.cpp
+++ b/tests/SumPoolTest/src/SumPoolTestLayer.cpp
@@ -1,5 +1,5 @@
 #include "SumPoolTestLayer.hpp"
-
+#include <cmath>
 namespace PV {
 
 SumPoolTestLayer::SumPoolTestLayer(const char *name, HyPerCol *hc) {

--- a/tests/test_patch_head/src/test_patch_head.cpp
+++ b/tests/test_patch_head/src/test_patch_head.cpp
@@ -1,5 +1,5 @@
 #include "utils/PVLog.hpp"
-#include <math.h>
+#include <cmath>
 #include <stdio.h>
 #include <stdlib.h>
 #include <utils/conversions.h>

--- a/tests/test_sign/src/test_sign.cpp
+++ b/tests/test_sign/src/test_sign.cpp
@@ -1,6 +1,6 @@
 #include "layers/PVLayerCube.hpp"
 #include "utils/PVLog.hpp"
-#include <math.h>
+#include <cmath>
 #include <stdio.h>
 #include <stdlib.h>
 


### PR DESCRIPTION
This pull request adds missing cmath includes and reverts a change to pv_types.h. Passes all tests.