### PR TITLE
Only initialize CUDA if some object will use it.

### DIFF
--- a/src/arch/cuda/CudaDevice.cpp
+++ b/src/arch/cuda/CudaDevice.cpp
@@ -91,7 +91,11 @@ int CudaDevice::initialize(int device) {
    return status;
 }
 
-void CudaDevice::syncDevice() { handleError(cudaDeviceSynchronize(), "Synchronizing device"); }
+void CudaDevice::syncDevice() {
+   if (this != nullptr) {
+      handleError(cudaDeviceSynchronize(), "Synchronizing device");
+   }
+}
 
 int CudaDevice::query_device_info() {
    // query and print information about the devices found

--- a/src/columns/BaseObject.hpp
+++ b/src/columns/BaseObject.hpp
@@ -69,6 +69,15 @@ class BaseObject : public Observer, public CheckpointerDataInterface {
     */
    bool getInitialValuesSetFlag() { return mInitialValuesSetFlag; }
 
+#ifdef PV_USE_CUDA
+   /**
+    * Returns true if the object requires the GPU; false otherwise.
+    * HyPerCol will not initialize the GPU unless one of the objects in its
+    * hierarchy returns true
+    */
+   bool isUsingGPU() const { return mUsingGPUFlag; }
+#endif // PV_USE_CUDA
+
   protected:
    BaseObject();
    int initialize(char const *name, HyPerCol *hc);
@@ -118,6 +127,9 @@ class BaseObject : public Observer, public CheckpointerDataInterface {
    bool mInitInfoCommunicatedFlag    = false;
    bool mDataStructuresAllocatedFlag = false;
    bool mInitialValuesSetFlag        = false;
+#ifdef PV_USE_CUDA
+   bool mUsingGPUFlag                = false;
+#endif // PV_USE_CUDA
 
   private:
    int initialize_base();

--- a/src/columns/HyPerCol.hpp
+++ b/src/columns/HyPerCol.hpp
@@ -281,7 +281,6 @@ class HyPerCol : public Subject, Observer {
 // PVParams.
 
 #ifdef PV_USE_CUDA
-   int finalizeThreads();
    void addGpuGroup(BaseConnection *conn, int gpuGroupIdx);
 #endif // PV_USE_CUDA
 
@@ -364,7 +363,6 @@ class HyPerCol : public Subject, Observer {
 
   private:
    void setDescription();
-   int initializeThreads(char const *in_device);
    int initialize_base();
    int initialize(const char *name, PV_Init *initObj);
    int ioParams(enum ParamsIOFlag ioFlag);
@@ -378,6 +376,10 @@ class HyPerCol : public Subject, Observer {
       notify(std::vector<std::shared_ptr<BaseMessage const>>{message});
    }
    int respondPrepareCheckpointWrite(PrepareCheckpointWriteMessage const *message);
+#ifdef PV_USE_CUDA
+   void initializeCUDA(std::string const &in_device);
+   int finalizeCUDA();
+#endif // PV_USE_CUDA
    int normalizeWeights();
    int outputParams(char const *path);
    int outputParamsHeadComments(FileStream *fileStream, char const *commentToken);

--- a/src/connections/BaseConnection.cpp
+++ b/src/connections/BaseConnection.cpp
@@ -395,6 +395,7 @@ void BaseConnection::ioParam_receiveGpu(enum ParamsIOFlag ioFlag) {
 #ifdef PV_USE_CUDA
    parent->parameters()->ioParamValue(
          ioFlag, name, "receiveGpu", &receiveGpu, false /*default*/, true /*warn if absent*/);
+   mUsingGPUFlag = receiveGpu;
 #else
    receiveGpu = false;
    parent->parameters()->ioParamValue(

--- a/src/connections/CloneConn.cpp
+++ b/src/connections/CloneConn.cpp
@@ -59,6 +59,11 @@ int CloneConn::setWeightInitializer() {
    return PV_SUCCESS;
 }
 
+int CloneConn::registerData(Checkpointer *checkpointer, std::string const &objName) {
+   registerTimers(checkpointer);
+   return PV_SUCCESS;
+}
+
 int CloneConn::constructWeights() {
    int status = setPatchStrides();
 

--- a/src/connections/CloneConn.hpp
+++ b/src/connections/CloneConn.hpp
@@ -91,9 +91,7 @@ class CloneConn : public HyPerConn {
    virtual int setPatchSize(); // virtual int setPatchSize(const char * filename); // filename is
    // now a member variable.
 
-   virtual int registerData(Checkpointer *checkpointer, std::string const &objName) override {
-      return PV_SUCCESS;
-   }
+   virtual int registerData(Checkpointer *checkpointer, std::string const &objName) override;
 
    char *originalConnName;
    HyPerConn *originalConn;

--- a/src/connections/HyPerConn.cpp
+++ b/src/connections/HyPerConn.cpp
@@ -399,8 +399,6 @@ int HyPerConn::initialize(char const *name, HyPerCol *hc) {
    }
 
    ioAppend     = parent->getCheckpointReadFlag();
-   io_timer     = new Timer(getName(), "conn", "io     ");
-   update_timer = new Timer(getName(), "conn", "update ");
 
    mSparseWeightsAllocated.resize(numAxonalArborLists);
    std::fill(mSparseWeightsAllocated.begin(), mSparseWeightsAllocated.end(), false);
@@ -2172,9 +2170,8 @@ int HyPerConn::registerData(Checkpointer *checkpointer, std::string const &objNa
          objName, "nextWrite", &writeTime, (std::size_t)1, true /*broadcast*/);
 
    openOutputStateFile(checkpointer);
+   registerTimers(checkpointer);
 
-   checkpointer->registerTimer(io_timer);
-   checkpointer->registerTimer(update_timer);
    return status;
 }
 
@@ -2197,6 +2194,14 @@ void HyPerConn::openOutputStateFile(Checkpointer *checkpointer) {
                outputStatePath.c_str(), createFlag, checkpointer, checkpointLabel);
       }
    }
+}
+
+void HyPerConn::registerTimers(Checkpointer *checkpointer) {
+   io_timer     = new Timer(getName(), "conn", "io     ");
+   checkpointer->registerTimer(io_timer);
+
+   update_timer = new Timer(getName(), "conn", "update ");
+   checkpointer->registerTimer(update_timer);
 }
 
 float HyPerConn::minWeight(int arborId) {

--- a/src/connections/HyPerConn.hpp
+++ b/src/connections/HyPerConn.hpp
@@ -868,6 +868,7 @@ class HyPerConn : public BaseConnection {
    virtual int initPlasticityPatches();
    virtual int registerData(Checkpointer *checkpointer, std::string const &objName) override;
    void openOutputStateFile(Checkpointer *checkpointer);
+   void registerTimers(Checkpointer *checkpointer);
 
    /**
     * Called by registerData. If writeStep is nonnegative, opens the weights pvp file to be

--- a/src/connections/IdentConn.cpp
+++ b/src/connections/IdentConn.cpp
@@ -268,6 +268,11 @@ int IdentConn::communicateInitInfo() {
 
 void IdentConn::handleDefaultSelfFlag() { assert(selfFlag == false); }
 
+int IdentConn::registerData(Checkpointer *checkpointer, std::string const &objName) {
+   registerTimers(checkpointer);
+   return PV_SUCCESS;
+}
+
 int IdentConn::deliverPresynapticPerspective(PVLayerCube const *activity, int arborID) {
 
    // Check if we need to update based on connection's channel

--- a/src/connections/IdentConn.hpp
+++ b/src/connections/IdentConn.hpp
@@ -62,9 +62,7 @@ class IdentConn : public HyPerConn {
 
    virtual void handleDefaultSelfFlag();
 
-   virtual int registerData(Checkpointer *checkpointer, std::string const &objName) override {
-      return PV_SUCCESS;
-   }
+   virtual int registerData(Checkpointer *checkpointer, std::string const &objName) override;
 
    virtual int deliverPresynapticPerspective(PVLayerCube const *activity, int arborID);
 }; // class IdentConn

--- a/src/connections/PoolingConn.cpp
+++ b/src/connections/PoolingConn.cpp
@@ -405,6 +405,11 @@ int PoolingConn::allocateDataStructures() {
    return PV_SUCCESS;
 }
 
+int PoolingConn::registerData(Checkpointer *checkpointer, std::string const &objName) {
+   registerTimers(checkpointer);
+   return PV_SUCCESS;
+}
+
 int PoolingConn::setInitialValues() {
 #ifdef PV_USE_CUDA
    if (receiveGpu) {

--- a/src/connections/PoolingConn.hpp
+++ b/src/connections/PoolingConn.hpp
@@ -73,9 +73,7 @@ class PoolingConn : public HyPerConn {
    int initializeDeliverKernelArgs();
 #endif // PV_USE_CUDA
 
-   virtual int registerData(Checkpointer *checkpointer, std::string const &objName) override {
-      return PV_SUCCESS;
-   }
+   virtual int registerData(Checkpointer *checkpointer, std::string const &objName) override;
 
    virtual int setInitialValues() override;
    virtual int constructWeights() override;

--- a/src/connections/TransposeConn.cpp
+++ b/src/connections/TransposeConn.cpp
@@ -393,6 +393,7 @@ int TransposeConn::allocateDataStructures() {
 
 int TransposeConn::registerData(Checkpointer *checkpointer, std::string const &objName) {
    openOutputStateFile(checkpointer);
+   registerTimers(checkpointer);
    return PV_SUCCESS;
 }
 

--- a/src/connections/TransposePoolingConn.cpp
+++ b/src/connections/TransposePoolingConn.cpp
@@ -528,6 +528,11 @@ int TransposePoolingConn::deleteWeights() {
    return 0;
 }
 
+int TransposePoolingConn::registerData(Checkpointer *checkpointer, std::string const &objName) {
+   registerTimers(checkpointer);
+   return PV_SUCCESS;
+}
+
 int TransposePoolingConn::setInitialValues() {
 #ifdef PV_USE_CUDA
    if (receiveGpu) {

--- a/src/connections/TransposePoolingConn.hpp
+++ b/src/connections/TransposePoolingConn.hpp
@@ -62,12 +62,10 @@ class TransposePoolingConn : public HyPerConn {
    virtual int allocateDeviceWeights() override { return PV_SUCCESS; }
    virtual int initializeReceivePostKernelArgs() override { return PV_SUCCESS; }
    virtual int initializeReceivePreKernelArgs() override { return PV_SUCCESS; }
-   virtual int registerData(Checkpointer *checkpointer, std::string const &objName) override {
-      return PV_SUCCESS;
-   }
    virtual void updateDeviceWeights() override {}
    int initializeTransposePoolingDeliverKernelArgs();
 #endif // PV_USE_CUDA
+   virtual int registerData(Checkpointer *checkpointer, std::string const &objName) override;
    virtual int setInitialValues() override;
    virtual int constructWeights() override;
    virtual int deliverPresynapticPerspective(PVLayerCube const *activity, int arborID) override;


### PR DESCRIPTION
This pull request adds a flag, isUsingGPU(), to BaseObject. This flag is set to true by layers if updateGpu is set, and by connections if receiveGpu is set. The initialization of the CudaDevice has been moved from HyPerCol::initialize to HyPerCol::allocateColumn, where it can check each object's isUsingGPU flag. It then only creates the CudaDevice if at least one object in the hierarchy has set the flag.

This change required that the CudaTimers in HyPerLayer be constructed in registerData as opposed to initialize. For the sake of consistency, non-CUDA Timers in HyPerLayer and HyPerConn have also been moved to registerData.