### PR TITLE
Postpone Instead of Wait

### DIFF
--- a/src/arch/mpi/mpi.c
+++ b/src/arch/mpi/mpi.c
@@ -47,6 +47,25 @@ int MPI_Barrier(MPI_Comm comm) { return 0; }
 int MPI_Bcast(void *buffer, int count, MPI_Datatype datatype, int root, MPI_Comm comm) { return 0; }
 
 /**
+ * A stub for MPI_Iallreduce when PV_USE_MPI is off.  Copies recvbuf into
+ * sendbuf (if MPI_IN_PLACE is used or if sendbuf==recvbuf, returns
+ * immediately). The MPI_Request argument is not changed.
+ */
+int MPI_Iallreduce(
+      void *sendbuf,
+      void *recvbuf,
+      int count,
+      MPI_Datatype datatype,
+      MPI_Op op,
+      MPI_Comm comm,
+      MPI_Request *request) {
+   if (sendbuf != MPI_IN_PLACE && sendbuf != recvbuf) {
+      memmove(recvbuf, sendbuf, count * datatype);
+   }
+   return 0;
+}
+
+/**
  * A stub for MPI_Allreduce when PV_USE_MPI is off.  Copies recvbuf into sendbuf
  * (if MPI_IN_PLACE is used or if sendbuf==recvbuf, returns immediately).
  */
@@ -64,7 +83,7 @@ int MPI_Allreduce(
 }
 
 /**
- * A stub for MPI_Allreduce when PV_USE_MPI is off.  Copies recvbuf into sendbuf
+ * A stub for MPI_Reduce when PV_USE_MPI is off.  Copies recvbuf into sendbuf
  * (if MPI_IN_PLACE is used or if sendbuf==recvbuf, returns immediately).
  * The root argument is not read.
  */
