### PR TITLE
Deliver from contiguous memory when using deliverFromPre with a sparse pre layer

### DIFF
--- a/cmake/PVConfigProject.cmake
+++ b/cmake/PVConfigProject.cmake
@@ -41,7 +41,7 @@ macro(pv_config_project)
   set(GCC_LINK_LIBRARIES m)
   
   # CUDA flags
-  set(CUDA_BASE_FLAGS "-arch=sm_30")
+  set(CUDA_BASE_FLAGS "-arch=sm_30 -std=c++11")
   set(CUDA_RELEASE_FLAGS "${CUDA_BASE_FLAGS};-O")
   set(CUDA_DEBUG_FLAGS "${CUDA_BASE_FLAGS};-Xptxas;-v;-keep;-lineinfo;-g;-G")
   

--- a/src/columns/Arguments.cpp
+++ b/src/columns/Arguments.cpp
@@ -42,8 +42,6 @@ int Arguments::printState() const {
    return PV_SUCCESS;
 }
 
-Arguments::~Arguments() {
-   delete mConfigFromStream;
-}
+Arguments::~Arguments() { delete mConfigFromStream; }
 
 } /* namespace PV */

--- a/src/columns/Communicator.cpp
+++ b/src/columns/Communicator.cpp
@@ -160,8 +160,8 @@ int Communicator::neighborInit() {
    // MPI_Send/MPI_Irecv pairs can be distinguished.
 
    for (int i = 0; i < NUM_NEIGHBORHOOD; i++) {
-      int n              = neighborIndex(localRank, i);
-      neighbors[i]       = localRank; // default neighbor is self
+      int n        = neighborIndex(localRank, i);
+      neighbors[i] = localRank; // default neighbor is self
       if (n >= 0) {
          neighbors[i] = n;
          num_neighbors++;

--- a/src/columns/DataStore.cpp
+++ b/src/columns/DataStore.cpp
@@ -29,7 +29,7 @@ DataStore::DataStore(int numBuffers, int numItems, int numLevels, bool isSparse_
 
    mSparseFlag = isSparse_flag;
    if (mSparseFlag) {
-      mActiveIndices = new RingBuffer<unsigned int>(numLevels, numBuffers * numItems);
+      mActiveIndices = new RingBuffer<SparseList<float>::Entry>(numLevels, numBuffers * numItems, {0,0});
       mNumActive     = new RingBuffer<long>(numLevels, numBuffers);
    }
 }
@@ -39,10 +39,13 @@ void DataStore::updateActiveIndices(int bufferId, int level) {
    int numActive   = 0;
    float *activity = buffer(bufferId, level);
 
-   unsigned int *activeIndices = activeIndicesBuffer(bufferId, level);
+   SparseList<float>::Entry *activeIndices = activeIndicesBuffer(bufferId, level);
+//   unsigned int *activeIndices = activeIndicesBuffer(bufferId, level);
    for (int kex = 0; kex < getNumItems(); kex++) {
-      if (activity[kex] != 0.0f) {
-         activeIndices[numActive] = kex;
+      float a = activity[kex];
+      if (a != 0.0f) {
+         activeIndices[numActive].index = kex;
+         activeIndices[numActive].value = a;
          numActive++;
       }
    }

--- a/src/columns/DataStore.cpp
+++ b/src/columns/DataStore.cpp
@@ -29,24 +29,29 @@ DataStore::DataStore(int numBuffers, int numItems, int numLevels, bool isSparse_
 
    mSparseFlag = isSparse_flag;
    if (mSparseFlag) {
-      mActiveIndices = new RingBuffer<SparseList<float>::Entry>(numLevels, numBuffers * numItems, {0,0});
-      mNumActive     = new RingBuffer<long>(numLevels, numBuffers);
+      mActiveIndices =
+            new RingBuffer<SparseList<float>::Entry>(numLevels, numBuffers * numItems, {0, 0});
+      mNumActive = new RingBuffer<long>(numLevels, numBuffers);
    }
 }
 
 void DataStore::markActiveIndicesOutOfSync(int bufferId, int level) {
-   if (!mSparseFlag) { return; }
+   if (!mSparseFlag) {
+      return;
+   }
    long *numActiveBuf = numActiveBuffer(bufferId, level);
-   *numActiveBuf = -1;
+   *numActiveBuf      = -1;
 }
 
 void DataStore::updateActiveIndices(int bufferId, int level) {
-   if (!mSparseFlag) { return; }
+   if (!mSparseFlag) {
+      return;
+   }
    int numActive   = 0;
    float *activity = buffer(bufferId, level);
 
    SparseList<float>::Entry *activeIndices = activeIndicesBuffer(bufferId, level);
-//   unsigned int *activeIndices = activeIndicesBuffer(bufferId, level);
+   //   unsigned int *activeIndices = activeIndicesBuffer(bufferId, level);
    for (int kex = 0; kex < getNumItems(); kex++) {
       float a = activity[kex];
       if (a != 0.0f) {
@@ -57,17 +62,17 @@ void DataStore::updateActiveIndices(int bufferId, int level) {
    }
 
    long *numActiveBuf = numActiveBuffer(bufferId, level);
-   *numActiveBuf = numActive;
+   *numActiveBuf      = numActive;
 }
 
 PVLayerCube DataStore::createCube(PVLayerLoc const &loc, int delay) {
    PVLayerCube cube;
-   cube.size = sizeof(PVLayerCube);
+   cube.size     = sizeof(PVLayerCube);
    cube.numItems = mNumItems * mNumBuffers;
-   cube.data = buffer(0 /*batch element*/, delay);
+   cube.data     = buffer(0 /*batch element*/, delay);
    // All batch elements allocated contiguously, so the numItems and data fields cover all
    // batch elements.
-   cube.loc = loc;
+   cube.loc      = loc;
    cube.isSparse = isSparse();
    if (isSparse()) {
       cube.numActive     = numActiveBuffer(0, delay);

--- a/src/columns/DataStore.hpp
+++ b/src/columns/DataStore.hpp
@@ -11,6 +11,7 @@
 #include "include/pv_arch.h"
 #include "include/pv_types.h"
 #include "structures/RingBuffer.hpp"
+#include "structures/SparseList.hpp"
 #include <cstdlib>
 #include <cstring>
 
@@ -61,11 +62,11 @@ class DataStore {
 
    bool isSparse() const { return mSparseFlag; }
 
-   unsigned int *activeIndicesBuffer(int bufferId, int level) {
+   SparseList<float>::Entry *activeIndicesBuffer(int bufferId, int level) {
       return mActiveIndices->getBuffer(level, bufferId * mNumItems);
    }
 
-   unsigned int *activeIndicesBuffer(int bufferId) {
+   SparseList<float>::Entry *activeIndicesBuffer(int bufferId) {
       return mActiveIndices->getBuffer(bufferId * mNumItems);
    }
 
@@ -89,7 +90,7 @@ class DataStore {
    RingBuffer<float> *mBuffer               = nullptr;
    RingBuffer<double> *mLastUpdateTimes     = nullptr;
    RingBuffer<long> *mNumActive             = nullptr;
-   RingBuffer<unsigned int> *mActiveIndices = nullptr;
+   RingBuffer<SparseList<float>::Entry> *mActiveIndices = nullptr;
 };
 
 } // NAMESPACE

--- a/src/columns/DataStore.hpp
+++ b/src/columns/DataStore.hpp
@@ -97,9 +97,9 @@ class DataStore {
    int mNumBuffers;
    bool mSparseFlag;
 
-   RingBuffer<float> *mBuffer               = nullptr;
-   RingBuffer<double> *mLastUpdateTimes     = nullptr;
-   RingBuffer<long> *mNumActive             = nullptr;
+   RingBuffer<float> *mBuffer                           = nullptr;
+   RingBuffer<double> *mLastUpdateTimes                 = nullptr;
+   RingBuffer<long> *mNumActive                         = nullptr;
    RingBuffer<SparseList<float>::Entry> *mActiveIndices = nullptr;
 };
 

--- a/src/columns/Publisher.hpp
+++ b/src/columns/Publisher.hpp
@@ -54,10 +54,10 @@ class Publisher {
       return store->numActiveBuffer(bufferId, delay);
    }
 
-   unsigned int *recvActiveIndicesBuffer(int bufferId) {
+   SparseList<float>::Entry *recvActiveIndicesBuffer(int bufferId) {
       return store->activeIndicesBuffer(bufferId);
    }
-   unsigned int *recvActiveIndicesBuffer(int bufferId, int delay) {
+   SparseList<float>::Entry *recvActiveIndicesBuffer(int bufferId, int delay) {
       return store->activeIndicesBuffer(bufferId, delay);
    }
 

--- a/src/columns/RandomSeed.hpp
+++ b/src/columns/RandomSeed.hpp
@@ -16,6 +16,7 @@ class RandomSeed {
    void initialize(unsigned int initialSeed);
    unsigned int allocate(unsigned int numRequested);
    unsigned int getInitialSeed() { return mInitialSeed; }
+
   private:
    RandomSeed();
    virtual ~RandomSeed() {}

--- a/src/connections/HyPerConn.cpp
+++ b/src/connections/HyPerConn.cpp
@@ -2972,7 +2972,7 @@ int HyPerConn::deliverPresynapticPerspectiveConvolve(PVLayerCube const *activity
             post->getChannel(getChannel()) + b * postLoc->nx * postLoc->ny * postLoc->nf;
       SparseList<float>::Entry const *activeIndicesBatch = NULL;
       if (activity->isSparse) {
-         activeIndicesBatch = (SparseList<float>::Entry*)activity->activeIndices + batchOffset;
+         activeIndicesBatch = (SparseList<float>::Entry *)activity->activeIndices + batchOffset;
       }
 
       int numNeurons = activity->isSparse ? activity->numActive[b] : numExtended;
@@ -3134,7 +3134,8 @@ int HyPerConn::deliverPresynapticPerspectiveStochastic(PVLayerCube const *activi
             post->getChannel(getChannel()) + b * postLoc->nx * postLoc->ny * postLoc->nf;
       SparseList<taus_uint4>::Entry const *activeIndicesBatch = NULL;
       if (activity->isSparse) {
-         activeIndicesBatch = (SparseList<taus_uint4>::Entry*)activity->activeIndices + batchOffset;
+         activeIndicesBatch =
+               (SparseList<taus_uint4>::Entry *)activity->activeIndices + batchOffset;
       }
 
       int numNeurons = activity->isSparse ? activity->numActive[b] : numExtended;
@@ -3593,8 +3594,9 @@ int HyPerConn::deliverPresynapticPerspectiveGPU(PVLayerCube const *activity, int
          d_ActiveIndices = preSynapticLayer()->getDeviceActiveIndices();
          d_numActive     = preSynapticLayer()->getDeviceNumActive();
          pvAssert(d_ActiveIndices);
-         SparseList<float>::Entry const *h_ActiveIndices = (SparseList<float>::Entry*)activity->activeIndices;
-         long const *h_numActive             = activity->numActive;
+         SparseList<float>::Entry const *h_ActiveIndices =
+               (SparseList<float>::Entry *)activity->activeIndices;
+         long const *h_numActive = activity->numActive;
          pvAssert(h_ActiveIndices);
          d_numActive->copyToDevice(h_numActive);
          d_ActiveIndices->copyToDevice(h_ActiveIndices);

--- a/src/connections/IdentConn.cpp
+++ b/src/connections/IdentConn.cpp
@@ -307,8 +307,8 @@ int IdentConn::deliverPresynapticPerspective(PVLayerCube const *activity, int ar
             post->getChannel(getChannel()) + b * postLoc->nx * postLoc->ny * postLoc->nf;
 
       if (activity->isSparse) {
-         unsigned int const *activeIndicesBatch =
-               activity->activeIndices
+         SparseList<float>::Entry const *activeIndicesBatch =
+               (SparseList<float>::Entry*)activity->activeIndices
                + b * (preLoc->nx + preLoc->halo.rt + preLoc->halo.lt)
                        * (preLoc->ny + preLoc->halo.up + preLoc->halo.dn) * preLoc->nf;
          int numLoop = activity->numActive[b];
@@ -316,9 +316,9 @@ int IdentConn::deliverPresynapticPerspective(PVLayerCube const *activity, int ar
 #pragma omp parallel for
 #endif
          for (int loopIndex = 0; loopIndex < numLoop; loopIndex++) {
-            int kPre = activeIndicesBatch[loopIndex];
+            int kPre = activeIndicesBatch[loopIndex].index;
 
-            float a          = activityBatch[kPre];
+            float a          = activeIndicesBatch[loopIndex].value; //activityBatch[kPre];
             PVPatch *weights = getWeights(kPre, arborID);
             if (weights->nx > 0 && weights->ny > 0) {
                int f = featureIndex(kPre, preLoc->nx, preLoc->ny, preLoc->nf); // Not taking halo

--- a/src/connections/IdentConn.cpp
+++ b/src/connections/IdentConn.cpp
@@ -308,7 +308,7 @@ int IdentConn::deliverPresynapticPerspective(PVLayerCube const *activity, int ar
 
       if (activity->isSparse) {
          SparseList<float>::Entry const *activeIndicesBatch =
-               (SparseList<float>::Entry*)activity->activeIndices
+               (SparseList<float>::Entry *)activity->activeIndices
                + b * (preLoc->nx + preLoc->halo.rt + preLoc->halo.lt)
                        * (preLoc->ny + preLoc->halo.up + preLoc->halo.dn) * preLoc->nf;
          int numLoop = activity->numActive[b];
@@ -318,7 +318,7 @@ int IdentConn::deliverPresynapticPerspective(PVLayerCube const *activity, int ar
          for (int loopIndex = 0; loopIndex < numLoop; loopIndex++) {
             int kPre = activeIndicesBatch[loopIndex].index;
 
-            float a          = activeIndicesBatch[loopIndex].value; //activityBatch[kPre];
+            float a = activeIndicesBatch[loopIndex].value; // activityBatch[kPre];
             PVPatch *weights = getWeights(kPre, arborID);
             if (weights->nx > 0 && weights->ny > 0) {
                int f = featureIndex(kPre, preLoc->nx, preLoc->ny, preLoc->nf); // Not taking halo

--- a/src/connections/PoolingConn.cpp
+++ b/src/connections/PoolingConn.cpp
@@ -568,9 +568,9 @@ int PoolingConn::deliverPresynapticPerspective(PVLayerCube const *activity, int 
                postIndexLayer->getChannel(CHANNEL_EXC) + b * postIndexLayer->getNumNeurons();
       }
 
-      unsigned int const *activeIndicesBatch = NULL;
+      SparseList<float>::Entry const *activeIndicesBatch = NULL;
       if (activity->isSparse) {
-         activeIndicesBatch = activity->activeIndices
+         activeIndicesBatch = (SparseList<float>::Entry*)activity->activeIndices
                               + b * (preLoc->nx + preLoc->halo.rt + preLoc->halo.lt)
                                       * (preLoc->ny + preLoc->halo.up + preLoc->halo.dn)
                                       * preLoc->nf;
@@ -614,14 +614,13 @@ int PoolingConn::deliverPresynapticPerspective(PVLayerCube const *activity, int 
 #endif
       for (int loopIndex = 0; loopIndex < numLoop; loopIndex++) {
          int kPreExt;
+         float a = dt_factor;
          if (activity->isSparse) {
-            kPreExt = activeIndicesBatch[loopIndex];
+            a *= activeIndicesBatch[loopIndex].value;
          }
          else {
-            kPreExt = loopIndex;
+            a *= activityBatch[loopIndex];
          }
-
-         float a = activityBatch[kPreExt] * dt_factor;
 
          // If we're using thread_gSyn, set this here
          float *gSynPatchHead;

--- a/src/connections/PoolingConn.cpp
+++ b/src/connections/PoolingConn.cpp
@@ -570,7 +570,7 @@ int PoolingConn::deliverPresynapticPerspective(PVLayerCube const *activity, int 
 
       SparseList<float>::Entry const *activeIndicesBatch = NULL;
       if (activity->isSparse) {
-         activeIndicesBatch = (SparseList<float>::Entry*)activity->activeIndices
+         activeIndicesBatch = (SparseList<float>::Entry *)activity->activeIndices
                               + b * (preLoc->nx + preLoc->halo.rt + preLoc->halo.lt)
                                       * (preLoc->ny + preLoc->halo.up + preLoc->halo.dn)
                                       * preLoc->nf;
@@ -623,7 +623,6 @@ int PoolingConn::deliverPresynapticPerspective(PVLayerCube const *activity, int 
             kPreExt = loopIndex;
             a *= activityBatch[kPreExt];
          }
-
 
          // If we're using thread_gSyn, set this here
          float *gSynPatchHead;

--- a/src/connections/PoolingConn.cpp
+++ b/src/connections/PoolingConn.cpp
@@ -616,11 +616,14 @@ int PoolingConn::deliverPresynapticPerspective(PVLayerCube const *activity, int 
          int kPreExt;
          float a = dt_factor;
          if (activity->isSparse) {
+            kPreExt = activeIndicesBatch[loopIndex].index;
             a *= activeIndicesBatch[loopIndex].value;
          }
          else {
-            a *= activityBatch[loopIndex];
+            kPreExt = loopIndex;
+            a *= activityBatch[kPreExt];
          }
+
 
          // If we're using thread_gSyn, set this here
          float *gSynPatchHead;

--- a/src/connections/RescaleConn.cpp
+++ b/src/connections/RescaleConn.cpp
@@ -81,7 +81,7 @@ int RescaleConn::deliverPresynapticPerspective(PVLayerCube const *activity, int 
 
       if (activity->isSparse) {
          SparseList<float>::Entry const *activeIndicesBatch =
-               (SparseList<float>::Entry*)activity->activeIndices
+               (SparseList<float>::Entry *)activity->activeIndices
                + b * (preLoc->nx + preLoc->halo.rt + preLoc->halo.lt)
                        * (preLoc->ny + preLoc->halo.up + preLoc->halo.dn) * preLoc->nf;
          int numLoop = activity->numActive[b];
@@ -89,8 +89,8 @@ int RescaleConn::deliverPresynapticPerspective(PVLayerCube const *activity, int 
 #pragma omp parallel for
 #endif
          for (int loopIndex = 0; loopIndex < numLoop; loopIndex++) {
-            int kPre = activeIndicesBatch[loopIndex].index;
-            float a = scale * activeIndicesBatch[loopIndex].value;
+            int kPre         = activeIndicesBatch[loopIndex].index;
+            float a          = scale * activeIndicesBatch[loopIndex].value;
             PVPatch *weights = getWeights(kPre, arborID);
             if (weights->nx > 0 && weights->ny > 0) {
                int f = featureIndex(kPre, preLoc->nx, preLoc->ny, preLoc->nf); // Not taking halo

--- a/src/connections/RescaleConn.cpp
+++ b/src/connections/RescaleConn.cpp
@@ -80,8 +80,8 @@ int RescaleConn::deliverPresynapticPerspective(PVLayerCube const *activity, int 
             post->getChannel(getChannel()) + b * postLoc->nx * postLoc->ny * postLoc->nf;
 
       if (activity->isSparse) {
-         unsigned int const *activeIndicesBatch =
-               activity->activeIndices
+         SparseList<float>::Entry const *activeIndicesBatch =
+               (SparseList<float>::Entry*)activity->activeIndices
                + b * (preLoc->nx + preLoc->halo.rt + preLoc->halo.lt)
                        * (preLoc->ny + preLoc->halo.up + preLoc->halo.dn) * preLoc->nf;
          int numLoop = activity->numActive[b];
@@ -89,9 +89,8 @@ int RescaleConn::deliverPresynapticPerspective(PVLayerCube const *activity, int 
 #pragma omp parallel for
 #endif
          for (int loopIndex = 0; loopIndex < numLoop; loopIndex++) {
-            int kPre = activeIndicesBatch[loopIndex];
-
-            float a          = scale * activityBatch[kPre];
+            int kPre = activeIndicesBatch[loopIndex].index;
+            float a = scale * activeIndicesBatch[loopIndex].value;
             PVPatch *weights = getWeights(kPre, arborID);
             if (weights->nx > 0 && weights->ny > 0) {
                int f = featureIndex(kPre, preLoc->nx, preLoc->ny, preLoc->nf); // Not taking halo

--- a/src/connections/TransposePoolingConn.cpp
+++ b/src/connections/TransposePoolingConn.cpp
@@ -634,7 +634,7 @@ int TransposePoolingConn::deliverPresynapticPerspective(PVLayerCube const *activ
 
       SparseList<float>::Entry const *activeIndicesBatch = NULL;
       if (activity->isSparse) {
-         activeIndicesBatch = (SparseList<float>::Entry*)activity->activeIndices
+         activeIndicesBatch = (SparseList<float>::Entry *)activity->activeIndices
                               + b * (preLoc->nx + preLoc->halo.rt + preLoc->halo.lt)
                                       * (preLoc->ny + preLoc->halo.up + preLoc->halo.dn)
                                       * preLoc->nf;
@@ -667,10 +667,10 @@ int TransposePoolingConn::deliverPresynapticPerspective(PVLayerCube const *activ
 #pragma omp parallel for schedule(static)
 #endif
       for (int loopIndex = 0; loopIndex < numLoop; loopIndex++) {
-         float a = 0.0f;
+         float a     = 0.0f;
          int kPreExt = loopIndex;
          if (activity->isSparse) {
-            a = activeIndicesBatch[loopIndex].value;
+            a       = activeIndicesBatch[loopIndex].value;
             kPreExt = activeIndicesBatch[loopIndex].index;
          }
          else {

--- a/src/cudakernels/CudaRecvPre.cpp
+++ b/src/cudakernels/CudaRecvPre.cpp
@@ -60,7 +60,7 @@ void CudaRecvPre::setArgs(
    params.isSparse = isSparse;
    if (activeIndices) {
       params.numActive     = (long *)numActive->getPointer();
-      params.activeIndices = (unsigned int *)activeIndices->getPointer();
+      params.activeIndices = (PV::SparseList<float>::Entry*)activeIndices->getPointer();
    }
    else {
       params.activeIndices = NULL;

--- a/src/cudakernels/CudaRecvPre.cpp
+++ b/src/cudakernels/CudaRecvPre.cpp
@@ -60,7 +60,7 @@ void CudaRecvPre::setArgs(
    params.isSparse = isSparse;
    if (activeIndices) {
       params.numActive     = (long *)numActive->getPointer();
-      params.activeIndices = (PV::SparseList<float>::Entry*)activeIndices->getPointer();
+      params.activeIndices = (PV::SparseList<float>::Entry *)activeIndices->getPointer();
    }
    else {
       params.activeIndices = NULL;

--- a/src/cudakernels/CudaRecvPre.cu
+++ b/src/cudakernels/CudaRecvPre.cu
@@ -32,17 +32,17 @@ __global__ void HyPerLayer_recv_pre(recv_pre_params params, int batchIdx) {
    int preBatchOffset = batchIdx * params.numPreExt;
    if (params.isSparse) {
       kPreExt = params.activeIndices[neuronIndex + preBatchOffset].index;
-      a = params.activeIndices[neuronIndex + preBatchOffset].value;
+      a       = params.activeIndices[neuronIndex + preBatchOffset].value;
    }
    else {
       kPreExt = neuronIndex;
-      a = params.preData[kPreExt + preBatchOffset] * params.dt_factor;
+      a       = params.preData[kPreExt + preBatchOffset] * params.dt_factor;
    }
 
    if (a == 0) {
       return;
    }
- 
+
    int kernelIndex;
    if (params.sharedWeights == 1) {
       kernelIndex = params.patch2datalookuptable[kPreExt];

--- a/src/cudakernels/CudaRecvPre.hpp
+++ b/src/cudakernels/CudaRecvPre.hpp
@@ -10,6 +10,7 @@
 
 #include "../arch/cuda/CudaBuffer.hpp"
 #include "../arch/cuda/CudaKernel.hpp"
+#include "../structures/SparseList.hpp"
 //#include "../arch/cuda/Cuda3dFloatTextureBuffer.hpp"
 //#include "../utils/conversions.h"
 //#include "../layers/accumulate_functions.h"
@@ -48,7 +49,7 @@ struct recv_pre_params {
 
    bool isSparse;
    long *numActive;
-   unsigned int *activeIndices;
+   PV::SparseList<float>::Entry *activeIndices;
 };
 
 class CudaRecvPre : public CudaKernel {

--- a/src/include/pv_types.h
+++ b/src/include/pv_types.h
@@ -70,7 +70,7 @@ typedef struct PVLayerCube_ {
    PVLayerLoc loc;
    int isSparse;
    long const *numActive;
-   unsigned int const *activeIndices;
+   void const *activeIndices;
 } PVLayerCube;
 
 /**

--- a/src/io/FileStream.cpp
+++ b/src/io/FileStream.cpp
@@ -37,7 +37,7 @@ FileStream::~FileStream() {
 
 void FileStream::openFile(char const *path, std::ios_base::openmode mode, bool verifyWrites) {
    string fullPath = expandLeadingTilde(path);
-   mFileName = fullPath;
+   mFileName       = fullPath;
    int attempts    = 0;
    while (!mFStream.is_open()) {
       mFStream.open(fullPath, mode);
@@ -66,7 +66,8 @@ void FileStream::openFile(char const *path, std::ios_base::openmode mode, bool v
       mVerifyWrites = true;
       if (binary()) {
          mWriteVerifier = new FileStream(path, std::ios_base::in | std::ios_base::binary, false);
-      } else {
+      }
+      else {
          mWriteVerifier = new FileStream(path, std::ios_base::in, false);
       }
    }
@@ -95,7 +96,8 @@ void FileStream::write(void const *data, long length) {
       mWriteVerifier->read(check.data(), length);
       if (memcmp(check.data(), data, length) != 0) {
          Fatal() << "Verify write failed when writing " << length << " bytes to position "
-                 << startPos << "\n" << mFileName << "\n";
+                 << startPos << "\n"
+                 << mFileName << "\n";
       }
    }
 }

--- a/src/io/fileio.cpp
+++ b/src/io/fileio.cpp
@@ -1526,7 +1526,7 @@ int writeActivitySparse(
    for (int b = 0; b < loc->nbatch; b++) {
 
       int localActive       = *(store->numActiveBuffer(b));
-      unsigned int *indices = store->activeIndicesBuffer(b);
+      indexvaluepair *localpairs = (indexvaluepair*)store->activeIndicesBuffer(b);
       float *valueData      = store->buffer(b);
 
       indexvaluepair *indexvaluepairs = NULL;
@@ -1564,13 +1564,13 @@ int writeActivitySparse(
             }
             int pairsIdx = 0;
             for (int j = 0; j < localActive; j++) {
-               int localExtK  = indices[j];
+               int localExtK  = localpairs[j].index;
                int globalResK = localExtToGlobalRes(localExtK, loc);
                if (globalResK == -1) {
                   continue;
                }
                indexvaluepairs[pairsIdx].index = globalResK;
-               indexvaluepairs[pairsIdx].value = valueData[localExtK];
+               indexvaluepairs[pairsIdx].value = localpairs[j].value;
                pairsIdx++;
             }
             data           = (void *)indexvaluepairs;
@@ -1582,7 +1582,7 @@ int writeActivitySparse(
             globalResIndices = (unsigned int *)malloc(localActive * sizeof(unsigned int));
             int indiciesIdx  = 0;
             for (int j = 0; j < localActive; j++) {
-               int localExtK  = indices[j];
+               int localExtK  = localpairs[j].index;
                int globalResK = localExtToGlobalRes(localExtK, loc);
                if (globalResK == -1) {
                   continue;
@@ -1623,13 +1623,13 @@ int writeActivitySparse(
 
                int pairsIdx = 0;
                for (int k = 0; k < localActive; k++) {
-                  int localExtK  = indices[k];
+                  int localExtK  = localpairs[k].index;
                   int globalResK = localExtToGlobalRes(localExtK, loc);
                   if (globalResK == -1) {
                      continue;
                   }
                   indexvaluepairs[pairsIdx].index = globalResK;
-                  indexvaluepairs[pairsIdx].value = valueData[localExtK];
+                  indexvaluepairs[pairsIdx].value = localpairs[k].value;
                   pairsIdx++;
                }
                localResActive = pairsIdx;
@@ -1639,7 +1639,7 @@ int writeActivitySparse(
                globalResIndices = (unsigned int *)malloc(localActive * sizeof(unsigned int));
                int indiciesIdx  = 0;
                for (int j = 0; j < localActive; j++) {
-                  int localExtK  = indices[j];
+                  int localExtK  = localpairs[j].index;
                   int globalResK = localExtToGlobalRes(localExtK, loc);
                   if (globalResK == -1) {
                      continue;

--- a/src/io/fileio.cpp
+++ b/src/io/fileio.cpp
@@ -1466,9 +1466,9 @@ int writeActivitySparse(
 
    for (int b = 0; b < loc->nbatch; b++) {
 
-      int const localActive       = cube->numActive[b];
-      indexvaluepair *localpairs = &((indexvaluepair*)cube->activeIndices)[b * numNeurons];
-      float const *valueData      = &cube->data[b * numNeurons];
+      int const localActive      = cube->numActive[b];
+      indexvaluepair *localpairs = &((indexvaluepair *)cube->activeIndices)[b * numNeurons];
+      float const *valueData     = &cube->data[b * numNeurons];
 
       indexvaluepair *indexvaluepairs = NULL;
       unsigned int *globalResIndices  = NULL;

--- a/src/io/fileio.hpp
+++ b/src/io/fileio.hpp
@@ -24,7 +24,7 @@ namespace PV {
 
 // index/value pairs used by writeActivitySparseNonspiking()
 typedef struct indexvaluepair_ {
-   unsigned int index;
+   uint32_t index;
    float value;
 } indexvaluepair;
 

--- a/src/layers/ANNLayer.cpp
+++ b/src/layers/ANNLayer.cpp
@@ -365,7 +365,8 @@ int ANNLayer::setVertices() {
       }
       slopePosInf = 0.0f;
    }
-   assert(!isnan(slopeNegInf) && !isnan(slopePosInf) && numVertices > 0);
+   // Check for NaN
+   assert(slopeNegInf == slopeNegInf && slopePosInf == slopePosInf && numVertices > 0);
    assert(vectorA.size() == numVertices && vectorV.size() == numVertices);
    verticesV = (float *)malloc((size_t)numVertices * sizeof(*verticesV));
    verticesA = (float *)malloc((size_t)numVertices * sizeof(*verticesA));

--- a/src/layers/HyPerLayer.cpp
+++ b/src/layers/HyPerLayer.cpp
@@ -1129,7 +1129,8 @@ int HyPerLayer::allocateDeviceBuffers() {
 
    if (allocDeviceActiveIndices) {
       d_numActive     = device->createBuffer(parent->getNBatch() * sizeof(long), &description);
-      d_ActiveIndices = device->createBuffer(getNumExtendedAllBatches() * sizeof(SparseList<float>::Entry), &description);
+      d_ActiveIndices = device->createBuffer(
+            getNumExtendedAllBatches() * sizeof(SparseList<float>::Entry), &description);
       assert(d_ActiveIndices);
    }
 

--- a/src/layers/HyPerLayer.cpp
+++ b/src/layers/HyPerLayer.cpp
@@ -1129,7 +1129,7 @@ int HyPerLayer::allocateDeviceBuffers() {
 
    if (allocDeviceActiveIndices) {
       d_numActive     = device->createBuffer(parent->getNBatch() * sizeof(long), &description);
-      d_ActiveIndices = device->createBuffer(size_ex, &description);
+      d_ActiveIndices = device->createBuffer(getNumExtendedAllBatches() * sizeof(SparseList<float>::Entry), &description);
       assert(d_ActiveIndices);
    }
 

--- a/src/probes/ColumnEnergyProbe.cpp
+++ b/src/probes/ColumnEnergyProbe.cpp
@@ -148,7 +148,7 @@ int ColumnEnergyProbe::calcValues(double timevalue) {
       mLastTimeValue = timevalue;
       return PV_SUCCESS;
    }
-   mSkipTimer = mSkipInterval+1;
+   mSkipTimer           = mSkipInterval + 1;
    double *valuesBuffer = getValuesBuffer();
    int numValues        = this->getNumValues();
    memset(valuesBuffer, 0, numValues * sizeof(*valuesBuffer));

--- a/src/probes/ColumnEnergyProbe.hpp
+++ b/src/probes/ColumnEnergyProbe.hpp
@@ -115,8 +115,8 @@ class ColumnEnergyProbe : public ColProbe {
     */
    int initialize_base();
 
-   int mSkipTimer = 0;
-   int mSkipInterval = 0;
+   int mSkipTimer        = 0;
+   int mSkipInterval     = 0;
    double mLastTimeValue = -1;
 }; // end class ColumnEnergyProbe
 

--- a/src/probes/FirmThresholdCostFnProbe.cpp
+++ b/src/probes/FirmThresholdCostFnProbe.cpp
@@ -157,10 +157,11 @@ double FirmThresholdCostFnProbe::getValueInternal(double timevalue, int index) {
    }
    else {
       if (getTargetLayer()->getSparseFlag()) {
-         PVLayerCube cube               = getTargetLayer()->getPublisher()->createCube();
-         long int numActive             = cube.numActive[index];
-         int numItems                   = cube.numItems / cube.loc.nbatch;
-         SparseList<float>::Entry const *activeList = &((SparseList<float>::Entry*)cube.activeIndices)[index * numItems];
+         PVLayerCube cube   = getTargetLayer()->getPublisher()->createCube();
+         long int numActive = cube.numActive[index];
+         int numItems       = cube.numItems / cube.loc.nbatch;
+         SparseList<float>::Entry const *activeList =
+               &((SparseList<float>::Entry *)cube.activeIndices)[index * numItems];
 #ifdef PV_USE_OPENMP_THREADS
 #pragma omp parallel for reduction(+ : sum)
 #endif // PV_USE_OPENMP_THREADS

--- a/src/probes/FirmThresholdCostFnProbe.cpp
+++ b/src/probes/FirmThresholdCostFnProbe.cpp
@@ -159,12 +159,12 @@ double FirmThresholdCostFnProbe::getValueInternal(double timevalue, int index) {
       if (getTargetLayer()->getSparseFlag()) {
          DataStore *store               = getTargetLayer()->getPublisher()->dataStore();
          int numActive                  = (int)store->numActiveBuffer(index)[0];
-         unsigned int const *activeList = store->activeIndicesBuffer(index);
+         SparseList<float>::Entry const *activeList = store->activeIndicesBuffer(index);
 #ifdef PV_USE_OPENMP_THREADS
 #pragma omp parallel for reduction(+ : sum)
 #endif // PV_USE_OPENMP_THREADS
          for (int k = 0; k < numActive; k++) {
-            int extIndex     = activeList[k];
+            int extIndex     = activeList[k].index;
             int inRestricted = !extendedIndexInBorderRegion(
                   extIndex, nx, ny, nf, halo->lt, halo->rt, halo->dn, halo->up);
             double a = inRestricted * (double)fabs(aBuffer[extIndex]);

--- a/src/probes/L0NormProbe.cpp
+++ b/src/probes/L0NormProbe.cpp
@@ -97,10 +97,11 @@ double L0NormProbe::getValueInternal(double timevalue, int index) {
    }
    else {
       if (getTargetLayer()->getSparseFlag()) {
-         PVLayerCube cube               = getTargetLayer()->getPublisher()->createCube();
-         long int numActive             = cube.numActive[index];
-         int numItems                   = cube.numItems / cube.loc.nbatch;
-         SparseList<float>::Entry const *activeList = &((SparseList<float>::Entry*)cube.activeIndices)[index * numItems];
+         PVLayerCube cube   = getTargetLayer()->getPublisher()->createCube();
+         long int numActive = cube.numActive[index];
+         int numItems       = cube.numItems / cube.loc.nbatch;
+         SparseList<float>::Entry const *activeList =
+               &((SparseList<float>::Entry *)cube.activeIndices)[index * numItems];
 #ifdef PV_USE_OPENMP_THREADS
 #pragma omp parallel for reduction(+ : sum)
 #endif // PV_USE_OPENMP_THREADS

--- a/src/probes/L0NormProbe.cpp
+++ b/src/probes/L0NormProbe.cpp
@@ -99,12 +99,12 @@ double L0NormProbe::getValueInternal(double timevalue, int index) {
       if (getTargetLayer()->getSparseFlag()) {
          DataStore *store               = getTargetLayer()->getPublisher()->dataStore();
          int numActive                  = (int)store->numActiveBuffer(index)[0];
-         unsigned int const *activeList = store->activeIndicesBuffer(index);
+         SparseList<float>::Entry const *activeList = store->activeIndicesBuffer(index);
 #ifdef PV_USE_OPENMP_THREADS
 #pragma omp parallel for reduction(+ : sum)
 #endif // PV_USE_OPENMP_THREADS
          for (int k = 0; k < numActive; k++) {
-            int extIndex     = activeList[k];
+            int extIndex     = activeList[k].index;
             int inRestricted = !extendedIndexInBorderRegion(
                   extIndex, nx, ny, nf, halo->lt, halo->rt, halo->dn, halo->up);
             float val = inRestricted * fabsf(aBuffer[extIndex]);

--- a/src/probes/L1NormProbe.cpp
+++ b/src/probes/L1NormProbe.cpp
@@ -89,12 +89,12 @@ double L1NormProbe::getValueInternal(double timevalue, int index) {
       if (getTargetLayer()->getSparseFlag()) {
          DataStore *store               = getTargetLayer()->getPublisher()->dataStore();
          int numActive                  = (int)store->numActiveBuffer(index)[0];
-         unsigned int const *activeList = store->activeIndicesBuffer(index);
+         SparseList<float>::Entry const *activeList = store->activeIndicesBuffer(index);
 #ifdef PV_USE_OPENMP_THREADS
 #pragma omp parallel for reduction(+ : sum)
 #endif // PV_USE_OPENMP_THREADS
          for (int k = 0; k < numActive; k++) {
-            int extIndex     = activeList[k];
+            int extIndex     = activeList[k].index;
             int inRestricted = !extendedIndexInBorderRegion(
                   extIndex, nx, ny, nf, halo->lt, halo->rt, halo->dn, halo->up);
             double val = inRestricted * (double)fabs(aBuffer[extIndex]);

--- a/src/probes/L1NormProbe.cpp
+++ b/src/probes/L1NormProbe.cpp
@@ -87,10 +87,11 @@ double L1NormProbe::getValueInternal(double timevalue, int index) {
    }
    else {
       if (getTargetLayer()->getSparseFlag()) {
-         PVLayerCube cube               = getTargetLayer()->getPublisher()->createCube();
-         long int numActive             = cube.numActive[index];
-         int numItems                   = cube.numItems / cube.loc.nbatch;
-         SparseList<float>::Entry const *activeList = &((SparseList<float>::Entry*)cube.activeIndices)[index * numItems];
+         PVLayerCube cube   = getTargetLayer()->getPublisher()->createCube();
+         long int numActive = cube.numActive[index];
+         int numItems       = cube.numItems / cube.loc.nbatch;
+         SparseList<float>::Entry const *activeList =
+               &((SparseList<float>::Entry *)cube.activeIndices)[index * numItems];
 #ifdef PV_USE_OPENMP_THREADS
 #pragma omp parallel for reduction(+ : sum)
 #endif // PV_USE_OPENMP_THREADS

--- a/src/probes/L2NormProbe.cpp
+++ b/src/probes/L2NormProbe.cpp
@@ -118,12 +118,12 @@ double L2NormProbe::getValueInternal(double timevalue, int index) {
       if (getTargetLayer()->getSparseFlag()) {
          DataStore *store               = getTargetLayer()->getPublisher()->dataStore();
          int numActive                  = (int)store->numActiveBuffer(index)[0];
-         unsigned int const *activeList = store->activeIndicesBuffer(index);
+         SparseList<float>::Entry const *activeList = store->activeIndicesBuffer(index);
 #ifdef PV_USE_OPENMP_THREADS
 #pragma omp parallel for reduction(+ : l2normsq)
 #endif // PV_USE_OPENMP_THREADS
          for (int k = 0; k < numActive; k++) {
-            int extIndex     = activeList[k];
+            int extIndex     = activeList[k].index;
             int inRestricted = !extendedIndexInBorderRegion(
                   extIndex, nx, ny, nf, halo->lt, halo->rt, halo->dn, halo->up);
             double val = inRestricted * fabs((double)aBuffer[extIndex]);

--- a/src/probes/L2NormProbe.cpp
+++ b/src/probes/L2NormProbe.cpp
@@ -116,10 +116,11 @@ double L2NormProbe::getValueInternal(double timevalue, int index) {
    }
    else {
       if (getTargetLayer()->getSparseFlag()) {
-         PVLayerCube cube               = getTargetLayer()->getPublisher()->createCube();
-         long int numActive             = cube.numActive[index];
-         int numItems                   = cube.numItems / cube.loc.nbatch;
-         SparseList<float>::Entry const *activeList = &((SparseList<float>::Entry*)cube.activeIndices)[index * numItems];
+         PVLayerCube cube   = getTargetLayer()->getPublisher()->createCube();
+         long int numActive = cube.numActive[index];
+         int numItems       = cube.numItems / cube.loc.nbatch;
+         SparseList<float>::Entry const *activeList =
+               &((SparseList<float>::Entry *)cube.activeIndices)[index * numItems];
 #ifdef PV_USE_OPENMP_THREADS
 #pragma omp parallel for reduction(+ : l2normsq)
 #endif // PV_USE_OPENMP_THREADS

--- a/src/structures/Buffer.tpp
+++ b/src/structures/Buffer.tpp
@@ -1,5 +1,5 @@
 #include "utils/PVLog.hpp"
-#include "utils/conversions.h"
+//#include "utils/conversions.h"
 
 #include <cmath>
 #include <cstring>
@@ -163,7 +163,7 @@ int Buffer<T>::getAnchorX(enum Anchor anchor, int smallerWidth, int biggerWidth)
       case NORTHEAST:
       case EAST:
       case SOUTHEAST: return biggerWidth - smallerWidth;
-      default: assert(0);
+      default: return 0;
    }
    return 0; // Statement included to suppress warnings about missing return type.
 }
@@ -180,7 +180,7 @@ int Buffer<T>::getAnchorY(enum Anchor anchor, int smallerHeight, int biggerHeigh
       case SOUTHWEST:
       case SOUTH:
       case SOUTHEAST: return biggerHeight - smallerHeight;
-      default: assert(0);
+      default: return 0;
    }
    return 0; // Statement included to suppress warnings about missing return type.
 }

--- a/src/utils/BufferUtilsPvp.tpp
+++ b/src/utils/BufferUtilsPvp.tpp
@@ -147,9 +147,9 @@ double readActivityFromPvp(char const *fName, Buffer<T> *buffer, int frameReadIn
    {
       FileStream headerStream(fName, std::ios_base::in | std::ios_base::binary, false);
       struct BufferUtils::ActivityHeader header = BufferUtils::readActivityHeader(headerStream);
-      fileType = header.fileType;
+      fileType                                  = header.fileType;
    }
-   switch(fileType) {
+   switch (fileType) {
       case PVP_NONSPIKING_ACT_FILE_TYPE:
          timestamp = BufferUtils::readDenseFromPvp<T>(fName, buffer, frameReadIndex);
          break;
@@ -160,7 +160,11 @@ double readActivityFromPvp(char const *fName, Buffer<T> *buffer, int frameReadIn
          timestamp = BufferUtils::readDenseFromSparseBinaryPvp<T>(fName, buffer, frameReadIndex);
          break;
       default:
-         Fatal().printf("readActivityFromPvp: \"%s\" has file type %d, which is not an activity file type.\n", fName, fileType);
+         Fatal().printf(
+               "readActivityFromPvp: \"%s\" has file type %d, which is not an activity file "
+               "type.\n",
+               fName,
+               fileType);
          break;
    }
    return timestamp;

--- a/src/utils/conversions.h
+++ b/src/utils/conversions.h
@@ -8,7 +8,7 @@
 #ifndef CONVERSIONS_H_
 #define CONVERSIONS_H_
 
-#include "../include/pv_types.h"
+#include "include/pv_types.h"
 
 #include <math.h>
 #include <stdio.h>

--- a/tests/BufferUtilsPvpTest/src/main.cpp
+++ b/tests/BufferUtilsPvpTest/src/main.cpp
@@ -94,7 +94,7 @@ void testWriteToPvp() {
    // and check that it's correct
    for (int frame = 0; frame < 3; ++frame) {
       Buffer<float> testBuffer;
-      double timeVal             = BufferUtils::readDenseFromPvp<float>("test.pvp", &testBuffer, frame);
+      double timeVal = BufferUtils::readDenseFromPvp<float>("test.pvp", &testBuffer, frame);
       vector<float> expectedData = allFrames.at(frame);
 
       FatalIf(

--- a/tests/HyPerConnCheckpointerTest/src/CorrectState.cpp
+++ b/tests/HyPerConnCheckpointerTest/src/CorrectState.cpp
@@ -7,7 +7,11 @@
 
 #include "CorrectState.hpp"
 
-CorrectState::CorrectState(int initialUpdateNumber, float initialWeight, float initialInput, float initialOutput)
+CorrectState::CorrectState(
+      int initialUpdateNumber,
+      float initialWeight,
+      float initialInput,
+      float initialOutput)
       : mUpdateNumber(initialUpdateNumber),
         mCorrectWeight(initialWeight),
         mCorrectInput(initialInput),

--- a/tests/HyPerConnCheckpointerTest/src/CorrectState.hpp
+++ b/tests/HyPerConnCheckpointerTest/src/CorrectState.hpp
@@ -57,7 +57,7 @@
  *    18     5      5100       5     25500
  *    19     5      5100       5     25500
  *    20     5      5100       5     25500
- * 
+ *
  */
 class CorrectState {
   public:
@@ -65,7 +65,11 @@ class CorrectState {
     * Public constructor for the CorrectState class, setting the initial update number,
     * weight value, input value, and output value.
     */
-   CorrectState(int initialUpdateNumber, float initialWeight, float initialInput, float initialOutput);
+   CorrectState(
+         int initialUpdateNumber,
+         float initialWeight,
+         float initialInput,
+         float initialOutput);
 
    /**
     * Destructor for the CorrectState class.

--- a/tests/HyPerConnCheckpointerTest/src/HyPerConnCheckpointerTestProbe.hpp
+++ b/tests/HyPerConnCheckpointerTest/src/HyPerConnCheckpointerTestProbe.hpp
@@ -70,7 +70,7 @@ class HyPerConnCheckpointerTestProbe : public PV::ColProbe {
     * Checks whether the given object has finished its communicateInitInfo stage, and
     * returns PV_SUCCESS if it has, or PV_POSTPONE if it has not.
     */
-   int checkCommunicatedFlag(PV::BaseObject* dependencyObject);
+   int checkCommunicatedFlag(PV::BaseObject *dependencyObject);
 
    int calcUpdateNumber(double timevalue);
    void initializeCorrectValues(double timevalue);
@@ -80,13 +80,13 @@ class HyPerConnCheckpointerTestProbe : public PV::ColProbe {
 
    // Data members
   protected:
-   int mStartingUpdateNumber      = 0;
-   bool mValuesSet                = false;
-   PV::InputLayer *mInputLayer    = nullptr;
-   PV::HyPerLayer *mOutputLayer   = nullptr;
-   PV::HyPerConn *mConnection     = nullptr;
-   CorrectState *mCorrectState    = nullptr;
-   bool mTestFailed               = false;
+   int mStartingUpdateNumber    = 0;
+   bool mValuesSet              = false;
+   PV::InputLayer *mInputLayer  = nullptr;
+   PV::HyPerLayer *mOutputLayer = nullptr;
+   PV::HyPerConn *mConnection   = nullptr;
+   CorrectState *mCorrectState  = nullptr;
+   bool mTestFailed             = false;
 };
 
 #endif // HYPERCONNCHECKPOINTERTESTPROBE_HPP_

--- a/tests/MomentumConnViscosityCheckpointerTest/src/CorrectState.cpp
+++ b/tests/MomentumConnViscosityCheckpointerTest/src/CorrectState.cpp
@@ -21,7 +21,7 @@ CorrectState::CorrectState(
 
 void CorrectState::update() {
    mUpdateNumber++;
-   mCorrect_dw = 0.5f*mCorrect_dw + (mCorrectInput * mCorrectOutput);
+   mCorrect_dw = 0.5f * mCorrect_dw + (mCorrectInput * mCorrectOutput);
    mCorrectWeight += mCorrect_dw;
    mCorrectInput  = (float)mUpdateNumber;
    mCorrectOutput = mCorrectInput * mCorrectWeight;

--- a/tests/test_datatypes/src/test_datatypes.cpp
+++ b/tests/test_datatypes/src/test_datatypes.cpp
@@ -59,7 +59,7 @@ int main(int argc, char *argv[]) {
    loc.halo.dn        = nyBorder;
    loc.halo.up        = nyBorder;
 
-   int numItems            = (2 * nxBorder + loc.nx) * (2 * nyBorder + loc.ny);
+   int numItems = (2 * nxBorder + loc.nx) * (2 * nyBorder + loc.ny);
 
    // create a local portion of the "image"
    float *image = new float[numItems];


### PR DESCRIPTION
This pull request changes the updateActiveIndices step to also store the value at the given index. When delivering, this value is used instead of looking it up again from the datastore. This should be benchmarked against the current develop before merging. All tests pass.