### PR TITLE
Generic read-activity function

### DIFF
--- a/src/checkpointing/CheckpointEntryPvp.tpp
+++ b/src/checkpointing/CheckpointEntryPvp.tpp
@@ -61,7 +61,7 @@ void CheckpointEntryPvp<T>::read(std::string const &checkpointDirectory, double 
    for (int b = 0; b < mLayerLoc->nbatch; b++) {
       Buffer<T> pvpBuffer;
       if (getCommunicator()->commRank() == 0) {
-         *simTimePtr = BufferUtils::readFromPvp(path.c_str(), &pvpBuffer, b);
+         *simTimePtr = BufferUtils::readDenseFromPvp(path.c_str(), &pvpBuffer, b);
       }
       else {
          pvpBuffer.resize(mLayerLoc->nx, mLayerLoc->ny, mLayerLoc->nf);

--- a/src/initv/InitVFromFile.cpp
+++ b/src/initv/InitVFromFile.cpp
@@ -57,7 +57,7 @@ int InitVFromFile::calcV(float *V, const PVLayerLoc *loc) {
          float *Vbatch = V + b * (loc->nx * loc->ny * loc->nf);
          Buffer<float> pvpBuffer;
          if (isRootProc) {
-            BufferUtils::readFromPvp(mVfilename, &pvpBuffer, b);
+            BufferUtils::readDenseFromPvp(mVfilename, &pvpBuffer, b);
          }
          else {
             pvpBuffer.resize(loc->nx, loc->ny, loc->nf);

--- a/src/initv/InitVFromFile.cpp
+++ b/src/initv/InitVFromFile.cpp
@@ -53,6 +53,9 @@ int InitVFromFile::calcV(float *V, const PVLayerLoc *loc) {
    char const *ext = strrchr(mVfilename, '.');
    bool isPvpFile  = (ext && strcmp(ext, ".pvp") == 0);
    if (isPvpFile) {
+      FileStream headerStream(mVfilename, std::ios_base::in | std::ios_base::binary, false);
+      struct BufferUtils::ActivityHeader header = BufferUtils::readActivityHeader(headerStream);
+      int fileType = header.fileType;
       for (int b = 0; b < loc->nbatch; b++) {
          float *Vbatch = V + b * (loc->nx * loc->ny * loc->nf);
          Buffer<float> pvpBuffer;

--- a/src/io/randomstateio.cpp
+++ b/src/io/randomstateio.cpp
@@ -24,7 +24,7 @@ double readRandState(
    Buffer<taus_uint4> buffer{nxGlobal, nyGlobal, nf};
    double timestamp;
    if (comm->commRank() == 0) {
-      timestamp = BufferUtils::readFromPvp(path.c_str(), &buffer, 0 /*frameReadIndex*/);
+      timestamp = BufferUtils::readDenseFromPvp(path.c_str(), &buffer, 0 /*frameReadIndex*/);
    }
    BufferUtils::scatter(comm, buffer, loc->nx, loc->ny);
    int nxLocal = loc->nx;

--- a/src/layers/PvpLayer.cpp
+++ b/src/layers/PvpLayer.cpp
@@ -69,7 +69,7 @@ Buffer<float> PvpLayer::retrieveData(std::string filename, int batchIndex) {
 
    switch (mFileType) {
       case PVP_NONSPIKING_ACT_FILE_TYPE:
-         BufferUtils::readFromPvp<float>(filename.c_str(), &result, frameNumber);
+         BufferUtils::readDenseFromPvp<float>(filename.c_str(), &result, frameNumber);
          break;
       case PVP_ACT_SPARSEVALUES_FILE_TYPE:
          BufferUtils::readSparseFromPvp<float>(filename.c_str(), &list, frameNumber, &sparseTable);

--- a/src/layers/PvpLayer.cpp
+++ b/src/layers/PvpLayer.cpp
@@ -64,26 +64,11 @@ Buffer<float> PvpLayer::retrieveData(std::string filename, int batchIndex) {
       frameNumber = getStartIndex(batchIndex);
    }
 
-   SparseList<float> list;
-   Buffer<float> result(mInputNx, mInputNy, mInputNf);
-
-   switch (mFileType) {
-      case PVP_NONSPIKING_ACT_FILE_TYPE:
-         BufferUtils::readDenseFromPvp<float>(filename.c_str(), &result, frameNumber);
-         break;
-      case PVP_ACT_SPARSEVALUES_FILE_TYPE:
-         BufferUtils::readSparseFromPvp<float>(filename.c_str(), &list, frameNumber, &sparseTable);
-         // This is a hack. We should only ever be
-         // calling this with T == float.
-         list.toBuffer(result, {0});
-         break;
-      case PVP_ACT_FILE_TYPE:
-         // The {1} and {0} are the same hack.
-         BufferUtils::readSparseBinaryFromPvp<float>(
-               filename.c_str(), &list, frameNumber, {1}, &sparseTable);
-         list.toBuffer(result, {0});
-         break;
-   }
+   Buffer<float> result;
+   BufferUtils::readActivityFromPvp<float>(filename.c_str(), &result, frameNumber);
+   pvAssert(result.getWidth() == mInputNx);
+   pvAssert(result.getHeight() == mInputNy);
+   pvAssert(result.getFeatures() == mInputNf);
 
    return result;
 }

--- a/src/utils/BufferUtilsPvp.hpp
+++ b/src/utils/BufferUtilsPvp.hpp
@@ -70,7 +70,7 @@ void appendToPvp(
       bool verifyWrites = false);
 
 template <typename T>
-double readFromPvp(const char *fName, Buffer<T> *buffer, int frameReadIndex);
+double readDenseFromPvp(const char *fName, Buffer<T> *buffer, int frameReadIndex);
 
 template <typename T>
 void writeSparseFrame(FileStream &fStream, SparseList<T> *list, double timeStamp);

--- a/src/utils/BufferUtilsPvp.hpp
+++ b/src/utils/BufferUtilsPvp.hpp
@@ -69,6 +69,17 @@ void appendToPvp(
       double timeStamp,
       bool verifyWrites = false);
 
+/**
+ * Reads a frame from an activity layer of any activity file type into a buffer.
+ * The buffer will be resized to the size indicated in the pvp file's header.
+ */
+template <typename T>
+double readActivityFromPvp(char const *fName, Buffer<T> *buffer, int frameReadIndex);
+
+/**
+ * Reads a frame from a nonspiking activity layer into a buffer. If the file type
+ * is anything else, exits with an error.
+ */
 template <typename T>
 double readDenseFromPvp(const char *fName, Buffer<T> *buffer, int frameReadIndex);
 
@@ -106,6 +117,14 @@ double readSparseFromPvp(
       int frameReadIndex,
       SparseFileTable *cachedTable = nullptr);
 
+/**
+ * Reads a frame from a sparse-values pvp file into a (nonsparse) buffer.
+ * Neither the list of active indices nor the SparseFileTable is returned.
+ * Use the readSparseFromPvp function to get the SparseList or SparseFileTable.
+ */
+template <typename T>
+double readDenseFromSparsePvp(char const *fName, Buffer<T> *buffer, int frameReadIndex);
+
 template <typename T>
 double readSparseBinaryFromPvp(
       const char *fName,
@@ -113,6 +132,14 @@ double readSparseBinaryFromPvp(
       int frameReadIndex,
       T oneVal,
       SparseFileTable *cachedTable = nullptr);
+
+/**
+ * Reads a frame from a sparse-binary pvp file into a (nonsparse) buffer.
+ * Neither the list of active indices nor the SparseFileTable is returned.
+ * Use the readSparseBinaryFromPvp function to get the SparseList or SparseFileTable.
+ */
+template <typename T>
+double readDenseFromSparseBinaryPvp(char const *fName, Buffer<T> *buffer, int frameReadIndex);
 
 static void writeActivityHeader(FileStream &fStream, struct ActivityHeader const &header);
 static struct ActivityHeader readActivityHeader(FileStream &fStream);

--- a/src/utils/BufferUtilsPvp.tpp
+++ b/src/utils/BufferUtilsPvp.tpp
@@ -141,12 +141,12 @@ void appendToPvp(
 }
 
 template <typename T>
-double readFromPvp(const char *fName, Buffer<T> *buffer, int frameReadIndex) {
+double readDenseFromPvp(const char *fName, Buffer<T> *buffer, int frameReadIndex) {
    FileStream fStream(fName, std::ios_base::in | std::ios_base::binary, false);
    struct ActivityHeader header = readActivityHeader(fStream);
    FatalIf(
          header.fileType != PVP_NONSPIKING_ACT_FILE_TYPE,
-         "readFromPvp() can only be used on non-sparse activity pvps "
+         "readDenseFromPvp() can only be used on non-sparse activity pvps "
          "(PVP_NONSPIKING_ACT_FILE_TYPE)\n");
    buffer->resize(header.nx, header.ny, header.nf);
    long frameOffset = frameReadIndex * (header.recordSize * header.dataSize + sizeof(double));

--- a/tests/BufferUtilsPvpTest/src/main.cpp
+++ b/tests/BufferUtilsPvpTest/src/main.cpp
@@ -23,7 +23,7 @@ void testReadFromPvp() {
       }
       Buffer<float> testBuffer;
       double timeVal =
-            BufferUtils::readFromPvp<float>("input/input_8x4x2_x3.pvp", &testBuffer, frame);
+            BufferUtils::readDenseFromPvp<float>("input/input_8x4x2_x3.pvp", &testBuffer, frame);
 
       FatalIf(
             timeVal != (double)frame + 1,
@@ -94,7 +94,7 @@ void testWriteToPvp() {
    // and check that it's correct
    for (int frame = 0; frame < 3; ++frame) {
       Buffer<float> testBuffer;
-      double timeVal             = BufferUtils::readFromPvp<float>("test.pvp", &testBuffer, frame);
+      double timeVal             = BufferUtils::readDenseFromPvp<float>("test.pvp", &testBuffer, frame);
       vector<float> expectedData = allFrames.at(frame);
 
       FatalIf(
@@ -264,7 +264,7 @@ void testReadFromSparseBinaryPvp() {
 }
 int main(int argc, char **argv) {
 
-   InfoLog() << "Testing BufferUtils:readFromPvp(): ";
+   InfoLog() << "Testing BufferUtils:readDenseFromPvp(): ";
    testReadFromPvp();
    InfoLog() << "Completed.\n";
 


### PR DESCRIPTION
This pull request adds a readActivityFromPvp function, which reads a frame from any of the three activity pvp file types (nonspiking,sparse, or sparsevalues) into a buffer. InitVFromFile and PvpLayer call this function, thereby eliminating code duplication.