### PR TITLE
Miscellaneous hackathon changes

### DIFF
--- a/src/checkpointing/Checkpointer.cpp
+++ b/src/checkpointing/Checkpointer.cpp
@@ -556,7 +556,8 @@ void Checkpointer::checkpointRead(double *simTimePointer, long int *currentStepP
    }
    notify(
          mObserverTable,
-         std::make_shared<ProcessCheckpointReadMessage const>(checkpointReadDirectory));
+         std::make_shared<ProcessCheckpointReadMessage const>(checkpointReadDirectory),
+         getCommunicator()->commRank() == 0 /*printFlag*/);
 }
 
 void Checkpointer::checkpointWrite(double simTime) {
@@ -702,7 +703,8 @@ void Checkpointer::checkpointToDirectory(std::string const &directory) {
    }
    notify(
          mObserverTable,
-         std::make_shared<PrepareCheckpointWriteMessage const>(checkpointDirectory));
+         std::make_shared<PrepareCheckpointWriteMessage const>(checkpointDirectory),
+         getCommunicator()->commRank() == 0 /*printFlag*/);
    ensureDirExists(getCommunicator(), checkpointDirectory.c_str());
    for (auto &c : mCheckpointRegistry) {
       c->write(checkpointDirectory, mTimeInfo.mSimTime, mVerifyWritesFlag);

--- a/src/columns/HyPerCol.cpp
+++ b/src/columns/HyPerCol.cpp
@@ -203,7 +203,7 @@ int HyPerCol::initialize(const char *name, PV_Init *initObj) {
    mCurrentStep = mInitialStep;
    mFinalStep   = (long int)nearbyint(mStopTime / mDeltaTime);
    mCheckpointer->provideFinalStep(mFinalStep);
-   mNextProgressTime = mStartTime + mProgressInterval;
+   mNextProgressTime = mStartTime;
 
    RandomSeed::instance()->initialize(mRandomSeed);
 

--- a/src/columns/HyPerCol.hpp
+++ b/src/columns/HyPerCol.hpp
@@ -373,7 +373,7 @@ class HyPerCol : public Subject, Observer {
    void paramMovedToColumnEnergyProbe(enum ParamsIOFlag ioFlag, char const *paramName);
    int checkDirExists(const char *dirname, struct stat *pathstat);
    inline void notify(std::vector<std::shared_ptr<BaseMessage const>> messages) {
-      Subject::notify(mObjectHierarchy, messages);
+      Subject::notify(mObjectHierarchy, messages, getCommunicator()->commRank() == 0 /*printFlag*/);
    }
    inline void notify(std::shared_ptr<BaseMessage const> message) {
       notify(std::vector<std::shared_ptr<BaseMessage const>>{message});

--- a/src/layers/InputLayer.cpp
+++ b/src/layers/InputLayer.cpp
@@ -389,6 +389,7 @@ void InputLayer::populateFileList() {
       mFileList.clear();
       InfoLog() << "Reading list: " << mInputPath << "\n";
       std::ifstream infile(mInputPath, std::ios_base::in);
+      FatalIf(infile.fail(), "Unable to open \"%s\": %s\n", mInputPath.c_str(), strerror(errno));
       while (getline(infile, line, '\n')) {
          std::string noWhiteSpace = line;
          noWhiteSpace.erase(

--- a/src/observerpattern/Subject.hpp
+++ b/src/observerpattern/Subject.hpp
@@ -20,10 +20,13 @@ class Subject {
    virtual void addObserver(Observer *observer, BaseMessage const &message) { return; }
 
   protected:
-   void
-   notify(ObserverTable const &table, std::vector<std::shared_ptr<BaseMessage const>> messages);
-   inline void notify(ObserverTable const &table, std::shared_ptr<BaseMessage const> message) {
-      notify(table, std::vector<std::shared_ptr<BaseMessage const>>{message});
+   void notify(
+         ObserverTable const &table,
+         std::vector<std::shared_ptr<BaseMessage const>> messages,
+         bool printFlag);
+   inline void
+   notify(ObserverTable const &table, std::shared_ptr<BaseMessage const> message, bool printFlag) {
+      notify(table, std::vector<std::shared_ptr<BaseMessage const>>{message}, printFlag);
    }
 };
 


### PR DESCRIPTION
This pull request addresses a few minor issues that were discussed at the January hackathon:
*Subject::notify no longer prints a postponement message each time an object postpones, Instead, it prints the number of postponed objects at the end of a pass through the loop.
*Progress is printed at t==0 as well as t==progressInterval, etc., to provide a baseline timestamp for the start of the run.
*When using a list of input files, InputFile reports the error if opening the inputPath file failed.
