### PR TITLE
Reorders loops in deliverPresynapticPerspectiveConvolve

### DIFF
--- a/src/connections/HyPerConn.cpp
+++ b/src/connections/HyPerConn.cpp
@@ -3100,11 +3100,12 @@ int HyPerConn::deliverPresynapticPerspectiveConvolve(PVLayerCube const *activity
       if (thread_gSyn) {
          float *gSynPatchHead = gSynPatchHeadBatch;
          int numNeurons       = post->getNumNeurons();
-// Looping over neurons first to be thread safe
+         for (int ti = 0; ti < parent->getNumThreads(); ti++) {
+            float *onethread = thread_gSyn[ti];
+// Looping over neurons is thread safe
 #pragma omp parallel for
-         for (int ni = 0; ni < numNeurons; ni++) {
-            for (int ti = 0; ti < parent->getNumThreads(); ti++) {
-               gSynPatchHead[ni] += thread_gSyn[ti][ni];
+            for (int ni = 0; ni < numNeurons; ni++) {
+               gSynPatchHead[ni] += onethread[ni];
             }
          }
       }


### PR DESCRIPTION
Putting the thread_gSyn as the outer loop and the neuron index as the inner loop improved vectorization and sped up deliverPresynapticPerspectiveConvolve on trinity.