@@ -161,6 +180,14 @@ int MPI_Isend(
  * would need to be implemented if that's ever something we find convenient to do.
  */
 int MPI_Send(void *buf, int count, MPI_Datatype datatype, int dest, int tag, MPI_Comm comm) {
+   return 0;
+}
+
+/**
+ * A stub for MPI_Testall when PV_USE_MPI is off. Always sets the result flag to true.
+ */
+int MPI_Testall(int count, MPI_Request *reqs, int *flag, MPI_Status *stats) {
+   *flag = 1;
    return 0;
 }
 

--- a/src/arch/mpi/mpi.h
+++ b/src/arch/mpi/mpi.h
@@ -29,9 +29,19 @@ typedef void *voidptr;
 #define MPI_STATUS_IGNORE 0
 #define MPI_STATUSES_IGNORE NULL
 #define MPI_IN_PLACE ((voidptr)1)
-#define MPI_MAX 0
-#define MPI_MIN 1
-#define MPI_SUM 2
+#define MPI_MAX 1
+#define MPI_MIN 2
+#define MPI_SUM 3
+#define MPI_PROD 4
+#define MPI_LAND 5
+#define MPI_BAND 6
+#define MPI_LOR 7
+#define MPI_BOR 8
+#define MPI_LXOR 9
+#define MPI_BXOR 10
+#define MPI_MAXLOC 11
+#define MPI_MINLOC 12
+#define MPI_REPLACE 13
 
 #ifdef __cplusplus
 extern "C" {
@@ -44,6 +54,15 @@ int MPI_Finalize();
 int MPI_Barrier(MPI_Comm comm);
 
 int MPI_Bcast(void *buffer, int count, MPI_Datatype datatype, int root, MPI_Comm comm);
+
+int MPI_Iallreduce(
+      void *sendbuf,
+      void *recvbuf,
+      int count,
+      MPI_Datatype datatype,
+      MPI_Op op,
+      MPI_Comm comm,
+      MPI_Request *request);
 
 int MPI_Allreduce(
       void *sendbuf,
@@ -90,6 +109,7 @@ int MPI_Isend(
       MPI_Comm comm,
       MPI_Request *request);
 int MPI_Send(void *buf, int count, MPI_Datatype datatype, int dest, int tag, MPI_Comm comm);
+int MPI_Testall(int count, MPI_Request *reqs, int *flag, MPI_Status *stats);
 int MPI_Waitall(int count, MPI_Request array_of_requests[], MPI_Status array_of_statuses[]);
 
 double MPI_Wtime();

--- a/src/columns/Communicator.hpp
+++ b/src/columns/Communicator.hpp
@@ -91,6 +91,7 @@ class Communicator {
    int neighbors[NUM_NEIGHBORHOOD]; // [0] is interior (local)
    int remoteNeighbors[NUM_NEIGHBORHOOD];
    int tags[NUM_NEIGHBORHOOD]; // diagonal communication needs a different tag
+   int exchangeCounter = 0;
    // from left/right or
    // up/down communication.
 

--- a/src/columns/DataStore.cpp
+++ b/src/columns/DataStore.cpp
@@ -57,4 +57,20 @@ void DataStore::updateActiveIndices(int bufferId, int level) {
    *numActiveBuf = numActive;
 }
 
+PVLayerCube DataStore::createCube(PVLayerLoc const &loc, int delay) {
+   PVLayerCube cube;
+   cube.size = sizeof(PVLayerCube);
+   cube.numItems = mNumItems * mNumBuffers;
+   cube.data = buffer(0 /*batch element*/, delay);
+   // All batch elements allocated contiguously, so the numItems and data fields cover all
+   // batch elements.
+   cube.loc = loc;
+   cube.isSparse = isSparse();
+   if (isSparse()) {
+      cube.numActive     = numActiveBuffer(0, delay);
+      cube.activeIndices = activeIndicesBuffer(0, delay);
+   }
+   return cube;
+}
+
 } // end namespace PV

--- a/src/columns/DataStore.cpp
+++ b/src/columns/DataStore.cpp
@@ -34,6 +34,12 @@ DataStore::DataStore(int numBuffers, int numItems, int numLevels, bool isSparse_
    }
 }
 
+void DataStore::markActiveIndicesOutOfSync(int bufferId, int level) {
+   if (!mSparseFlag) { return; }
+   long *numActiveBuf = numActiveBuffer(bufferId, level);
+   *numActiveBuf = -1;
+}
+
 void DataStore::updateActiveIndices(int bufferId, int level) {
    if (!mSparseFlag) { return; }
    int numActive   = 0;

--- a/src/columns/DataStore.hpp
+++ b/src/columns/DataStore.hpp
@@ -75,6 +75,8 @@ class DataStore {
 
    long *numActiveBuffer(int bufferId) { return mNumActive->getBuffer(bufferId); }
 
+   void markActiveIndicesOutOfSync(int bufferId, int level);
+
    void updateActiveIndices(int bufferId, int level);
 
    int getNumItems() const { return mNumItems; }

--- a/src/columns/DataStore.hpp
+++ b/src/columns/DataStore.hpp
@@ -10,6 +10,7 @@
 
 #include "include/pv_arch.h"
 #include "include/pv_types.h"
+#include "layers/PVLayerCube.hpp"
 #include "structures/RingBuffer.hpp"
 #include <cstdlib>
 #include <cstring>
@@ -80,6 +81,13 @@ class DataStore {
    void updateActiveIndices(int bufferId, int level);
 
    int getNumItems() const { return mNumItems; }
+
+   /**
+    * Returns a PVLayerCube pointing to the data at the given delay.
+    * It does not check whether the PVLayerLoc is consistent with the
+    * DataStore's numItems or numBuffers.
+    */
+   PVLayerCube createCube(PVLayerLoc const &loc, int delay);
 
   private:
    int mNumItems;

--- a/src/columns/HyPerCol.cpp
+++ b/src/columns/HyPerCol.cpp
@@ -1110,13 +1110,11 @@ int HyPerCol::advanceTime(double sim_time) {
       notify(std::make_shared<LayerPublishMessage>(phase, mSimTime));
 
       // wait for all published data to arrive and call layer's outputState
-      std::vector<std::shared_ptr<BaseMessage const>> messageVector = {
-            std::make_shared<LayerUpdateActiveIndicesMessage>(phase),
-            std::make_shared<LayerOutputStateMessage>(phase, mSimTime)};
+      notify(std::make_shared<LayerUpdateActiveIndicesMessage>(phase));
+      notify(std::make_shared<LayerOutputStateMessage>(phase, mSimTime));
       if (mErrorOnNotANumber) {
-         messageVector.push_back(std::make_shared<LayerCheckNotANumberMessage>(phase));
+         notify(std::make_shared<LayerCheckNotANumberMessage>(phase));
       }
-      notify(messageVector);
    }
 
    mRunTimer->stop();

--- a/src/columns/HyPerCol.cpp
+++ b/src/columns/HyPerCol.cpp
@@ -1071,6 +1071,9 @@ int HyPerCol::advanceTime(double sim_time) {
 
    // Each layer's phase establishes a priority for updating
    for (int phase = 0; phase < mNumPhases; phase++) {
+      for (auto &l : mLayers) { // TODO: use notify/respond
+         l->clearProgressFlags();
+      }
 
       if (!mImmediateLayerPublish) {
          // Rotate DataStore ring buffers
@@ -1117,7 +1120,6 @@ int HyPerCol::advanceTime(double sim_time) {
                    phase, mPhaseRecvTimers.at(phase), mSimTime, mDeltaTime),
              std::make_shared<LayerUpdateStateMessage>(phase, mSimTime, mDeltaTime)});
 #endif
-
       if (mImmediateLayerPublish) {
          // Rotate DataStore ring buffers
          notify(std::make_shared<LayerAdvanceDataStoreMessage>(phase));

--- a/src/columns/HyPerCol.hpp
+++ b/src/columns/HyPerCol.hpp
@@ -267,6 +267,9 @@ class HyPerCol : public Subject, Observer {
    int addLayer(HyPerLayer *l);
    void advanceTimeLoop(Clock &runClock, int const runClockStartingStep);
    int advanceTime(double time);
+   void nonblockingLayerUpdate(
+         std::shared_ptr<LayerRecvSynapticInputMessage const> recvMessage,
+         std::shared_ptr<LayerUpdateStateMessage const> updateMessage);
    int insertProbe(ColProbe *p);
    int outputState(double time);
    int processParams(char const *path);

--- a/src/columns/HyPerCol.hpp
+++ b/src/columns/HyPerCol.hpp
@@ -240,14 +240,6 @@ class HyPerCol : public Subject, Observer {
     */
    virtual void ioParam_errorOnNotANumber(enum ParamsIOFlag ioFlag);
 
-   /**
-    * @brief immediateLayerPublish: If set to true, layers publish their
-    * activity to their data store immediately after updateState.
-    * If false, they wait until the next timestep to do so.
-    */
-   virtual void ioParam_immediateLayerPublish(enum ParamsIOFlag ioFlag);
-   /** @} */
-
   public:
    HyPerCol(const char *name, PV_Init *initObj);
    virtual ~HyPerCol();
@@ -424,8 +416,6 @@ class HyPerCol : public Subject, Observer {
    // passed in the
    // constructor
    bool mWriteTimescales;
-   bool mImmediateLayerPublish; // If true, do MPI border exchange immediately
-   // after layer update; if false, wait until the start of the next timestep.
    char *mName;
    char *mOutputPath; // path to output file directory
    char *mPrintParamsFilename; // filename for outputting the mParams, including

--- a/src/columns/Messages.hpp
+++ b/src/columns/Messages.hpp
@@ -196,14 +196,9 @@ class LayerPublishMessage : public BaseMessage {
    double mTime;
 };
 
-class LayerUpdateActiveIndicesMessage : public BaseMessage {
-  public:
-   LayerUpdateActiveIndicesMessage(int phase) {
-      setMessageType("LayerUpdateActiveIndices");
-      mPhase = phase;
-   }
-   int mPhase;
-};
+// LayerUpdateActiveIndices message removed Feb 3, 2017.
+// Active indices are updated by waitOnPublish, and by isExchangeFinished if
+// the MPI exchange has completed.
 
 class LayerOutputStateMessage : public BaseMessage {
   public:

--- a/src/columns/Publisher.cpp
+++ b/src/columns/Publisher.cpp
@@ -124,6 +124,23 @@ int Publisher::exchangeBorders(const PVLayerLoc *loc, int delay /*default 0*/) {
    return status;
 }
 
+int Publisher::isExchangeFinished(int delay /* default 0*/) {
+   bool isReady;
+   auto *requestsVector = mpiRequestsBuffer->getBuffer(delay, 0);
+   if (requestsVector->empty()) {
+      isReady = true;
+   }
+   else {
+      int test;
+      MPI_Testall((int)requestsVector->size(), requestsVector->data(), &test, MPI_STATUSES_IGNORE);
+      if (test) {
+         requestsVector->clear();
+      }
+      isReady = (bool)test;
+   }
+   return isReady;
+}
+
 /**
  * wait until all outstanding published messages have arrived
  */

--- a/src/columns/Publisher.cpp
+++ b/src/columns/Publisher.cpp
@@ -170,7 +170,6 @@ int Publisher::isExchangeFinished(int delay /* default 0*/) {
  * wait until all outstanding published messages have arrived
  */
 int Publisher::wait(int delay /*default 0*/) {
-#ifdef PV_USE_MPI
 #ifdef DEBUG_OUTPUT
    InfoLog().printf("[%2d]: waiting for data, num_requests==%d\n", mComm->commRank(), numRemote);
    InfoLog().flush();
@@ -182,7 +181,6 @@ int Publisher::wait(int delay /*default 0*/) {
       pvAssert(requestsVector->empty());
    }
    updateActiveIndices(delay);
-#endif // PV_USE_MPI
 
    return 0;
 }

--- a/src/columns/Publisher.cpp
+++ b/src/columns/Publisher.cpp
@@ -6,6 +6,7 @@
  */
 
 #include "Publisher.hpp"
+#include "checkpointing/CheckpointEntryDataStore.hpp"
 #include "include/pv_common.h"
 #include "utils/PVAssert.hpp"
 
@@ -38,6 +39,15 @@ Publisher::~Publisher() {
    delete store;
    Communicator::freeDatatypes(neighborDatatypes);
    neighborDatatypes = nullptr;
+}
+
+void Publisher::checkpointDataStore(
+      Checkpointer *checkpointer,
+      char const *objectName,
+      char const *bufferName) {
+   bool registerSucceeded = checkpointer->registerCheckpointEntry(
+         std::make_shared<CheckpointEntryDataStore>(
+               objectName, bufferName, mComm, store, &mLayerCube->loc));
 }
 
 int Publisher::updateAllActiveIndices() {

--- a/src/columns/Publisher.hpp
+++ b/src/columns/Publisher.hpp
@@ -37,6 +37,13 @@ class Publisher {
    void copyForward(double lastUpdateTime);
    int exchangeBorders(const PVLayerLoc *loc, int delay = 0);
    int isExchangeFinished(int delay = 0);
+
+   /**
+    * creates a PVLayerCube pointing to the data in the data store at the given delay.
+    * This method blocks until any pending border exchange for that delay level are completed.
+    */
+   PVLayerCube createCube(int delay = 0);
+
    int wait(int delay = 0);
 
    void increaseTimeLevel();
@@ -44,7 +51,7 @@ class Publisher {
    DataStore *dataStore() { return store; }
 
    int updateAllActiveIndices();
-   int updateActiveIndices(int delay=0);
+   int updateActiveIndices(int delay = 0);
 
   private:
    float *recvBuffer(int bufferId) { return store->buffer(bufferId); }
@@ -69,7 +76,7 @@ class Publisher {
    Communicator *mComm;
 
    RingBuffer<std::vector<MPI_Request>> *mpiRequestsBuffer = nullptr;
-   //std::vector<MPI_Request> requests;
+   // std::vector<MPI_Request> requests;
    MPI_Datatype *neighborDatatypes;
 };
 

--- a/src/columns/Publisher.hpp
+++ b/src/columns/Publisher.hpp
@@ -52,8 +52,6 @@ class Publisher {
 
    void increaseTimeLevel();
 
-   DataStore *dataStore() { return store; }
-
    int updateAllActiveIndices();
    int updateActiveIndices(int delay = 0);
 

--- a/src/columns/Publisher.hpp
+++ b/src/columns/Publisher.hpp
@@ -36,9 +36,9 @@ class Publisher {
     */
    void copyForward(double lastUpdateTime);
    int exchangeBorders(const PVLayerLoc *loc, int delay = 0);
-   int wait();
+   int wait(int delay = 0);
 
-   void increaseTimeLevel() { store->newLevelIndex(); }
+   void increaseTimeLevel();
 
    DataStore *dataStore() { return store; }
 
@@ -67,7 +67,8 @@ class Publisher {
 
    Communicator *mComm;
 
-   std::vector<MPI_Request> requests;
+   RingBuffer<std::vector<MPI_Request>> *mpiRequestsBuffer = nullptr;
+   //std::vector<MPI_Request> requests;
    MPI_Datatype *neighborDatatypes;
 };
 

--- a/src/columns/Publisher.hpp
+++ b/src/columns/Publisher.hpp
@@ -36,6 +36,7 @@ class Publisher {
     */
    void copyForward(double lastUpdateTime);
    int exchangeBorders(const PVLayerLoc *loc, int delay = 0);
+   int isExchangeFinished(int delay = 0);
    int wait(int delay = 0);
 
    void increaseTimeLevel();

--- a/src/columns/Publisher.hpp
+++ b/src/columns/Publisher.hpp
@@ -8,7 +8,8 @@
 #ifndef PUBLISHER_HPP_
 #define PUBLISHER_HPP_
 
-#include "../arch/mpi/mpi.h"
+#include "arch/mpi/mpi.h"
+#include "checkpointing/Checkpointer.hpp"
 #include "columns/Communicator.hpp"
 #include "columns/DataStore.hpp"
 #include "include/PVLayerLoc.h"
@@ -21,6 +22,9 @@ class Publisher {
   public:
    Publisher(Communicator *comm, PVLayerCube *cube, int numLevels, bool isSparse);
    virtual ~Publisher();
+
+   void
+   checkpointDataStore(Checkpointer *checkpointer, char const *objectName, char const *bufferName);
 
    /**
     * Copies the data from the cube to the top level of the data store, and exchanges

--- a/src/connections/HyPerConn.hpp
+++ b/src/connections/HyPerConn.hpp
@@ -81,7 +81,7 @@ class HyPerConn : public BaseConnection {
    virtual int updateState(double time, double dt) override;
    virtual int finalizeUpdate(double timed, double dt) override;
    virtual bool needUpdate(double time, double dt) override;
-   virtual int updateInd_dW(int arbor_ID, int batch_ID, int kExt);
+   int updateInd_dW(int arbor_ID, int batch_ID, int kExt);
    virtual double computeNewWeightUpdateTime(double time, double currentUpdateTime);
    virtual int writeWeights(double timed, bool last = false);
    virtual int writeWeights(const char *filename);

--- a/src/connections/HyPerConn.hpp
+++ b/src/connections/HyPerConn.hpp
@@ -81,7 +81,16 @@ class HyPerConn : public BaseConnection {
    virtual int updateState(double time, double dt) override;
    virtual int finalizeUpdate(double timed, double dt) override;
    virtual bool needUpdate(double time, double dt) override;
-   int updateInd_dW(int arbor_ID, int batch_ID, int kExt);
+
+   // preLayerData and postLayerData point to the data for pre and post over all batch elements
+   // (batchID argument is used to navigate to the correct part of the buffers)
+   int updateInd_dW(
+         int arborID,
+         int batchID,
+         float const *preLayerData,
+         float const *postLayerData,
+         int kExt);
+
    virtual double computeNewWeightUpdateTime(double time, double currentUpdateTime);
    virtual int writeWeights(double timed, bool last = false);
    virtual int writeWeights(const char *filename);
@@ -925,7 +934,7 @@ class HyPerConn : public BaseConnection {
    /**
     * Updates the dW buffer
     */
-   virtual int update_dW(int arborId);
+   virtual int update_dW(int arborID);
    virtual float updateRule_dW(float pre, float post);
 
    /**

--- a/src/connections/ImprintConn.hpp
+++ b/src/connections/ImprintConn.hpp
@@ -23,7 +23,7 @@ class ImprintConn : public HyPerConn {
   protected:
    virtual int initialize_dW(int arborId);
    virtual int registerData(Checkpointer *checkpointer, std::string const &objName) override;
-   virtual int update_dW(int arbor_ID);
+   virtual int update_dW(int arborID);
    virtual int updateWeights(int arbor_ID);
 
    virtual int ioParamsFillGroup(enum ParamsIOFlag ioFlag);

--- a/src/connections/TransposePoolingConn.cpp
+++ b/src/connections/TransposePoolingConn.cpp
@@ -615,10 +615,9 @@ int TransposePoolingConn::deliverPresynapticPerspective(PVLayerCube const *activ
       assert(postIndexLayer);
       // Make sure this layer is an integer layer
       assert(postIndexLayer->getDataType() == PV_INT);
-      DataStore *store = postIndexLayer->getPublisher()->dataStore();
       int delay        = getDelay(arborID);
-
-      postIdxData = store->buffer(Communicator::LOCAL, delay);
+      PVLayerCube cube = postIndexLayer->getPublisher()->createCube(delay);
+      postIdxData      = cube.data;
    }
 
    for (int b = 0; b < parent->getNBatch(); b++) {

--- a/src/io/fileio.cpp
+++ b/src/io/fileio.cpp
@@ -1463,19 +1463,20 @@ int pvp_read_time(PV_Stream *pvstream, Communicator *comm, int root_process, dou
    return status;
 }
 
-int writeActivity(
-      FileStream *fileStream,
-      Communicator *comm,
-      double timed,
-      DataStore *store,
-      const PVLayerLoc *loc) {
+int writeActivity(FileStream *fileStream, Communicator *comm, double timed, PVLayerCube *cube) {
    int status = PV_SUCCESS;
 
    // write header, but only at the beginning
    int rank = comm->commRank();
 
+   PVLayerLoc const *loc = &cube->loc;
+   PVHalo const &halo    = loc->halo;
+   int const nxExt       = loc->nx + halo.lt + halo.rt;
+   int const nyExt       = loc->ny + halo.dn + halo.up;
+   int const nf          = loc->nf;
+   pvAssert(cube->numItems == nxExt * nyExt * nf * loc->nbatch);
+
    for (int b = 0; b < loc->nbatch; b++) {
-      float *data = store->buffer(b);
       if (rank == 0) {
          long fpos = fileStream->getOutPos();
          if (fpos == 0L) {
@@ -1493,10 +1494,7 @@ int writeActivity(
          //
          fileStream->write(&timed, (long int)sizeof(timed));
       }
-      PVHalo const &halo   = loc->halo;
-      int const nxExt      = loc->nx + halo.lt + halo.rt;
-      int const nyExt      = loc->ny + halo.dn + halo.up;
-      int const nf         = loc->nf;
+      float const *data    = &cube->data[b * nxExt * nyExt * nf];
       auto pvpBuffer       = Buffer<float>(data, nxExt, nyExt, nf);
       auto pvpBufferGlobal = BufferUtils::gather(comm, pvpBuffer, loc->nx, loc->ny);
       if (rank == 0) {
@@ -1513,8 +1511,7 @@ int writeActivitySparse(
       FileStream *fileStream,
       Communicator *comm,
       double timed,
-      DataStore *store,
-      const PVLayerLoc *loc,
+      PVLayerCube *cube,
       bool includeValues) {
    int status = PV_SUCCESS;
 
@@ -1523,11 +1520,18 @@ int writeActivitySparse(
    const int icRoot = 0;
    const int icRank = comm->commRank();
 
+   PVLayerLoc const *loc = &cube->loc;
+   PVHalo const &halo    = loc->halo;
+   int const nxExt       = loc->nx + halo.lt + halo.rt;
+   int const nyExt       = loc->ny + halo.dn + halo.up;
+   int const nf          = loc->nf;
+   const int numNeurons  = nxExt * nyExt * nf;
+
    for (int b = 0; b < loc->nbatch; b++) {
 
-      int localActive       = *(store->numActiveBuffer(b));
-      unsigned int *indices = store->activeIndicesBuffer(b);
-      float *valueData      = store->buffer(b);
+      int const localActive       = cube->numActive[b];
+      unsigned int const *indices = &cube->activeIndices[b * numNeurons];
+      float const *valueData      = &cube->data[b * numNeurons];
 
       indexvaluepair *indexvaluepairs = NULL;
       unsigned int *globalResIndices  = NULL;

--- a/src/io/fileio.hpp
+++ b/src/io/fileio.hpp
@@ -11,7 +11,6 @@
 #include "FileStream.hpp"
 #include "arch/mpi/mpi.h"
 #include "columns/Communicator.hpp"
-#include "columns/DataStore.hpp"
 #include "include/PVLayerLoc.h"
 #include "include/pv_types.h"
 #include "io.hpp"
@@ -131,19 +130,13 @@ int set_weight_params(int *params, int nxp, int nyp, int nfp, float min, float m
 
 int pvp_read_time(PV_Stream *pvstream, Communicator *comm, int root_process, double *timed);
 
-int writeActivity(
-      FileStream *fileStream,
-      Communicator *comm,
-      double timed,
-      DataStore *store,
-      const PVLayerLoc *loc);
+int writeActivity(FileStream *fileStream, Communicator *comm, double timed, PVLayerCube *cube);
 
 int writeActivitySparse(
       FileStream *fileStream,
       Communicator *comm,
       double timed,
-      DataStore *store,
-      const PVLayerLoc *loc,
+      PVLayerCube *cube,
       bool includeValues);
 
 int readWeights(

--- a/src/layers/HyPerLayer.cpp
+++ b/src/layers/HyPerLayer.cpp
@@ -1032,7 +1032,7 @@ int HyPerLayer::respondLayerUpdateState(LayerUpdateStateMessage const *message) 
    if (!mHasReceived) {
       return PV_POSTPONE;
    }
-   status = callUpdateState(message->mTime, message->mDeltaT);
+   status      = callUpdateState(message->mTime, message->mDeltaT);
    mHasUpdated = true;
    return status;
 }
@@ -1115,7 +1115,7 @@ int HyPerLayer::respondLayerOutputState(LayerOutputStateMessage const *message) 
 
 void HyPerLayer::clearProgressFlags() {
    mHasReceived = false;
-   mHasUpdated = false;
+   mHasUpdated  = false;
 }
 
 #ifdef PV_USE_CUDA
@@ -2008,9 +2008,7 @@ int HyPerLayer::setActivity() {
 int HyPerLayer::updateAllActiveIndices() { return publisher->updateAllActiveIndices(); }
 int HyPerLayer::updateActiveIndices() { return publisher->updateActiveIndices(0); }
 
-bool HyPerLayer::isExchangeFinished(int delay ) {
-   return publisher->isExchangeFinished(delay);
-}
+bool HyPerLayer::isExchangeFinished(int delay) { return publisher->isExchangeFinished(delay); }
 
 bool HyPerLayer::isAllInputReady() {
    bool isReady = true;
@@ -2269,9 +2267,9 @@ int HyPerLayer::readDelaysFromCheckpoint(Checkpointer *checkpointer) {
 int HyPerLayer::processCheckpointRead() { return updateAllActiveIndices(); }
 
 int HyPerLayer::writeActivitySparse(double timed, bool includeValues) {
-   DataStore *store = publisher->dataStore();
+   PVLayerCube cube = publisher->createCube(0);
    int status       = PV::writeActivitySparse(
-         mOutputStateStream, parent->getCommunicator(), timed, store, getLayerLoc(), includeValues);
+         mOutputStateStream, parent->getCommunicator(), timed, &cube, includeValues);
 
    if (status == PV_SUCCESS) {
       status = incrementNBands(&writeActivitySparseCalls);
@@ -2281,10 +2279,9 @@ int HyPerLayer::writeActivitySparse(double timed, bool includeValues) {
 
 // write non-spiking activity
 int HyPerLayer::writeActivity(double timed) {
-   DataStore *store = publisher->dataStore();
+   PVLayerCube cube = publisher->createCube(0);
 
-   int status = PV::writeActivity(
-         mOutputStateStream, parent->getCommunicator(), timed, store, getLayerLoc());
+   int status = PV::writeActivity(mOutputStateStream, parent->getCommunicator(), timed, &cube);
    if (status == PV_SUCCESS) {
       status = incrementNBands(&writeActivityCalls);
    }

--- a/src/layers/HyPerLayer.cpp
+++ b/src/layers/HyPerLayer.cpp
@@ -13,7 +13,6 @@
 */
 
 #include "HyPerLayer.hpp"
-#include "checkpointing/CheckpointEntryDataStore.hpp"
 #include "checkpointing/CheckpointEntryPvp.hpp"
 #include "checkpointing/CheckpointEntryRandState.hpp"
 #include "columns/HyPerCol.hpp"
@@ -544,15 +543,6 @@ void HyPerLayer::checkpointPvpActivityFloat(
          "%s failed to register %s for checkpointing.\n",
          getDescription_c(),
          bufferName);
-}
-
-void HyPerLayer::checkpointDataStore(
-      Checkpointer *checkpointer,
-      char const *bufferName,
-      DataStore *datastore) {
-   bool registerSucceeded = checkpointer->registerCheckpointEntry(
-         std::make_shared<CheckpointEntryDataStore>(
-               getName(), bufferName, parent->getCommunicator(), datastore, getLayerLoc()));
 }
 
 void HyPerLayer::checkpointRandState(
@@ -1713,7 +1703,7 @@ int HyPerLayer::registerData(Checkpointer *checkpointer, std::string const &objN
    if (getV() != nullptr) {
       checkpointPvpActivityFloat(checkpointer, "V", getV(), false /*not extended*/);
    }
-   checkpointDataStore(checkpointer, "Delays", publisher->dataStore());
+   publisher->checkpointDataStore(checkpointer, getName(), "Delays");
    checkpointer->registerCheckpointData(
          std::string(getName()),
          std::string("lastUpdateTime"),

--- a/src/layers/HyPerLayer.cpp
+++ b/src/layers/HyPerLayer.cpp
@@ -963,11 +963,6 @@ int HyPerLayer::respond(std::shared_ptr<BaseMessage const> message) {
       return respondLayerPublish(castMessage);
    }
    else if (
-         LayerUpdateActiveIndicesMessage const *castMessage =
-               dynamic_cast<LayerUpdateActiveIndicesMessage const *>(message.get())) {
-      return respondLayerUpdateActiveIndices(castMessage);
-   }
-   else if (
          LayerOutputStateMessage const *castMessage =
                dynamic_cast<LayerOutputStateMessage const *>(message.get())) {
       return respondLayerOutputState(castMessage);
@@ -1081,16 +1076,6 @@ int HyPerLayer::respondLayerCheckNotANumber(LayerCheckNotANumberMessage const *m
       MPI_Barrier(parent->getCommunicator()->communicator());
       exit(EXIT_FAILURE);
    }
-   return status;
-}
-
-int HyPerLayer::respondLayerUpdateActiveIndices(LayerUpdateActiveIndicesMessage const *message) {
-   int status = PV_SUCCESS;
-   if (message->mPhase != getPhase()) {
-      return status;
-   }
-   waitOnPublish(getParent()->getCommunicator());
-   status = updateActiveIndices();
    return status;
 }
 

--- a/src/layers/HyPerLayer.cpp
+++ b/src/layers/HyPerLayer.cpp
@@ -1688,8 +1688,8 @@ int HyPerLayer::requireChannel(int channelNeeded, int *numChannelsResult) {
  * extended space (with margins).
  */
 const float *HyPerLayer::getLayerData(int delay) {
-   DataStore *store = publisher->dataStore();
-   return store->buffer(0, delay);
+   PVLayerCube cube = publisher->createCube(delay);
+   return cube.data;
 }
 
 int HyPerLayer::mirrorInteriorToBorder(PVLayerCube *cube, PVLayerCube *border) {

--- a/src/layers/HyPerLayer.cpp
+++ b/src/layers/HyPerLayer.cpp
@@ -1992,6 +1992,20 @@ int HyPerLayer::setActivity() {
 int HyPerLayer::updateAllActiveIndices() { return publisher->updateAllActiveIndices(); }
 int HyPerLayer::updateActiveIndices() { return publisher->updateActiveIndices(0); }
 
+bool HyPerLayer::isExchangeFinished(int delay ) {
+   return publisher->isExchangeFinished(delay);
+}
+
+bool HyPerLayer::isAllInputReady() {
+   bool isReady = true;
+   for (auto &c : recvConns) {
+      for (int a = 0; a < c->numberOfAxonalArborLists(); a++) {
+         isReady &= c->getPre()->isExchangeFinished(c->getDelay(a));
+      }
+   }
+   return isReady;
+}
+
 int HyPerLayer::recvAllSynapticInput() {
    int status = PV_SUCCESS;
    // Only recvAllSynapticInput if we need an update

--- a/src/layers/HyPerLayer.hpp
+++ b/src/layers/HyPerLayer.hpp
@@ -245,8 +245,7 @@ class HyPerLayer : public BaseLayer {
          char const *bufferName,
          float *pvpBuffer,
          bool extended);
-   void
-   checkpointDataStore(Checkpointer *checkpointer, char const *bufferName, DataStore *datastore);
+
    void checkpointRandState(
          Checkpointer *checkpointer,
          char const *bufferName,
@@ -593,7 +592,7 @@ class HyPerLayer : public BaseLayer {
    std::vector<BaseConnection *> recvConns;
 
    bool mHasReceived = false;
-   bool mHasUpdated = false;
+   bool mHasUpdated  = false;
 
 // GPU variables
 #ifdef PV_USE_CUDA

--- a/src/layers/HyPerLayer.hpp
+++ b/src/layers/HyPerLayer.hpp
@@ -410,6 +410,8 @@ class HyPerLayer : public BaseLayer {
     */
    bool isExchangeFinished(int delay = 0);
 
+   void clearProgressFlags();
+
    /**
     * Returns true if each layer that delivers input to this layer
     * has finished its MPI exchange for its delay; false if any of
@@ -480,6 +482,10 @@ class HyPerLayer : public BaseLayer {
    float getMaxRate() { return maxRate; }
 
    Publisher *getPublisher() { return publisher; }
+
+   bool getHasReceived() { return mHasReceived; }
+
+   bool getHasUpdated() { return mHasUpdated; }
 
   protected:
    virtual int communicateInitInfo() override;
@@ -585,6 +591,9 @@ class HyPerLayer : public BaseLayer {
 
    float **thread_gSyn; // Accumulate buffer for each thread, only used if numThreads > 1
    std::vector<BaseConnection *> recvConns;
+
+   bool mHasReceived = false;
+   bool mHasUpdated = false;
 
 // GPU variables
 #ifdef PV_USE_CUDA

--- a/src/layers/HyPerLayer.hpp
+++ b/src/layers/HyPerLayer.hpp
@@ -379,7 +379,8 @@ class HyPerLayer : public BaseLayer {
    virtual int respondLayerAdvanceDataStore(LayerAdvanceDataStoreMessage const *message);
    virtual int respondLayerPublish(LayerPublishMessage const *message);
    virtual int respondLayerCheckNotANumber(LayerCheckNotANumberMessage const *message);
-   virtual int respondLayerUpdateActiveIndices(LayerUpdateActiveIndicesMessage const *message);
+   // respondLayerUpdateActiveIndices removed Feb 3, 2017. Layers update active indices
+   // in response to other messages, when needed.
    virtual int respondLayerOutputState(LayerOutputStateMessage const *message);
    virtual int publish(Communicator *comm, double simTime);
    virtual int resetGSynBuffers(double timef, double dt);

--- a/src/layers/HyPerLayer.hpp
+++ b/src/layers/HyPerLayer.hpp
@@ -404,6 +404,19 @@ class HyPerLayer : public BaseLayer {
    virtual int insertProbe(LayerProbe *probe);
    int outputProbeParams();
 
+   /**
+    * Returns true if the MPI exchange for the specified delay has finished;
+    * false if it is still in process.
+    */
+   bool isExchangeFinished(int delay = 0);
+
+   /**
+    * Returns true if each layer that delivers input to this layer
+    * has finished its MPI exchange for its delay; false if any of
+    * them has not.
+    */
+   bool isAllInputReady();
+
    int getNumProbes() { return numProbes; }
    LayerProbe *getProbe(int n) { return (n >= 0 && n < numProbes) ? probes[n] : NULL; }
 

--- a/src/layers/ImageFromMemoryBuffer.cpp
+++ b/src/layers/ImageFromMemoryBuffer.cpp
@@ -175,10 +175,6 @@ double ImageFromMemoryBuffer::getDeltaUpdateTime() {
    return parent->getStopTime() - parent->getStartTime();
 }
 
-int ImageFromMemoryBuffer::outputState(double time, bool last) {
-   return HyPerLayer::outputState(time, last);
-}
-
 ImageFromMemoryBuffer::~ImageFromMemoryBuffer() {}
 
 } // namespace PV

--- a/src/layers/ImageFromMemoryBuffer.hpp
+++ b/src/layers/ImageFromMemoryBuffer.hpp
@@ -97,11 +97,6 @@ class ImageFromMemoryBuffer : public ImageLayer {
        */
    virtual int updateState(double time, double dt);
 
-   /**
-    * ImageFromMemoryBuffer uses the same outputState as HyPerLayer
-    */
-   virtual int outputState(double time, bool last = false);
-
   protected:
    ImageFromMemoryBuffer();
 

--- a/src/layers/Retina.cpp
+++ b/src/layers/Retina.cpp
@@ -381,11 +381,6 @@ int Retina::updateState(double timed, double dt) {
    return 0;
 }
 
-int Retina::outputState(double time, bool last) {
-   // HyPerLayer::outputState already has an io timer so don't duplicate
-   return HyPerLayer::outputState(time, last);
-}
-
 } // namespace PV
 
 ///////////////////////////////////////////////////////

--- a/src/layers/Retina.hpp
+++ b/src/layers/Retina.hpp
@@ -46,7 +46,6 @@ class Retina : public PV::HyPerLayer {
    int setRetinaParams(PVParams *p);
 
    virtual int updateState(double time, double dt);
-   virtual int outputState(double time, bool last);
 
    virtual bool activityIsSpiking() { return spikingFlag; }
 

--- a/src/probes/FirmThresholdCostFnProbe.cpp
+++ b/src/probes/FirmThresholdCostFnProbe.cpp
@@ -157,9 +157,10 @@ double FirmThresholdCostFnProbe::getValueInternal(double timevalue, int index) {
    }
    else {
       if (getTargetLayer()->getSparseFlag()) {
-         DataStore *store               = getTargetLayer()->getPublisher()->dataStore();
-         int numActive                  = (int)store->numActiveBuffer(index)[0];
-         unsigned int const *activeList = store->activeIndicesBuffer(index);
+         PVLayerCube cube               = getTargetLayer()->getPublisher()->createCube();
+         long int numActive             = cube.numActive[index];
+         int numItems                   = cube.numItems / cube.loc.nbatch;
+         unsigned int const *activeList = &cube.activeIndices[index * numItems];
 #ifdef PV_USE_OPENMP_THREADS
 #pragma omp parallel for reduction(+ : sum)
 #endif // PV_USE_OPENMP_THREADS

--- a/src/probes/L0NormProbe.cpp
+++ b/src/probes/L0NormProbe.cpp
@@ -97,9 +97,10 @@ double L0NormProbe::getValueInternal(double timevalue, int index) {
    }
    else {
       if (getTargetLayer()->getSparseFlag()) {
-         DataStore *store               = getTargetLayer()->getPublisher()->dataStore();
-         int numActive                  = (int)store->numActiveBuffer(index)[0];
-         unsigned int const *activeList = store->activeIndicesBuffer(index);
+         PVLayerCube cube               = getTargetLayer()->getPublisher()->createCube();
+         long int numActive             = cube.numActive[index];
+         int numItems                   = cube.numItems / cube.loc.nbatch;
+         unsigned int const *activeList = &cube.activeIndices[index * numItems];
 #ifdef PV_USE_OPENMP_THREADS
 #pragma omp parallel for reduction(+ : sum)
 #endif // PV_USE_OPENMP_THREADS

--- a/src/probes/L1NormProbe.cpp
+++ b/src/probes/L1NormProbe.cpp
@@ -7,8 +7,8 @@
 
 #include <cmath>
 
-#include "L1NormProbe.hpp"
 #include "../columns/HyPerCol.hpp"
+#include "L1NormProbe.hpp"
 
 namespace PV {
 
@@ -87,9 +87,10 @@ double L1NormProbe::getValueInternal(double timevalue, int index) {
    }
    else {
       if (getTargetLayer()->getSparseFlag()) {
-         DataStore *store               = getTargetLayer()->getPublisher()->dataStore();
-         int numActive                  = (int)store->numActiveBuffer(index)[0];
-         unsigned int const *activeList = store->activeIndicesBuffer(index);
+         PVLayerCube cube               = getTargetLayer()->getPublisher()->createCube();
+         long int numActive             = cube.numActive[index];
+         int numItems                   = cube.numItems / cube.loc.nbatch;
+         unsigned int const *activeList = &cube.activeIndices[index * numItems];
 #ifdef PV_USE_OPENMP_THREADS
 #pragma omp parallel for reduction(+ : sum)
 #endif // PV_USE_OPENMP_THREADS

--- a/src/probes/L2NormProbe.cpp
+++ b/src/probes/L2NormProbe.cpp
@@ -116,9 +116,10 @@ double L2NormProbe::getValueInternal(double timevalue, int index) {
    }
    else {
       if (getTargetLayer()->getSparseFlag()) {
-         DataStore *store               = getTargetLayer()->getPublisher()->dataStore();
-         int numActive                  = (int)store->numActiveBuffer(index)[0];
-         unsigned int const *activeList = store->activeIndicesBuffer(index);
+         PVLayerCube cube               = getTargetLayer()->getPublisher()->createCube();
+         long int numActive             = cube.numActive[index];
+         int numItems                   = cube.numItems / cube.loc.nbatch;
+         unsigned int const *activeList = &cube.activeIndices[index * numItems];
 #ifdef PV_USE_OPENMP_THREADS
 #pragma omp parallel for reduction(+ : l2normsq)
 #endif // PV_USE_OPENMP_THREADS

--- a/tests/DatastoreDelayTest/src/DatastoreDelayTestLayer.cpp
+++ b/tests/DatastoreDelayTest/src/DatastoreDelayTestLayer.cpp
@@ -58,8 +58,7 @@ int DatastoreDelayTestLayer::updateState(
       int dn,
       int up) {
    // updateV();
-   updateV_DatastoreDelayTestLayer(
-         getLayerLoc(), &inited, getV(), publisher->dataStore()->getNumLevels());
+   updateV_DatastoreDelayTestLayer(getLayerLoc(), &inited, getV(), getNumDelayLevels());
    setActivity_HyPerLayer(parent->getNBatch(), num_neurons, A, V, nx, ny, nf, lt, rt, dn, up);
    // resetGSynBuffers(); // Since V doesn't use the GSyn buffers, no need to maintain them.
 

--- a/tests/DryRunFlagTest/input/correct.params
+++ b/tests/DryRunFlagTest/input/correct.params
@@ -18,7 +18,6 @@ HyPerCol "column" = {
     ny                                  = 32;
     nbatch                              = 1;
     errorOnNotANumber                   = true;
-    immediateLayerPublish               = true;
 };
 
 PvpLayer "Input" = {


### PR DESCRIPTION
This pull request incorporates changes to way advanceTime handles the LayerRecvSynapticInput and LayerUpdateState messages. Instead of having each layer block each timestep until all MPI messages have arrived at the top of its data store, the advanceTime method tests each layer consecutively to see if the MPI messages that affect that specific layer have all arrived. If so, the receive method is called; if not, advanceTime moves on to the next layer, and iterates until all layers in that phase have done their receive. UpdateState is folded into this loop so that if all the layers in the phase have either done their convolutions or are still waiting for MPI, a layer that has done its convolution can do its update state.

The LayerUpdateActiveIndices message, which contained an expensive Waitall, has been removed. Instead, the Publisher updates the list of active indices when the data is requested.

The system tests pass both with and without MPI, and with and without CUDA.