### PR TITLE
Concurrent advanceTime

### DIFF
--- a/src/columns/HyPerCol.hpp
+++ b/src/columns/HyPerCol.hpp
@@ -236,10 +236,16 @@ class HyPerCol : public Subject, Observer {
 
    /**
     * @brief errorOnNotANumber: Specifies if the run should check on each
-    * timestep for nans in
-    * activity.
+    * timestep for nans in activity.
     */
    virtual void ioParam_errorOnNotANumber(enum ParamsIOFlag ioFlag);
+
+   /**
+    * @brief immediateLayerPublish: If set to true, layers publish their
+    * activity to their data store immediately after updateState.
+    * If false, they wait until the next timestep to do so.
+    */
+   virtual void ioParam_immediateLayerPublish(enum ParamsIOFlag ioFlag);
    /** @} */
 
   public:
@@ -418,6 +424,8 @@ class HyPerCol : public Subject, Observer {
    // passed in the
    // constructor
    bool mWriteTimescales;
+   bool mImmediateLayerPublish; // If true, do MPI border exchange immediately
+   // after layer update; if false, wait until the start of the next timestep.
    char *mName;
    char *mOutputPath; // path to output file directory
    char *mPrintParamsFilename; // filename for outputting the mParams, including

--- a/tests/DryRunFlagTest/input/correct.params
+++ b/tests/DryRunFlagTest/input/correct.params
@@ -7,17 +7,18 @@ HyPerCol "column" = {
     stopTime                            = 10;
     progressInterval                    = 10;
     writeProgressToErr                  = false;
-    verifyWrites                        = false;
     outputPath                          = "output/";
+    verifyWrites                        = false;
+    checkpointWrite                     = false;
+    lastCheckpointDir                   = "output/Last";
+    initializeFromCheckpointDir         = "";
     printParamsFilename                 = "pv.params";
     randomSeed                          = 1234567890;
     nx                                  = 32;
     ny                                  = 32;
     nbatch                              = 1;
-    initializeFromCheckpointDir         = "";
-    checkpointWrite                     = false;
-    lastCheckpointDir                   = "output/Last";
     errorOnNotANumber                   = true;
+    immediateLayerPublish               = true;
 };
 
 PvpLayer "Input" = {


### PR DESCRIPTION
This pull request adds a flag, immediateLayerPublish, to the HyPerCol params. If set to true (the default), the layer publish happens immediately after updateState. If set to false, it happens at the start of the next timestep.