### PR TITLE
Nonblocking HyPerConn bugfix

### DIFF
--- a/src/connections/HyPerConn.hpp
+++ b/src/connections/HyPerConn.hpp
@@ -493,7 +493,7 @@ class HyPerConn : public BaseConnection {
    double initialWeightUpdateTime;
    double lastUpdateTime;
    double lastTimeUpdateCalled;
-   bool mImmediateWeightUpdate = false;
+   bool mImmediateWeightUpdate = true;
 
    bool symmetrizeWeightsFlag;
    long **numKernelActivations;

--- a/tests/ConnectionRestartTest/input/ConnectionRestartTest.params
+++ b/tests/ConnectionRestartTest/input/ConnectionRestartTest.params
@@ -135,35 +135,6 @@ HyPerConn "initializeFromInitWeights" = {
 };
 
 HyPerConn "initializeFromCheckpoint" = {
-    initializeFromCheckpointFlag = true;
-    preLayerName = "input";
-    postLayerName = "output_from_initializeFromCheckpoint";
-    channelCode = 0;
-
-    nxp = 1;
-    nyp = 1;
-    numAxonalArbors = 1;
-    sharedWeights = true;
-    writeStep = -1;
-    
-    weightInitType = "UniformWeight";
-    weightInit = 1.0;
-    connectOnlySameFeatures = false;
-
-    normalizeMethod = "none";
-
-    writeCompressedCheckpoints = false;
-    plasticityFlag = true;
-    dWMax = 1.0;
-    weightUpdatePeriod = 20;
-    initialWeightUpdateTime = 20;
-    combine_dW_with_W_flag = false;
-    selfFlag = false;  
-
-    delay = 0;
-
-    pvpatchAccumulateType = "Convolve";
-    convertRateToSpikeCount = false;
-    shrinkPatches = false; 
-    updateGSynFromPostPerspective = false; 
+    #include "initializeFromInitWeights";
+    @initializeFromCheckpointFlag = true;
 };


### PR DESCRIPTION
If immediateWeightUpdate is false, the connection needs to checkpoint dW. In principle, it would also need to checkpoint numKernelActivations, but we avoid this by normalizing before a checkpointWrite, and adding a Boolean data member to make sure that normalize_dW is not called if it has already been normalized.