### PR TITLE
Improves error message if Image::read fails

### DIFF
--- a/src/structures/Image.cpp
+++ b/src/structures/Image.cpp
@@ -12,6 +12,8 @@
 #include "io/stb_image_write.h"
 #endif
 
+#include <cstring>
+
 namespace PV {
 
 Image::Image(std::string filename) { read(filename); }
@@ -163,6 +165,18 @@ void Image::convertToColor(bool alphaChannel) {
 void Image::read(std::string filename) {
    int width = 0, height = 0, channels = 0;
    uint8_t *data = stbi_load(filename.c_str(), &width, &height, &channels, 0);
+   if (data == nullptr) {
+      if (!std::strcmp(stbi_failure_reason(), "unknown image type")) {
+         Fatal().printf(
+               " File \"%s\" is an unknown image type.\n"
+               " (A list of image files must have a .txt extension;"
+               " an individual image file must be readable by the stb_image library.)\n",
+               filename.c_str());
+      }
+      else {
+         Fatal().printf("Unable to load \"%s\": %s\n", stbi_failure_reason());
+      }
+   }
    FatalIf(data == nullptr, " File not found: %s\n", filename.c_str());
    resize(width, height, channels);
 

--- a/src/structures/Image.cpp
+++ b/src/structures/Image.cpp
@@ -174,7 +174,7 @@ void Image::read(std::string filename) {
                filename.c_str());
       }
       else {
-         Fatal().printf("Unable to load \"%s\": %s\n", stbi_failure_reason());
+         Fatal().printf("Unable to load \"%s\": %s.\n", filename.c_str(), stbi_failure_reason());
       }
    }
    FatalIf(data == nullptr, " File not found: %s\n", filename.c_str());


### PR DESCRIPTION
This pull request creates a more helpful error message if the stbi_load call in Image::read fails. If the fopen system call inside stbi_load failed, the error message is

    ERROR <Image.cpp:177>: Unable to load "missingpath": can't fopen.

If the file exists and is readable but stb_image does not recognize it as an image file, the error message is

    ERROR <Image.cpp:170>:  File "unrecognizedpath" is an unknown image type.
    (A list of image files must have a .txt extension; an individual image file must be readable by the stb_image library.)