### PR TITLE
Checkpoint entry data store subclasses pvp

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -62,7 +62,7 @@ foreach(SUBDIR ${SRC_SUBDIRS})
   include("${SUBDIR}/CMakeLists.txt")
 endforeach()
 
-set(PVLibSrc ${PVLibSrcCpp} ${PVLibSrcHpp} ${PVLibSrcC} ${PVLibSrcH})
+set(PVLibSrc ${PVLibSrcCpp} ${PVLibSrcHpp} ${PVLibSrcTpp} ${PVLibSrcC} ${PVLibSrcH})
 
 include(PVGitRevision)
 

--- a/src/checkpointing/CMakeLists.txt
+++ b/src/checkpointing/CMakeLists.txt
@@ -11,7 +11,7 @@ set (PVLibSrcHpp ${PVLibSrcHpp}
    ${SUBDIR}/CheckpointEntry.hpp
    ${SUBDIR}/CheckpointEntryData.hpp
    ${SUBDIR}/CheckpointEntryDataStore.hpp
-   ${SUBDIR}/CheckpointEntryPvp.hpp
+   ${SUBDIR}/CheckpointEntryPvpBuffer.hpp
    ${SUBDIR}/CheckpointEntryRandState.hpp
    ${SUBDIR}/CheckpointEntryWeightPvp.hpp
    ${SUBDIR}/CheckpointableFileStream.hpp

--- a/src/checkpointing/CMakeLists.txt
+++ b/src/checkpointing/CMakeLists.txt
@@ -11,10 +11,17 @@ set (PVLibSrcHpp ${PVLibSrcHpp}
    ${SUBDIR}/CheckpointEntry.hpp
    ${SUBDIR}/CheckpointEntryData.hpp
    ${SUBDIR}/CheckpointEntryDataStore.hpp
+   ${SUBDIR}/CheckpointEntryPvp.hpp
    ${SUBDIR}/CheckpointEntryPvpBuffer.hpp
    ${SUBDIR}/CheckpointEntryRandState.hpp
    ${SUBDIR}/CheckpointEntryWeightPvp.hpp
    ${SUBDIR}/CheckpointableFileStream.hpp
    ${SUBDIR}/Checkpointer.hpp
    ${SUBDIR}/CheckpointingMessages.hpp
+)
+
+set (PVLibSrcTpp ${PVLibSrcTpp}
+   ${SUBDIR}/CheckpointEntryData.tpp
+   ${SUBDIR}/CheckpointEntryPvp.tpp
+   ${SUBDIR}/CheckpointEntryPvpBuffer.tpp
 )

--- a/src/checkpointing/CheckpointEntryDataStore.cpp
+++ b/src/checkpointing/CheckpointEntryDataStore.cpp
@@ -13,149 +13,39 @@
 
 namespace PV {
 
-// TODO: many commonalities between CheckpointEntryPvpBuffer and CheckpointEntryDataStore.
-// Refactor to eliminate code duplication
-
-void CheckpointEntryDataStore::initialize(DataStore *dataStore, PVLayerLoc const *layerLoc) {
-   mDataStore = dataStore;
-   mLayerLoc  = layerLoc;
-   mXMargins  = layerLoc->halo.lt + layerLoc->halo.rt;
-   mYMargins  = layerLoc->halo.dn + layerLoc->halo.up;
-}
-
-void CheckpointEntryDataStore::write(
-      std::string const &checkpointDirectory,
-      double simTime,
-      bool verifyWritesFlag) const {
-   int const numFrames = getNumFrames();
-   int const nxBlock   = mLayerLoc->nx * getMPIBlock()->getNumColumns();
-   int const nyBlock   = mLayerLoc->ny * getMPIBlock()->getNumRows();
-
-   FileStream *fileStream = nullptr;
-   if (getMPIBlock()->getRank() == 0) {
-      std::string path = generatePath(checkpointDirectory, "pvp");
-      fileStream       = new FileStream(path.c_str(), std::ios_base::out, verifyWritesFlag);
-      BufferUtils::ActivityHeader header =
-            BufferUtils::buildActivityHeader<float>(nxBlock, nyBlock, mLayerLoc->nf, numFrames);
-      BufferUtils::writeActivityHeader(*fileStream, header);
-   }
-   int const nxExtLocal = mLayerLoc->nx + mXMargins;
-   int const nyExtLocal = mLayerLoc->ny + mYMargins;
-   int const nf         = mLayerLoc->nf;
-
-   for (int frame = 0; frame < numFrames; frame++) {
-      float const *localData = calcBatchElementStart(frame);
-
-      Buffer<float> pvpBuffer{localData, nxExtLocal, nyExtLocal, nf};
-      pvpBuffer.crop(mLayerLoc->nx, mLayerLoc->ny, Buffer<float>::CENTER);
-
-      // All ranks with BatchIndex==mpiBatchIndex must call gather; so must
-      // the root process (which may or may not have BatchIndex==mpiBatchIndex).
-      // Other ranks will return from gather() immediately.
-      int const mpiBatchIndex       = calcMPIBatchIndex(frame);
-      Buffer<float> globalPvpBuffer = BufferUtils::gather(
-            getMPIBlock(), pvpBuffer, mLayerLoc->nx, mLayerLoc->ny, mpiBatchIndex, 0);
-
-      if (getMPIBlock()->getRank() == 0) {
-         pvAssert(fileStream);
-         pvAssert(globalPvpBuffer.getWidth() == nxBlock);
-         pvAssert(globalPvpBuffer.getHeight() == nyBlock);
-         BufferUtils::writeFrame(*fileStream, &globalPvpBuffer, simTime);
-      }
-   }
-   delete fileStream;
-}
-
-void CheckpointEntryDataStore::read(std::string const &checkpointDirectory, double *simTimePtr)
-      const {
-   int const numFrames = getNumFrames();
-   int const nxBlock   = mLayerLoc->nx * getMPIBlock()->getNumColumns();
-   int const nyBlock   = mLayerLoc->ny * getMPIBlock()->getNumRows();
-
-   int const nxExtLocal  = mLayerLoc->nx + mXMargins;
-   int const nyExtLocal  = mLayerLoc->ny + mYMargins;
-   int const nxExtGlobal = nxBlock + mXMargins;
-   int const nyExtGlobal = nyBlock + mYMargins;
-
-   std::string path;
-   if (getMPIBlock()->getRank() == 0) {
-      path = generatePath(checkpointDirectory, "pvp");
-      FileStream fileStream(path.c_str(), std::ios_base::in, false);
-      struct BufferUtils::ActivityHeader header = BufferUtils::readActivityHeader(fileStream);
-      FatalIf(
-            header.nBands != numFrames,
-            "CheckpointEntryDataStore::read error reading \"%s\": delays*batchwidth in file is %d, "
-            "but delays*batchwidth in layer is %d\n",
-            path.c_str(),
-            header.nBands,
-            numFrames);
-   }
-   Buffer<float> pvpBuffer;
-   std::vector<double> frameTimestamps;
-   frameTimestamps.resize(numFrames);
-   for (int frame = 0; frame < numFrames; frame++) {
-      int const mpiBatchIndex = calcMPIBatchIndex(frame);
-      if (getMPIBlock()->getRank() == 0) {
-         frameTimestamps.at(frame) =
-               BufferUtils::readActivityFromPvp(path.c_str(), &pvpBuffer, frame);
-         pvpBuffer.grow(nxExtGlobal, nyExtGlobal, Buffer<float>::CENTER);
-      }
-      else if (mpiBatchIndex == getMPIBlock()->getBatchIndex()) {
-         pvpBuffer.resize(nxExtLocal, nyExtLocal, mLayerLoc->nf);
-      }
-      // All ranks with BatchIndex==mpiBatchIndex must call scatter; so must
-      // the root process (which may or may not have BatchIndex==mpiBatchIndex).
-      // Other ranks will return from scatter() immediately.
-      BufferUtils::scatter(
-            getMPIBlock(), pvpBuffer, mLayerLoc->nx, mLayerLoc->ny, mpiBatchIndex, 0);
-      if (mpiBatchIndex == getMPIBlock()->getBatchIndex()) {
-         std::vector<float> bufferData = pvpBuffer.asVector();
-         float *localData              = calcBatchElementStart(frame);
-         std::memcpy(
-               localData,
-               bufferData.data(),
-               (std::size_t)pvpBuffer.getTotalElements() * sizeof(float));
-      }
-   }
-   MPI_Bcast(
-         frameTimestamps.data(), getNumFrames(), MPI_DOUBLE, 0 /*root*/, getMPIBlock()->getComm());
-   setLastUpdateTimes(frameTimestamps);
-}
+// Constructors defined in .hpp file.
+// Read, write and remove methods inherited from CheckpointEntryPvp.
 
 int CheckpointEntryDataStore::getNumFrames() const {
-   int const numBuffers  = mDataStore->getNumBuffers();
-   int const numLevels   = mDataStore->getNumLevels();
+   int const numBuffers  = getDataStore()->getNumBuffers();
+   int const numLevels   = getDataStore()->getNumLevels();
    int const mpiBatchDim = getMPIBlock()->getBatchDimension();
 
    return numLevels * numBuffers * mpiBatchDim;
 }
 
 float *CheckpointEntryDataStore::calcBatchElementStart(int frame) const {
-   int const numBuffers = mDataStore->getNumBuffers();
-   int const numLevels  = mDataStore->getNumLevels();
+   int const numBuffers = getDataStore()->getNumBuffers();
+   int const numLevels  = getDataStore()->getNumLevels();
    int const level      = frame % numLevels;
    int const buffer     = (frame / numLevels) % numBuffers; // Integer division
-   return mDataStore->buffer(buffer, level);
+   return getDataStore()->buffer(buffer, level);
 }
 
 int CheckpointEntryDataStore::calcMPIBatchIndex(int frame) const {
-   return frame / (mDataStore->getNumLevels() * mDataStore->getNumBuffers());
+   return frame / (getDataStore()->getNumLevels() * getDataStore()->getNumBuffers());
 }
 
 void CheckpointEntryDataStore::setLastUpdateTimes(std::vector<double> const &timestamps) const {
-   int const numBuffers                  = mDataStore->getNumBuffers();
-   int const numLevels                   = mDataStore->getNumLevels();
+   int const numBuffers                  = getDataStore()->getNumBuffers();
+   int const numLevels                   = getDataStore()->getNumLevels();
    int const mpiBatchIndex               = getMPIBlock()->getBatchIndex();
    double const *updateTimesBatchElement = &timestamps[numBuffers * numLevels * mpiBatchIndex];
    for (int b = 0; b < numBuffers; b++) {
       for (int l = 0; l < numLevels; l++) {
-         mDataStore->setLastUpdateTime(b, l, updateTimesBatchElement[b * numLevels + l]);
+         getDataStore()->setLastUpdateTime(b, l, updateTimesBatchElement[b * numLevels + l]);
       }
    }
-}
-
-void CheckpointEntryDataStore::remove(std::string const &checkpointDirectory) const {
-   deleteFile(checkpointDirectory, "pvp");
 }
 
 } // end namespace PV

--- a/src/checkpointing/CheckpointEntryDataStore.cpp
+++ b/src/checkpointing/CheckpointEntryDataStore.cpp
@@ -13,7 +13,7 @@
 
 namespace PV {
 
-// TODO: many commonalities between CheckpointEntryPvp and CheckpointEntryDataStore.
+// TODO: many commonalities between CheckpointEntryPvpBuffer and CheckpointEntryDataStore.
 // Refactor to eliminate code duplication
 
 void CheckpointEntryDataStore::initialize(DataStore *dataStore, PVLayerLoc const *layerLoc) {

--- a/src/checkpointing/CheckpointEntryDataStore.cpp
+++ b/src/checkpointing/CheckpointEntryDataStore.cpp
@@ -19,18 +19,17 @@ namespace PV {
 void CheckpointEntryDataStore::initialize(DataStore *dataStore, PVLayerLoc const *layerLoc) {
    mDataStore = dataStore;
    mLayerLoc  = layerLoc;
+   mXMargins  = layerLoc->halo.lt + layerLoc->halo.rt;
+   mYMargins  = layerLoc->halo.dn + layerLoc->halo.up;
 }
 
 void CheckpointEntryDataStore::write(
       std::string const &checkpointDirectory,
       double simTime,
       bool verifyWritesFlag) const {
-   int const numBuffers  = mDataStore->getNumBuffers();
-   int const numLevels   = mDataStore->getNumLevels();
-   int const mpiBatchDim = getMPIBlock()->getBatchDimension();
-   int const numFrames   = numLevels * numBuffers * mpiBatchDim;
-   int const nxBlock     = mLayerLoc->nx * getMPIBlock()->getNumColumns();
-   int const nyBlock     = mLayerLoc->ny * getMPIBlock()->getNumRows();
+   int const numFrames = getNumFrames();
+   int const nxBlock   = mLayerLoc->nx * getMPIBlock()->getNumColumns();
+   int const nyBlock   = mLayerLoc->ny * getMPIBlock()->getNumRows();
 
    FileStream *fileStream = nullptr;
    if (getMPIBlock()->getRank() == 0) {
@@ -40,22 +39,20 @@ void CheckpointEntryDataStore::write(
             BufferUtils::buildActivityHeader<float>(nxBlock, nyBlock, mLayerLoc->nf, numFrames);
       BufferUtils::writeActivityHeader(*fileStream, header);
    }
-   PVHalo const &halo   = mLayerLoc->halo;
-   int const nxExtLocal = mLayerLoc->nx + halo.lt + halo.rt;
-   int const nyExtLocal = mLayerLoc->ny + halo.dn + halo.up;
+   int const nxExtLocal = mLayerLoc->nx + mXMargins;
+   int const nyExtLocal = mLayerLoc->ny + mYMargins;
    int const nf         = mLayerLoc->nf;
-   for (int frame = 0; frame < numFrames; frame++) {
-      int const level         = frame % numLevels;
-      int const buffer        = (frame / numLevels) % numBuffers; // Integer division
-      int const mpiBatchIndex = frame / (numLevels * numBuffers); // Integer division
 
-      float const *localData = mDataStore->buffer(buffer, level);
+   for (int frame = 0; frame < numFrames; frame++) {
+      float const *localData = calcBatchElementStart(frame);
+
       Buffer<float> pvpBuffer{localData, nxExtLocal, nyExtLocal, nf};
       pvpBuffer.crop(mLayerLoc->nx, mLayerLoc->ny, Buffer<float>::CENTER);
 
       // All ranks with BatchIndex==mpiBatchIndex must call gather; so must
       // the root process (which may or may not have BatchIndex==mpiBatchIndex).
       // Other ranks will return from gather() immediately.
+      int const mpiBatchIndex       = calcMPIBatchIndex(frame);
       Buffer<float> globalPvpBuffer = BufferUtils::gather(
             getMPIBlock(), pvpBuffer, mLayerLoc->nx, mLayerLoc->ny, mpiBatchIndex, 0);
 
@@ -71,18 +68,14 @@ void CheckpointEntryDataStore::write(
 
 void CheckpointEntryDataStore::read(std::string const &checkpointDirectory, double *simTimePtr)
       const {
-   int const numBuffers  = mDataStore->getNumBuffers();
-   int const numLevels   = mDataStore->getNumLevels();
-   int const mpiBatchDim = getMPIBlock()->getBatchDimension();
-   int const numFrames   = numLevels * numBuffers * mpiBatchDim;
-   int const nxBlock     = mLayerLoc->nx * getMPIBlock()->getNumColumns();
-   int const nyBlock     = mLayerLoc->ny * getMPIBlock()->getNumRows();
+   int const numFrames = getNumFrames();
+   int const nxBlock   = mLayerLoc->nx * getMPIBlock()->getNumColumns();
+   int const nyBlock   = mLayerLoc->ny * getMPIBlock()->getNumRows();
 
-   PVHalo const &halo    = mLayerLoc->halo;
-   int const nxExtLocal  = mLayerLoc->nx + halo.lt + halo.rt;
-   int const nyExtLocal  = mLayerLoc->ny + halo.dn + halo.up;
-   int const nxExtGlobal = nxBlock + halo.lt + halo.rt;
-   int const nyExtGlobal = nyBlock + halo.dn + halo.up;
+   int const nxExtLocal  = mLayerLoc->nx + mXMargins;
+   int const nyExtLocal  = mLayerLoc->ny + mYMargins;
+   int const nxExtGlobal = nxBlock + mXMargins;
+   int const nyExtGlobal = nyBlock + mYMargins;
 
    std::string path;
    if (getMPIBlock()->getRank() == 0) {
@@ -98,36 +91,62 @@ void CheckpointEntryDataStore::read(std::string const &checkpointDirectory, doub
             numFrames);
    }
    Buffer<float> pvpBuffer;
-   std::vector<double> updateTimes;
-   updateTimes.resize(numFrames);
+   std::vector<double> frameTimestamps;
+   frameTimestamps.resize(numFrames);
    for (int frame = 0; frame < numFrames; frame++) {
-      int const level         = frame % numLevels;
-      int const buffer        = (frame / numLevels) % numBuffers; // Integer division
-      int const mpiBatchIndex = frame / (numLevels * numBuffers); // Integer division
+      int const mpiBatchIndex = calcMPIBatchIndex(frame);
       if (getMPIBlock()->getRank() == 0) {
-         updateTimes.at(frame) = BufferUtils::readActivityFromPvp(path.c_str(), &pvpBuffer, frame);
+         frameTimestamps.at(frame) =
+               BufferUtils::readActivityFromPvp(path.c_str(), &pvpBuffer, frame);
          pvpBuffer.grow(nxExtGlobal, nyExtGlobal, Buffer<float>::CENTER);
       }
-      else {
+      else if (mpiBatchIndex == getMPIBlock()->getBatchIndex()) {
          pvpBuffer.resize(nxExtLocal, nyExtLocal, mLayerLoc->nf);
       }
-      // All ranks with BatchIndex==m must call scatter; so must the root
-      // process (which may or may not have BatchIndex==m).
+      // All ranks with BatchIndex==mpiBatchIndex must call scatter; so must
+      // the root process (which may or may not have BatchIndex==mpiBatchIndex).
       // Other ranks will return from scatter() immediately.
       BufferUtils::scatter(
             getMPIBlock(), pvpBuffer, mLayerLoc->nx, mLayerLoc->ny, mpiBatchIndex, 0);
       if (mpiBatchIndex == getMPIBlock()->getBatchIndex()) {
          std::vector<float> bufferData = pvpBuffer.asVector();
-         float *localData              = mDataStore->buffer(buffer, level);
+         float *localData              = calcBatchElementStart(frame);
          std::memcpy(
                localData,
                bufferData.data(),
                (std::size_t)pvpBuffer.getTotalElements() * sizeof(float));
       }
    }
-   MPI_Bcast(updateTimes.data(), numFrames, MPI_DOUBLE, 0 /*root*/, getMPIBlock()->getComm());
-   int const mpiBatchIndex         = getMPIBlock()->getBatchIndex();
-   double *updateTimesBatchElement = &updateTimes[mpiBatchIndex * numLevels * numBuffers];
+   MPI_Bcast(
+         frameTimestamps.data(), getNumFrames(), MPI_DOUBLE, 0 /*root*/, getMPIBlock()->getComm());
+   setLastUpdateTimes(frameTimestamps);
+}
+
+int CheckpointEntryDataStore::getNumFrames() const {
+   int const numBuffers  = mDataStore->getNumBuffers();
+   int const numLevels   = mDataStore->getNumLevels();
+   int const mpiBatchDim = getMPIBlock()->getBatchDimension();
+
+   return numLevels * numBuffers * mpiBatchDim;
+}
+
+float *CheckpointEntryDataStore::calcBatchElementStart(int frame) const {
+   int const numBuffers = mDataStore->getNumBuffers();
+   int const numLevels  = mDataStore->getNumLevels();
+   int const level      = frame % numLevels;
+   int const buffer     = (frame / numLevels) % numBuffers; // Integer division
+   return mDataStore->buffer(buffer, level);
+}
+
+int CheckpointEntryDataStore::calcMPIBatchIndex(int frame) const {
+   return frame / (mDataStore->getNumLevels() * mDataStore->getNumBuffers());
+}
+
+void CheckpointEntryDataStore::setLastUpdateTimes(std::vector<double> const &timestamps) const {
+   int const numBuffers                  = mDataStore->getNumBuffers();
+   int const numLevels                   = mDataStore->getNumLevels();
+   int const mpiBatchIndex               = getMPIBlock()->getBatchIndex();
+   double const *updateTimesBatchElement = &timestamps[numBuffers * numLevels * mpiBatchIndex];
    for (int b = 0; b < numBuffers; b++) {
       for (int l = 0; l < numLevels; l++) {
          mDataStore->setLastUpdateTime(b, l, updateTimesBatchElement[b * numLevels + l]);

--- a/src/checkpointing/CheckpointEntryDataStore.hpp
+++ b/src/checkpointing/CheckpointEntryDataStore.hpp
@@ -42,8 +42,16 @@ class CheckpointEntryDataStore : public CheckpointEntry {
    void initialize(DataStore *dataStore, PVLayerLoc const *layerLoc);
 
   private:
-   DataStore *mDataStore;
+   int getNumFrames() const;
+   float *calcBatchElementStart(int frame) const;
+   int calcMPIBatchIndex(int frame) const;
+   void setLastUpdateTimes(std::vector<double> const &timestamps) const;
+
+  private:
+   DataStore *mDataStore       = nullptr;
    PVLayerLoc const *mLayerLoc = nullptr;
+   int mXMargins               = 0;
+   int mYMargins               = 0;
 };
 
 } // end namespace PV

--- a/src/checkpointing/CheckpointEntryDataStore.hpp
+++ b/src/checkpointing/CheckpointEntryDataStore.hpp
@@ -8,50 +8,44 @@
 #ifndef CHECKPOINTENTRYDATASTORE_HPP_
 #define CHECKPOINTENTRYDATASTORE_HPP_
 
-#include "checkpointing/CheckpointEntry.hpp"
+#include "checkpointing/CheckpointEntryPvp.hpp"
 #include "columns/DataStore.hpp"
 #include <string>
 
 namespace PV {
 
-class CheckpointEntryDataStore : public CheckpointEntry {
+class CheckpointEntryDataStore : public CheckpointEntryPvp<float> {
   public:
    CheckpointEntryDataStore(
          std::string const &name,
          MPIBlock const *mpiBlock,
          DataStore *dataStore,
          PVLayerLoc const *layerLoc)
-         : CheckpointEntry(name, mpiBlock) {
-      initialize(dataStore, layerLoc);
-   }
+         : CheckpointEntryPvp<float>(name, mpiBlock, layerLoc, true), mDataStore(dataStore) {}
    CheckpointEntryDataStore(
          std::string const &objName,
          std::string const &dataName,
          MPIBlock const *mpiBlock,
          DataStore *dataStore,
          PVLayerLoc const *layerLoc)
-         : CheckpointEntry(objName, dataName, mpiBlock) {
-      initialize(dataStore, layerLoc);
-   }
-   virtual void write(std::string const &checkpointDirectory, double simTime, bool verifyWritesFlag)
-         const override;
-   virtual void read(std::string const &checkpointDirectory, double *simTimePtr) const override;
-   virtual void remove(std::string const &checkpointDirectory) const override;
+         : CheckpointEntryPvp<float>(objName, dataName, mpiBlock, layerLoc, true),
+           mDataStore(dataStore) {}
 
   protected:
-   void initialize(DataStore *dataStore, PVLayerLoc const *layerLoc);
+   virtual int getNumFrames() const override;
+   virtual float *calcBatchElementStart(int batchElement) const override;
+   virtual int calcMPIBatchIndex(int frame) const override;
+   virtual void applyTimestamps(std::vector<double> const &timestamps) const override {
+      setLastUpdateTimes(timestamps);
+   }
+
+   DataStore *getDataStore() const { return mDataStore; }
 
   private:
-   int getNumFrames() const;
-   float *calcBatchElementStart(int frame) const;
-   int calcMPIBatchIndex(int frame) const;
    void setLastUpdateTimes(std::vector<double> const &timestamps) const;
 
   private:
-   DataStore *mDataStore       = nullptr;
-   PVLayerLoc const *mLayerLoc = nullptr;
-   int mXMargins               = 0;
-   int mYMargins               = 0;
+   DataStore *mDataStore = nullptr;
 };
 
 } // end namespace PV

--- a/src/checkpointing/CheckpointEntryPvp.hpp
+++ b/src/checkpointing/CheckpointEntryPvp.hpp
@@ -22,34 +22,32 @@ class CheckpointEntryPvp : public CheckpointEntry {
          MPIBlock const *mpiBlock,
          T *dataPtr,
          PVLayerLoc const *layerLoc,
-         bool extended)
-         : CheckpointEntry(name, mpiBlock),
-           mDataPointer(dataPtr),
-           mLayerLoc(layerLoc),
-           mExtended(extended) {}
+         bool extended);
    CheckpointEntryPvp(
          std::string const &objName,
          std::string const &dataName,
          MPIBlock const *mpiBlock,
          T *dataPtr,
          PVLayerLoc const *layerLoc,
-         bool extended)
-         : CheckpointEntry(objName, dataName, mpiBlock),
-           mDataPointer(dataPtr),
-           mLayerLoc(layerLoc),
-           mExtended(extended) {}
+         bool extended);
    virtual void write(std::string const &checkpointDirectory, double simTime, bool verifyWritesFlag)
          const override;
    virtual void read(std::string const &checkpointDirectory, double *simTimePtr) const override;
    virtual void remove(std::string const &checkpointDirectory) const override;
 
-  private:
-   T *calcBatchElementStart(int batchElement) const;
+  protected:
+   void initialize(T *dataPtr, PVLayerLoc const *layerLoc, bool extended);
 
   private:
-   T *mDataPointer;
+   int getNumFrames() const;
+   T *calcBatchElementStart(int batchElement) const;
+   int calcMPIBatchIndex(int frame) const;
+
+  private:
+   T *mDataPointer             = nullptr;
    PVLayerLoc const *mLayerLoc = nullptr;
-   bool mExtended              = false;
+   int mXMargins               = 0; // If extended is true, use mLayerLoc's halo for the margins.
+   int mYMargins               = 0; // If extended is false, use zero for the margins.
 };
 
 } // end namespace PV

--- a/src/checkpointing/CheckpointEntryPvp.hpp
+++ b/src/checkpointing/CheckpointEntryPvp.hpp
@@ -1,0 +1,64 @@
+/*
+ * CheckpointEntryPvp.hpp
+ *
+ *  Created on Feb 13, 2017
+ *      Author: Pete Schultz
+ */
+
+#ifndef CHECKPOINTENTRYPVP_HPP_
+#define CHECKPOINTENTRYPVP_HPP_
+
+#include "CheckpointEntry.hpp"
+#include "include/PVLayerLoc.h"
+#include <string>
+#include <vector>
+
+namespace PV {
+
+template <typename T>
+class CheckpointEntryPvp : public CheckpointEntry {
+  public:
+   CheckpointEntryPvp(
+         std::string const &name,
+         MPIBlock const *mpiBlock,
+         PVLayerLoc const *layerLoc,
+         bool extended);
+   CheckpointEntryPvp(
+         std::string const &objName,
+         std::string const &dataName,
+         MPIBlock const *mpiBlock,
+         PVLayerLoc const *layerLoc,
+         bool extended);
+   virtual void write(std::string const &checkpointDirectory, double simTime, bool verifyWritesFlag)
+         const override;
+   virtual void read(std::string const &checkpointDirectory, double *simTimePtr) const override;
+   virtual void remove(std::string const &checkpointDirectory) const override;
+
+  protected:
+   void initialize(PVLayerLoc const *layerLoc, bool extended);
+
+   virtual int getNumFrames() const                         = 0;
+   virtual T *calcBatchElementStart(int batchElement) const = 0;
+   virtual int calcMPIBatchIndex(int frame) const           = 0;
+   virtual void applyTimestamps(std::vector<double> const &timestamps) const {}
+
+   T *getDataPointer() const { return mDataPointer; }
+   PVLayerLoc const *getLayerLoc() const { return mLayerLoc; }
+   int getXMargins() const { return mXMargins; }
+   int getYMargins() const { return mYMargins; }
+
+  private:
+   T *mDataPointer             = nullptr;
+   PVLayerLoc const *mLayerLoc = nullptr;
+
+   // If extended is true (reading/writing an extended buffer), use mLayerLoc->halo for the margins
+   // If extended is false (reading/writing a restricted buffer), use 0 for the margins.
+   int mXMargins = 0;
+   int mYMargins = 0;
+};
+
+} // end namespace PV
+
+#include "CheckpointEntryPvp.tpp"
+
+#endif // CHECKPOINTENTRYPVP_HPP_

--- a/src/checkpointing/CheckpointEntryPvp.tpp
+++ b/src/checkpointing/CheckpointEntryPvp.tpp
@@ -1,0 +1,158 @@
+/*
+ * CheckpointEntryPvp.tpp
+ *
+ *  Created on Sep 27, 2016
+ *      Author: Pete Schultz
+ *  template implementations for CheckpointEntryPvp class.
+ *  Note that the .hpp includes this .tpp file at the end;
+ *  the .tpp file does not include the .hpp file.
+ */
+
+#include "structures/Buffer.hpp"
+#include "utils/BufferUtilsMPI.hpp"
+#include "utils/BufferUtilsPvp.hpp"
+#include "utils/PVAssert.hpp"
+#include "utils/PVLog.hpp"
+#include <cstring>
+#include <vector>
+
+namespace PV {
+
+template <typename T>
+CheckpointEntryPvp<T>::CheckpointEntryPvp(
+      std::string const &name,
+      MPIBlock const *mpiBlock,
+      PVLayerLoc const *layerLoc,
+      bool extended)
+      : CheckpointEntry(name, mpiBlock) {
+   initialize(layerLoc, extended);
+}
+
+template <typename T>
+CheckpointEntryPvp<T>::CheckpointEntryPvp(
+      std::string const &objName,
+      std::string const &dataName,
+      MPIBlock const *mpiBlock,
+      PVLayerLoc const *layerLoc,
+      bool extended)
+      : CheckpointEntry(objName, dataName, mpiBlock) {
+   initialize(layerLoc, extended);
+}
+
+template <typename T>
+void CheckpointEntryPvp<T>::initialize(PVLayerLoc const *layerLoc, bool extended) {
+   mLayerLoc = layerLoc;
+   if (extended) {
+      mXMargins = layerLoc->halo.lt + layerLoc->halo.rt;
+      mYMargins = layerLoc->halo.dn + layerLoc->halo.up;
+   }
+   else {
+      mXMargins = 0;
+      mYMargins = 0;
+   }
+}
+
+template <typename T>
+void CheckpointEntryPvp<T>::write(
+      std::string const &checkpointDirectory,
+      double simTime,
+      bool verifyWritesFlag) const {
+   int const numFrames = getNumFrames();
+   int const nxBlock   = mLayerLoc->nx * getMPIBlock()->getNumColumns();
+   int const nyBlock   = mLayerLoc->ny * getMPIBlock()->getNumRows();
+
+   FileStream *fileStream = nullptr;
+   if (getMPIBlock()->getRank() == 0) {
+      std::string path = generatePath(checkpointDirectory, "pvp");
+      fileStream       = new FileStream(path.c_str(), std::ios_base::out, verifyWritesFlag);
+      BufferUtils::ActivityHeader header =
+            BufferUtils::buildActivityHeader<T>(nxBlock, nyBlock, mLayerLoc->nf, numFrames);
+      BufferUtils::writeActivityHeader(*fileStream, header);
+   }
+   int const nxExtLocal = mLayerLoc->nx + mXMargins;
+   int const nyExtLocal = mLayerLoc->ny + mYMargins;
+   int const nf         = mLayerLoc->nf;
+
+   for (int frame = 0; frame < numFrames; frame++) {
+      T const *localData = calcBatchElementStart(frame);
+
+      Buffer<T> pvpBuffer{localData, nxExtLocal, nyExtLocal, nf};
+      pvpBuffer.crop(mLayerLoc->nx, mLayerLoc->ny, Buffer<T>::CENTER);
+
+      // All ranks with BatchIndex==mpiBatchIndex must call gather; so must
+      // the root process (which may or may not have BatchIndex==mpiBatchIndex).
+      // Other ranks will return from gather() immediately.
+      int const mpiBatchIndex   = calcMPIBatchIndex(frame);
+      Buffer<T> globalPvpBuffer = BufferUtils::gather(
+            getMPIBlock(), pvpBuffer, mLayerLoc->nx, mLayerLoc->ny, mpiBatchIndex, 0);
+
+      if (getMPIBlock()->getRank() == 0) {
+         pvAssert(fileStream);
+         pvAssert(globalPvpBuffer.getWidth() == nxBlock);
+         pvAssert(globalPvpBuffer.getHeight() == nyBlock);
+         BufferUtils::writeFrame(*fileStream, &globalPvpBuffer, simTime);
+      }
+   }
+   delete fileStream;
+}
+
+template <typename T>
+void CheckpointEntryPvp<T>::read(std::string const &checkpointDirectory, double *simTimePtr) const {
+   int const numFrames = getNumFrames();
+   int const nxBlock   = mLayerLoc->nx * getMPIBlock()->getNumColumns();
+   int const nyBlock   = mLayerLoc->ny * getMPIBlock()->getNumRows();
+
+   int const nxExtLocal  = mLayerLoc->nx + mXMargins;
+   int const nyExtLocal  = mLayerLoc->ny + mYMargins;
+   int const nxExtGlobal = nxBlock + mXMargins;
+   int const nyExtGlobal = nyBlock + mYMargins;
+
+   std::string path;
+   if (getMPIBlock()->getRank() == 0) {
+      path = generatePath(checkpointDirectory, "pvp");
+      FileStream fileStream(path.c_str(), std::ios_base::in, false);
+      struct BufferUtils::ActivityHeader header = BufferUtils::readActivityHeader(fileStream);
+      FatalIf(
+            header.nBands != numFrames,
+            "CheckpointEntryDataStore::read error reading \"%s\": delays*batchwidth in file is %d, "
+            "but delays*batchwidth in layer is %d\n",
+            path.c_str(),
+            header.nBands,
+            numFrames);
+   }
+   Buffer<T> pvpBuffer;
+   std::vector<double> frameTimestamps;
+   frameTimestamps.resize(numFrames);
+   for (int frame = 0; frame < numFrames; frame++) {
+      int const mpiBatchIndex = calcMPIBatchIndex(frame);
+      if (getMPIBlock()->getRank() == 0) {
+         frameTimestamps.at(frame) =
+               BufferUtils::readActivityFromPvp(path.c_str(), &pvpBuffer, frame);
+         pvpBuffer.grow(nxExtGlobal, nyExtGlobal, Buffer<float>::CENTER);
+      }
+      else if (mpiBatchIndex == getMPIBlock()->getBatchIndex()) {
+         pvpBuffer.resize(nxExtLocal, nyExtLocal, mLayerLoc->nf);
+      }
+      // All ranks with BatchIndex==mpiBatchIndex must call scatter; so must
+      // the root process (which may or may not have BatchIndex==mpiBatchIndex).
+      // Other ranks will return from scatter() immediately.
+      BufferUtils::scatter(
+            getMPIBlock(), pvpBuffer, mLayerLoc->nx, mLayerLoc->ny, mpiBatchIndex, 0);
+      if (mpiBatchIndex == getMPIBlock()->getBatchIndex()) {
+         std::vector<T> bufferData = pvpBuffer.asVector();
+         T *localData              = calcBatchElementStart(frame);
+         std::memcpy(
+               localData, bufferData.data(), (std::size_t)pvpBuffer.getTotalElements() * sizeof(T));
+      }
+   }
+   MPI_Bcast(
+         frameTimestamps.data(), getNumFrames(), MPI_DOUBLE, 0 /*root*/, getMPIBlock()->getComm());
+   applyTimestamps(frameTimestamps);
+   *simTimePtr = frameTimestamps[0];
+}
+
+template <typename T>
+void CheckpointEntryPvp<T>::remove(std::string const &checkpointDirectory) const {
+   deleteFile(checkpointDirectory, "pvp");
+}
+} // end namespace PV

--- a/src/checkpointing/CheckpointEntryPvp.tpp
+++ b/src/checkpointing/CheckpointEntryPvp.tpp
@@ -22,11 +22,48 @@ namespace PV {
 // Refactor to eliminate code duplication
 
 template <typename T>
+CheckpointEntryPvp<T>::CheckpointEntryPvp(
+      std::string const &name,
+      MPIBlock const *mpiBlock,
+      T *dataPtr,
+      PVLayerLoc const *layerLoc,
+      bool extended)
+      : CheckpointEntry(name, mpiBlock) {
+   initialize(dataPtr, layerLoc, extended);
+}
+
+template <typename T>
+CheckpointEntryPvp<T>::CheckpointEntryPvp(
+      std::string const &objName,
+      std::string const &dataName,
+      MPIBlock const *mpiBlock,
+      T *dataPtr,
+      PVLayerLoc const *layerLoc,
+      bool extended)
+      : CheckpointEntry(objName, dataName, mpiBlock) {
+   initialize(dataPtr, layerLoc, extended);
+}
+
+template <typename T>
+void CheckpointEntryPvp<T>::initialize(T *dataPtr, PVLayerLoc const *layerLoc, bool extended) {
+   mDataPointer = dataPtr;
+   mLayerLoc    = layerLoc;
+   if (extended) {
+      mXMargins = layerLoc->halo.lt + layerLoc->halo.rt;
+      mYMargins = layerLoc->halo.dn + layerLoc->halo.up;
+   }
+   else {
+      mXMargins = 0;
+      mYMargins = 0;
+   }
+}
+
+template <typename T>
 void CheckpointEntryPvp<T>::write(
       std::string const &checkpointDirectory,
       double simTime,
       bool verifyWritesFlag) const {
-   int const numFrames = getMPIBlock()->getBatchDimension() * mLayerLoc->nbatch;
+   int const numFrames = getNumFrames();
    int const nxBlock   = mLayerLoc->nx * getMPIBlock()->getNumColumns();
    int const nyBlock   = mLayerLoc->ny * getMPIBlock()->getNumRows();
 
@@ -38,22 +75,20 @@ void CheckpointEntryPvp<T>::write(
             BufferUtils::buildActivityHeader<T>(nxBlock, nyBlock, mLayerLoc->nf, numFrames);
       BufferUtils::writeActivityHeader(*fileStream, header);
    }
-   PVHalo const &halo   = mLayerLoc->halo;
-   int const nxExtLocal = mLayerLoc->nx + (mExtended ? halo.lt + halo.rt : 0);
-   int const nyExtLocal = mLayerLoc->ny + (mExtended ? halo.dn + halo.up : 0);
+   int const nxExtLocal = mLayerLoc->nx + mXMargins;
+   int const nyExtLocal = mLayerLoc->ny + mYMargins;
    int const nf         = mLayerLoc->nf;
 
    for (int frame = 0; frame < numFrames; frame++) {
-      int const localBatchIndex = frame % mLayerLoc->nbatch;
-      int const mpiBatchIndex   = frame / mLayerLoc->nbatch; // Integer division
+      T const *localData = calcBatchElementStart(frame);
 
-      T *localData = calcBatchElementStart(localBatchIndex);
       Buffer<T> pvpBuffer{localData, nxExtLocal, nyExtLocal, nf};
       pvpBuffer.crop(mLayerLoc->nx, mLayerLoc->ny, Buffer<T>::CENTER);
 
       // All ranks with BatchIndex==mpiBatchIndex must call gather; so must
       // the root process (which may or may not have BatchIndex==mpiBatchIndex).
       // Other ranks will return from gather() immediately.
+      int const mpiBatchIndex   = calcMPIBatchIndex(frame);
       Buffer<T> globalPvpBuffer = BufferUtils::gather(
             getMPIBlock(), pvpBuffer, mLayerLoc->nx, mLayerLoc->ny, mpiBatchIndex, 0);
 
@@ -69,24 +104,36 @@ void CheckpointEntryPvp<T>::write(
 
 template <typename T>
 void CheckpointEntryPvp<T>::read(std::string const &checkpointDirectory, double *simTimePtr) const {
-   int const numFrames = getMPIBlock()->getBatchDimension() * mLayerLoc->nbatch;
+   int const numFrames = getNumFrames();
    int const nxBlock   = mLayerLoc->nx * getMPIBlock()->getNumColumns();
    int const nyBlock   = mLayerLoc->ny * getMPIBlock()->getNumRows();
 
-   PVHalo const &halo    = mLayerLoc->halo;
-   int const nxExtLocal  = mLayerLoc->nx + (mExtended ? halo.lt + halo.rt : 0);
-   int const nyExtLocal  = mLayerLoc->ny + (mExtended ? halo.dn + halo.up : 0);
-   int const nxExtGlobal = nxBlock + (mExtended ? halo.lt + halo.rt : 0);
-   int const nyExtGlobal = nyBlock + (mExtended ? halo.dn + halo.up : 0);
+   int const nxExtLocal  = mLayerLoc->nx + mXMargins;
+   int const nyExtLocal  = mLayerLoc->ny + mYMargins;
+   int const nxExtGlobal = nxBlock + mXMargins;
+   int const nyExtGlobal = nyBlock + mYMargins;
 
-   std::string path = generatePath(checkpointDirectory, "pvp");
+   std::string path;
+   if (getMPIBlock()->getRank() == 0) {
+      path = generatePath(checkpointDirectory, "pvp");
+      FileStream fileStream(path.c_str(), std::ios_base::in, false);
+      struct BufferUtils::ActivityHeader header = BufferUtils::readActivityHeader(fileStream);
+      FatalIf(
+            header.nBands != numFrames,
+            "CheckpointEntryDataStore::read error reading \"%s\": delays*batchwidth in file is %d, "
+            "but delays*batchwidth in layer is %d\n",
+            path.c_str(),
+            header.nBands,
+            numFrames);
+   }
    Buffer<T> pvpBuffer;
+   std::vector<double> frameTimestamps;
+   frameTimestamps.resize(numFrames);
    for (int frame = 0; frame < numFrames; frame++) {
-      int const localBatchIndex = frame % mLayerLoc->nbatch;
-      int const mpiBatchIndex   = frame / mLayerLoc->nbatch; // Integer division
-
+      int const mpiBatchIndex = calcMPIBatchIndex(frame);
       if (getMPIBlock()->getRank() == 0) {
-         *simTimePtr = BufferUtils::readActivityFromPvp(path.c_str(), &pvpBuffer, frame);
+         frameTimestamps.at(frame) =
+               BufferUtils::readActivityFromPvp(path.c_str(), &pvpBuffer, frame);
          pvpBuffer.grow(nxExtGlobal, nyExtGlobal, Buffer<float>::CENTER);
       }
       else if (mpiBatchIndex == getMPIBlock()->getBatchIndex()) {
@@ -99,23 +146,32 @@ void CheckpointEntryPvp<T>::read(std::string const &checkpointDirectory, double 
             getMPIBlock(), pvpBuffer, mLayerLoc->nx, mLayerLoc->ny, mpiBatchIndex, 0);
       if (mpiBatchIndex == getMPIBlock()->getBatchIndex()) {
          std::vector<T> bufferData = pvpBuffer.asVector();
-         T *localData              = calcBatchElementStart(localBatchIndex);
+         T *localData              = calcBatchElementStart(frame);
          std::memcpy(
                localData, bufferData.data(), (std::size_t)pvpBuffer.getTotalElements() * sizeof(T));
       }
    }
-   MPI_Bcast(simTimePtr, 1, MPI_DOUBLE, 0, getMPIBlock()->getComm());
+   MPI_Bcast(
+         frameTimestamps.data(), getNumFrames(), MPI_DOUBLE, 0 /*root*/, getMPIBlock()->getComm());
+   *simTimePtr = frameTimestamps[0];
 }
 
 template <typename T>
-T *CheckpointEntryPvp<T>::calcBatchElementStart(int batchElement) const {
-   int nx = mLayerLoc->nx;
-   int ny = mLayerLoc->ny;
-   if (mExtended) {
-      nx += mLayerLoc->halo.lt + mLayerLoc->halo.rt;
-      ny += mLayerLoc->halo.dn + mLayerLoc->halo.up;
-   }
-   return &mDataPointer[batchElement * nx * ny * mLayerLoc->nf];
+int CheckpointEntryPvp<T>::getNumFrames() const {
+   return getMPIBlock()->getBatchDimension() * mLayerLoc->nbatch;
+}
+
+template <typename T>
+T *CheckpointEntryPvp<T>::calcBatchElementStart(int frame) const {
+   int const localBatchIndex = frame % mLayerLoc->nbatch;
+   int const nx              = mLayerLoc->nx + mXMargins;
+   int const ny              = mLayerLoc->ny + mYMargins;
+   return &mDataPointer[localBatchIndex * nx * ny * mLayerLoc->nf];
+}
+
+template <typename T>
+int CheckpointEntryPvp<T>::calcMPIBatchIndex(int frame) const {
+   return frame / mLayerLoc->nbatch; // Integer division
 }
 
 template <typename T>

--- a/src/checkpointing/CheckpointEntryPvpBuffer.hpp
+++ b/src/checkpointing/CheckpointEntryPvpBuffer.hpp
@@ -1,12 +1,12 @@
 /*
- * CheckpointEntryPvp.hpp
+ * CheckpointEntryPvpBuffer.hpp
  *
  *  Created on Sep 27, 2016
  *      Author: Pete Schultz
  */
 
-#ifndef CHECKPOINTENTRYPVP_HPP_
-#define CHECKPOINTENTRYPVP_HPP_
+#ifndef CHECKPOINTENTRYPVPBUFFER_HPP_
+#define CHECKPOINTENTRYPVPBUFFER_HPP_
 
 #include "CheckpointEntry.hpp"
 #include "include/PVLayerLoc.h"
@@ -15,15 +15,15 @@
 namespace PV {
 
 template <typename T>
-class CheckpointEntryPvp : public CheckpointEntry {
+class CheckpointEntryPvpBuffer : public CheckpointEntry {
   public:
-   CheckpointEntryPvp(
+   CheckpointEntryPvpBuffer(
          std::string const &name,
          MPIBlock const *mpiBlock,
          T *dataPtr,
          PVLayerLoc const *layerLoc,
          bool extended);
-   CheckpointEntryPvp(
+   CheckpointEntryPvpBuffer(
          std::string const &objName,
          std::string const &dataName,
          MPIBlock const *mpiBlock,
@@ -52,6 +52,6 @@ class CheckpointEntryPvp : public CheckpointEntry {
 
 } // end namespace PV
 
-#include "CheckpointEntryPvp.tpp"
+#include "CheckpointEntryPvpBuffer.tpp"
 
-#endif // CHECKPOINTENTRYPVP_HPP_
+#endif // CHECKPOINTENTRYPVPBUFFER_HPP_

--- a/src/checkpointing/CheckpointEntryPvpBuffer.hpp
+++ b/src/checkpointing/CheckpointEntryPvpBuffer.hpp
@@ -8,46 +8,41 @@
 #ifndef CHECKPOINTENTRYPVPBUFFER_HPP_
 #define CHECKPOINTENTRYPVPBUFFER_HPP_
 
-#include "CheckpointEntry.hpp"
+#include "CheckpointEntryPvp.hpp"
 #include "include/PVLayerLoc.h"
 #include <string>
 
 namespace PV {
 
 template <typename T>
-class CheckpointEntryPvpBuffer : public CheckpointEntry {
+class CheckpointEntryPvpBuffer : public CheckpointEntryPvp<T> {
   public:
    CheckpointEntryPvpBuffer(
          std::string const &name,
          MPIBlock const *mpiBlock,
          T *dataPtr,
          PVLayerLoc const *layerLoc,
-         bool extended);
+         bool extended)
+         : CheckpointEntryPvp<T>(name, mpiBlock, layerLoc, extended), mDataPointer(dataPtr) {}
    CheckpointEntryPvpBuffer(
          std::string const &objName,
          std::string const &dataName,
          MPIBlock const *mpiBlock,
          T *dataPtr,
          PVLayerLoc const *layerLoc,
-         bool extended);
-   virtual void write(std::string const &checkpointDirectory, double simTime, bool verifyWritesFlag)
-         const override;
-   virtual void read(std::string const &checkpointDirectory, double *simTimePtr) const override;
-   virtual void remove(std::string const &checkpointDirectory) const override;
+         bool extended)
+         : CheckpointEntryPvp<T>(objName, dataName, mpiBlock, layerLoc, extended),
+           mDataPointer(dataPtr) {}
 
   protected:
-   void initialize(T *dataPtr, PVLayerLoc const *layerLoc, bool extended);
+   virtual int getNumFrames() const override;
+   virtual T *calcBatchElementStart(int batchElement) const override;
+   virtual int calcMPIBatchIndex(int frame) const override;
+
+   T *getDataPointer() const { return mDataPointer; }
 
   private:
-   int getNumFrames() const;
-   T *calcBatchElementStart(int batchElement) const;
-   int calcMPIBatchIndex(int frame) const;
-
-  private:
-   T *mDataPointer             = nullptr;
-   PVLayerLoc const *mLayerLoc = nullptr;
-   int mXMargins               = 0; // If extended is true, use mLayerLoc's halo for the margins.
-   int mYMargins               = 0; // If extended is false, use zero for the margins.
+   T *mDataPointer = nullptr;
 };
 
 } // end namespace PV

--- a/src/checkpointing/CheckpointEntryPvpBuffer.tpp
+++ b/src/checkpointing/CheckpointEntryPvpBuffer.tpp
@@ -18,164 +18,24 @@
 
 namespace PV {
 
-// TODO: many commonalities between CheckpointEntryPvpBuffer and CheckpointEntryDataStore.
-// Refactor to eliminate code duplication
-
-template <typename T>
-CheckpointEntryPvpBuffer<T>::CheckpointEntryPvpBuffer(
-      std::string const &name,
-      MPIBlock const *mpiBlock,
-      T *dataPtr,
-      PVLayerLoc const *layerLoc,
-      bool extended)
-      : CheckpointEntry(name, mpiBlock) {
-   initialize(dataPtr, layerLoc, extended);
-}
-
-template <typename T>
-CheckpointEntryPvpBuffer<T>::CheckpointEntryPvpBuffer(
-      std::string const &objName,
-      std::string const &dataName,
-      MPIBlock const *mpiBlock,
-      T *dataPtr,
-      PVLayerLoc const *layerLoc,
-      bool extended)
-      : CheckpointEntry(objName, dataName, mpiBlock) {
-   initialize(dataPtr, layerLoc, extended);
-}
-
-template <typename T>
-void CheckpointEntryPvpBuffer<T>::initialize(T *dataPtr, PVLayerLoc const *layerLoc, bool extended) {
-   mDataPointer = dataPtr;
-   mLayerLoc    = layerLoc;
-   if (extended) {
-      mXMargins = layerLoc->halo.lt + layerLoc->halo.rt;
-      mYMargins = layerLoc->halo.dn + layerLoc->halo.up;
-   }
-   else {
-      mXMargins = 0;
-      mYMargins = 0;
-   }
-}
-
-template <typename T>
-void CheckpointEntryPvpBuffer<T>::write(
-      std::string const &checkpointDirectory,
-      double simTime,
-      bool verifyWritesFlag) const {
-   int const numFrames = getNumFrames();
-   int const nxBlock   = mLayerLoc->nx * getMPIBlock()->getNumColumns();
-   int const nyBlock   = mLayerLoc->ny * getMPIBlock()->getNumRows();
-
-   FileStream *fileStream = nullptr;
-   if (getMPIBlock()->getRank() == 0) {
-      std::string path = generatePath(checkpointDirectory, "pvp");
-      fileStream       = new FileStream(path.c_str(), std::ios_base::out, verifyWritesFlag);
-      BufferUtils::ActivityHeader header =
-            BufferUtils::buildActivityHeader<T>(nxBlock, nyBlock, mLayerLoc->nf, numFrames);
-      BufferUtils::writeActivityHeader(*fileStream, header);
-   }
-   int const nxExtLocal = mLayerLoc->nx + mXMargins;
-   int const nyExtLocal = mLayerLoc->ny + mYMargins;
-   int const nf         = mLayerLoc->nf;
-
-   for (int frame = 0; frame < numFrames; frame++) {
-      T const *localData = calcBatchElementStart(frame);
-
-      Buffer<T> pvpBuffer{localData, nxExtLocal, nyExtLocal, nf};
-      pvpBuffer.crop(mLayerLoc->nx, mLayerLoc->ny, Buffer<T>::CENTER);
-
-      // All ranks with BatchIndex==mpiBatchIndex must call gather; so must
-      // the root process (which may or may not have BatchIndex==mpiBatchIndex).
-      // Other ranks will return from gather() immediately.
-      int const mpiBatchIndex   = calcMPIBatchIndex(frame);
-      Buffer<T> globalPvpBuffer = BufferUtils::gather(
-            getMPIBlock(), pvpBuffer, mLayerLoc->nx, mLayerLoc->ny, mpiBatchIndex, 0);
-
-      if (getMPIBlock()->getRank() == 0) {
-         pvAssert(fileStream);
-         pvAssert(globalPvpBuffer.getWidth() == nxBlock);
-         pvAssert(globalPvpBuffer.getHeight() == nyBlock);
-         BufferUtils::writeFrame(*fileStream, &globalPvpBuffer, simTime);
-      }
-   }
-   delete fileStream;
-}
-
-template <typename T>
-void CheckpointEntryPvpBuffer<T>::read(std::string const &checkpointDirectory, double *simTimePtr) const {
-   int const numFrames = getNumFrames();
-   int const nxBlock   = mLayerLoc->nx * getMPIBlock()->getNumColumns();
-   int const nyBlock   = mLayerLoc->ny * getMPIBlock()->getNumRows();
-
-   int const nxExtLocal  = mLayerLoc->nx + mXMargins;
-   int const nyExtLocal  = mLayerLoc->ny + mYMargins;
-   int const nxExtGlobal = nxBlock + mXMargins;
-   int const nyExtGlobal = nyBlock + mYMargins;
-
-   std::string path;
-   if (getMPIBlock()->getRank() == 0) {
-      path = generatePath(checkpointDirectory, "pvp");
-      FileStream fileStream(path.c_str(), std::ios_base::in, false);
-      struct BufferUtils::ActivityHeader header = BufferUtils::readActivityHeader(fileStream);
-      FatalIf(
-            header.nBands != numFrames,
-            "CheckpointEntryDataStore::read error reading \"%s\": delays*batchwidth in file is %d, "
-            "but delays*batchwidth in layer is %d\n",
-            path.c_str(),
-            header.nBands,
-            numFrames);
-   }
-   Buffer<T> pvpBuffer;
-   std::vector<double> frameTimestamps;
-   frameTimestamps.resize(numFrames);
-   for (int frame = 0; frame < numFrames; frame++) {
-      int const mpiBatchIndex = calcMPIBatchIndex(frame);
-      if (getMPIBlock()->getRank() == 0) {
-         frameTimestamps.at(frame) =
-               BufferUtils::readActivityFromPvp(path.c_str(), &pvpBuffer, frame);
-         pvpBuffer.grow(nxExtGlobal, nyExtGlobal, Buffer<float>::CENTER);
-      }
-      else if (mpiBatchIndex == getMPIBlock()->getBatchIndex()) {
-         pvpBuffer.resize(nxExtLocal, nyExtLocal, mLayerLoc->nf);
-      }
-      // All ranks with BatchIndex==mpiBatchIndex must call scatter; so must
-      // the root process (which may or may not have BatchIndex==mpiBatchIndex).
-      // Other ranks will return from scatter() immediately.
-      BufferUtils::scatter(
-            getMPIBlock(), pvpBuffer, mLayerLoc->nx, mLayerLoc->ny, mpiBatchIndex, 0);
-      if (mpiBatchIndex == getMPIBlock()->getBatchIndex()) {
-         std::vector<T> bufferData = pvpBuffer.asVector();
-         T *localData              = calcBatchElementStart(frame);
-         std::memcpy(
-               localData, bufferData.data(), (std::size_t)pvpBuffer.getTotalElements() * sizeof(T));
-      }
-   }
-   MPI_Bcast(
-         frameTimestamps.data(), getNumFrames(), MPI_DOUBLE, 0 /*root*/, getMPIBlock()->getComm());
-   *simTimePtr = frameTimestamps[0];
-}
+// Constructors defined in .hpp file.
+// Read, write and remove methods inherited from CheckpointEntryPvp.
 
 template <typename T>
 int CheckpointEntryPvpBuffer<T>::getNumFrames() const {
-   return getMPIBlock()->getBatchDimension() * mLayerLoc->nbatch;
+   return this->getMPIBlock()->getBatchDimension() * this->getLayerLoc()->nbatch;
 }
 
 template <typename T>
 T *CheckpointEntryPvpBuffer<T>::calcBatchElementStart(int frame) const {
-   int const localBatchIndex = frame % mLayerLoc->nbatch;
-   int const nx              = mLayerLoc->nx + mXMargins;
-   int const ny              = mLayerLoc->ny + mYMargins;
-   return &mDataPointer[localBatchIndex * nx * ny * mLayerLoc->nf];
+   int const localBatchIndex = frame % this->getLayerLoc()->nbatch;
+   int const nx              = this->getLayerLoc()->nx + this->getXMargins();
+   int const ny              = this->getLayerLoc()->ny + this->getYMargins();
+   return &getDataPointer()[localBatchIndex * nx * ny * this->getLayerLoc()->nf];
 }
 
 template <typename T>
 int CheckpointEntryPvpBuffer<T>::calcMPIBatchIndex(int frame) const {
-   return frame / mLayerLoc->nbatch; // Integer division
-}
-
-template <typename T>
-void CheckpointEntryPvpBuffer<T>::remove(std::string const &checkpointDirectory) const {
-   deleteFile(checkpointDirectory, "pvp");
+   return frame / this->getLayerLoc()->nbatch; // Integer division
 }
 } // end namespace PV

--- a/src/checkpointing/CheckpointEntryPvpBuffer.tpp
+++ b/src/checkpointing/CheckpointEntryPvpBuffer.tpp
@@ -1,9 +1,9 @@
 /*
- * CheckpointEntryPvp.tpp
+ * CheckpointEntryPvpBuffer.tpp
  *
  *  Created on Sep 27, 2016
  *      Author: Pete Schultz
- *  template implementations for CheckpointEntryPvp class.
+ *  template implementations for CheckpointEntryPvpBuffer class.
  *  Note that the .hpp includes this .tpp file at the end;
  *  the .tpp file does not include the .hpp file.
  */
@@ -18,11 +18,11 @@
 
 namespace PV {
 
-// TODO: many commonalities between CheckpointEntryPvp and CheckpointEntryDataStore.
+// TODO: many commonalities between CheckpointEntryPvpBuffer and CheckpointEntryDataStore.
 // Refactor to eliminate code duplication
 
 template <typename T>
-CheckpointEntryPvp<T>::CheckpointEntryPvp(
+CheckpointEntryPvpBuffer<T>::CheckpointEntryPvpBuffer(
       std::string const &name,
       MPIBlock const *mpiBlock,
       T *dataPtr,
@@ -33,7 +33,7 @@ CheckpointEntryPvp<T>::CheckpointEntryPvp(
 }
 
 template <typename T>
-CheckpointEntryPvp<T>::CheckpointEntryPvp(
+CheckpointEntryPvpBuffer<T>::CheckpointEntryPvpBuffer(
       std::string const &objName,
       std::string const &dataName,
       MPIBlock const *mpiBlock,
@@ -45,7 +45,7 @@ CheckpointEntryPvp<T>::CheckpointEntryPvp(
 }
 
 template <typename T>
-void CheckpointEntryPvp<T>::initialize(T *dataPtr, PVLayerLoc const *layerLoc, bool extended) {
+void CheckpointEntryPvpBuffer<T>::initialize(T *dataPtr, PVLayerLoc const *layerLoc, bool extended) {
    mDataPointer = dataPtr;
    mLayerLoc    = layerLoc;
    if (extended) {
@@ -59,7 +59,7 @@ void CheckpointEntryPvp<T>::initialize(T *dataPtr, PVLayerLoc const *layerLoc, b
 }
 
 template <typename T>
-void CheckpointEntryPvp<T>::write(
+void CheckpointEntryPvpBuffer<T>::write(
       std::string const &checkpointDirectory,
       double simTime,
       bool verifyWritesFlag) const {
@@ -103,7 +103,7 @@ void CheckpointEntryPvp<T>::write(
 }
 
 template <typename T>
-void CheckpointEntryPvp<T>::read(std::string const &checkpointDirectory, double *simTimePtr) const {
+void CheckpointEntryPvpBuffer<T>::read(std::string const &checkpointDirectory, double *simTimePtr) const {
    int const numFrames = getNumFrames();
    int const nxBlock   = mLayerLoc->nx * getMPIBlock()->getNumColumns();
    int const nyBlock   = mLayerLoc->ny * getMPIBlock()->getNumRows();
@@ -157,12 +157,12 @@ void CheckpointEntryPvp<T>::read(std::string const &checkpointDirectory, double 
 }
 
 template <typename T>
-int CheckpointEntryPvp<T>::getNumFrames() const {
+int CheckpointEntryPvpBuffer<T>::getNumFrames() const {
    return getMPIBlock()->getBatchDimension() * mLayerLoc->nbatch;
 }
 
 template <typename T>
-T *CheckpointEntryPvp<T>::calcBatchElementStart(int frame) const {
+T *CheckpointEntryPvpBuffer<T>::calcBatchElementStart(int frame) const {
    int const localBatchIndex = frame % mLayerLoc->nbatch;
    int const nx              = mLayerLoc->nx + mXMargins;
    int const ny              = mLayerLoc->ny + mYMargins;
@@ -170,12 +170,12 @@ T *CheckpointEntryPvp<T>::calcBatchElementStart(int frame) const {
 }
 
 template <typename T>
-int CheckpointEntryPvp<T>::calcMPIBatchIndex(int frame) const {
+int CheckpointEntryPvpBuffer<T>::calcMPIBatchIndex(int frame) const {
    return frame / mLayerLoc->nbatch; // Integer division
 }
 
 template <typename T>
-void CheckpointEntryPvp<T>::remove(std::string const &checkpointDirectory) const {
+void CheckpointEntryPvpBuffer<T>::remove(std::string const &checkpointDirectory) const {
    deleteFile(checkpointDirectory, "pvp");
 }
 } // end namespace PV

--- a/src/layers/HyPerLayer.cpp
+++ b/src/layers/HyPerLayer.cpp
@@ -13,7 +13,7 @@
 */
 
 #include "HyPerLayer.hpp"
-#include "checkpointing/CheckpointEntryPvp.hpp"
+#include "checkpointing/CheckpointEntryPvpBuffer.hpp"
 #include "checkpointing/CheckpointEntryRandState.hpp"
 #include "columns/HyPerCol.hpp"
 #include "connections/BaseConnection.hpp"
@@ -531,7 +531,7 @@ void HyPerLayer::checkpointPvpActivityFloat(
       float *pvpBuffer,
       bool extended) {
    bool registerSucceeded = checkpointer->registerCheckpointEntry(
-         std::make_shared<CheckpointEntryPvp<float>>(
+         std::make_shared<CheckpointEntryPvpBuffer<float>>(
                getName(),
                bufferName,
                checkpointer->getMPIBlock(),

--- a/src/structures/CMakeLists.txt
+++ b/src/structures/CMakeLists.txt
@@ -9,3 +9,7 @@ set (PVLibSrcHpp ${PVLibSrcHpp}
    ${SUBDIR}/Buffer.hpp
    ${SUBDIR}/RingBuffer.hpp
 )
+
+set (PVLibSrcHpp ${PVLibSrcHpp}
+   ${SUBDIR}/Buffer.tpp
+)

--- a/src/utils/CMakeLists.txt
+++ b/src/utils/CMakeLists.txt
@@ -20,6 +20,11 @@ set (PVLibSrcHpp ${PVLibSrcHpp}
    ${SUBDIR}/Timer.hpp
 )
 
+set (PVLibSrcHpp ${PVLibSrcHpp}
+   ${SUBDIR}/BufferUtilsMPI.tpp
+   ${SUBDIR}/BufferUtilsPvp.tpp
+)
+
 set (PVLibSrcC ${PVLibSrcC}
    ${SUBDIR}/cl_random.c
    ${SUBDIR}/conversions.c

--- a/tests/CheckpointEntryTest/src/testPvpBatch.cpp
+++ b/tests/CheckpointEntryTest/src/testPvpBatch.cpp
@@ -1,5 +1,5 @@
 #include "testPvpBatch.hpp"
-#include "checkpointing/CheckpointEntryPvp.hpp"
+#include "checkpointing/CheckpointEntryPvpBuffer.hpp"
 #include "include/PVLayerLoc.h"
 #include "utils/conversions.h"
 #include <vector>
@@ -57,9 +57,9 @@ void testPvpBatch(PV::MPIBlock const *mpiBlock, std::string const &directory) {
 
    // Initialize checkpointData as a vector with the same size as correctData.
    // Need to make sure that checkpointData.data() never gets relocated, since the
-   // CheckpointEntryPvp's mDataPointer doesn't change with it.
+   // CheckpointEntryPvpBuffer's mDataPointer doesn't change with it.
    std::vector<float> checkpointData(correctData.size());
-   PV::CheckpointEntryPvp<float> checkpointEntryPvp{
+   PV::CheckpointEntryPvpBuffer<float> checkpointEntryPvp{
          "checkpointEntryPvpBatch", mpiBlock, checkpointData.data(), &loc, false /*not extended*/};
 
    double const simTime = 10.0;

--- a/tests/CheckpointEntryTest/src/testPvpExtended.cpp
+++ b/tests/CheckpointEntryTest/src/testPvpExtended.cpp
@@ -1,5 +1,5 @@
 #include "testPvpExtended.hpp"
-#include "checkpointing/CheckpointEntryPvp.hpp"
+#include "checkpointing/CheckpointEntryPvpBuffer.hpp"
 #include "include/PVLayerLoc.h"
 #include "utils/PVLog.hpp"
 #include "utils/conversions.h"
@@ -48,9 +48,9 @@ void testPvpExtended(PV::MPIBlock const *mpiBlock, std::string const &directory)
 
    // Initialize checkpointData as a vector with the same size as correctData.
    // Need to make sure that checkpointData.data() never gets relocated, since the
-   // CheckpointEntryPvp's mDataPointer doesn't change with it.
+   // CheckpointEntryPvpBuffer's mDataPointer doesn't change with it.
    std::vector<float> checkpointData(correctData.size());
-   PV::CheckpointEntryPvp<float> checkpointEntryPvp{
+   PV::CheckpointEntryPvpBuffer<float> checkpointEntryPvp{
          "checkpointEntryPvpExtended", mpiBlock, checkpointData.data(), &loc, true /*extended*/};
 
    double const simTime = 10.0;

--- a/tests/CheckpointEntryTest/src/testPvpRestricted.cpp
+++ b/tests/CheckpointEntryTest/src/testPvpRestricted.cpp
@@ -1,5 +1,5 @@
 #include "testPvpRestricted.hpp"
-#include "checkpointing/CheckpointEntryPvp.hpp"
+#include "checkpointing/CheckpointEntryPvpBuffer.hpp"
 #include "include/PVLayerLoc.h"
 #include "utils/conversions.h"
 #include <vector>
@@ -43,9 +43,9 @@ void testPvpRestricted(PV::MPIBlock const *mpiBlock, std::string const &director
 
    // Initialize checkpointData as a vector with the same size as correctData.
    // Need to make sure that checkpointData.data() never gets relocated, since the
-   // CheckpointEntryPvp's mDataPointer doesn't change with it.
+   // CheckpointEntryPvpBuffer's mDataPointer doesn't change with it.
    std::vector<float> checkpointData(correctData.size());
-   PV::CheckpointEntryPvp<float> checkpointEntryPvp{"checkpointEntryPvpRestricted",
+   PV::CheckpointEntryPvpBuffer<float> checkpointEntryPvp{"checkpointEntryPvpRestricted",
                                                     mpiBlock,
                                                     checkpointData.data(),
                                                     &loc,

--- a/tests/CheckpointEntryTest/src/testSeparatedName.cpp
+++ b/tests/CheckpointEntryTest/src/testSeparatedName.cpp
@@ -1,6 +1,6 @@
 #include "testSeparatedName.hpp"
 #include "checkpointing/CheckpointEntryData.hpp"
-#include "checkpointing/CheckpointEntryPvp.hpp"
+#include "checkpointing/CheckpointEntryPvpBuffer.hpp"
 #include "include/PVLayerLoc.h"
 #include "utils/PVLog.hpp"
 
@@ -17,7 +17,7 @@ void testSeparatedName(PV::MPIBlock const *mpiBlock) {
          entryDataName.c_str(),
          correctName.c_str());
 
-   PV::CheckpointEntryPvp<float> separatedNameEntryPvp{"separated",
+   PV::CheckpointEntryPvpBuffer<float> separatedNameEntryPvp{"separated",
                                                        "name",
                                                        mpiBlock,
                                                        (float *)nullptr,

--- a/tests/CheckpointerMPIBlockTest/src/CheckpointerMPIBlockTest.cpp
+++ b/tests/CheckpointerMPIBlockTest/src/CheckpointerMPIBlockTest.cpp
@@ -4,7 +4,7 @@
  */
 #include "checkpointing/Checkpointer.hpp"
 #include "arch/mpi/mpi.h"
-#include "checkpointing/CheckpointEntryPvp.hpp"
+#include "checkpointing/CheckpointEntryPvpBuffer.hpp"
 #include "columns/ConfigFileArguments.hpp"
 #include "include/pv_common.h"
 #include "utils/PVLog.hpp"
@@ -147,7 +147,7 @@ int run(int argc, char *argv[]) {
    // Copy correctValues to a separate vector, write it to checkpoint, read it back, and compare.
    auto testValues = correctValues;
 
-   auto checkpointEntry = std::make_shared<PV::CheckpointEntryPvp<float>>(
+   auto checkpointEntry = std::make_shared<PV::CheckpointEntryPvpBuffer<float>>(
          std::string("TestBuffer"),
          checkpointer->getMPIBlock(),
          testValues.data(),


### PR DESCRIPTION
This pull request addresses the code duplication between CheckpointEntryPvp and CheckpointEntryDataStore. CheckpointEntryPvp has been renamed to CheckpointEntryPvpBuffer, and it and CheckpointEntryDataStrore are now derived from a new abstract class called CheckpointEntryPvp.