### PR TITLE
Hotfix: PlasticCloneConns and original conn have equal post-synaptic borders

### DIFF
--- a/src/connections/PlasticCloneConn.cpp
+++ b/src/connections/PlasticCloneConn.cpp
@@ -128,6 +128,9 @@ void PlasticCloneConn::ioParam_normalizeDw(enum ParamsIOFlag ioFlag) {
 
 int PlasticCloneConn::communicateInitInfo() {
    int status = CloneConn::communicateInitInfo();
+   if (status != PV_SUCCESS) {
+      return status;
+   }
    originalConn->addClone(this);
    normalizeDwFlag = originalConn->getNormalizeDwFlag();
 


### PR DESCRIPTION
This pull request fixes a bug that arose when a PlasticCloneConn and its original have different border sizes. When a PlasticCloneConn adds itself to the original conn's list of clones, the original conn synchronizes the post-synaptic borders of the original conn, any existing PlasticCloneConns, and the new PlasticCloneConn.