### PR TITLE
Each batch element writes energy to its own file.

### DIFF
--- a/src/probes/BaseProbe.cpp
+++ b/src/probes/BaseProbe.cpp
@@ -205,7 +205,6 @@ int BaseProbe::initOutputStream(const char *filename) {
          }
          path += filename;
          bool append                  = parent->getCheckpointReadFlag();
-         const char *fopenstring      = append ? "a" : "w";
          std::ios_base::openmode mode = std::ios_base::out;
          if (append) {
             mode |= std::ios_base::app;

--- a/src/probes/BaseProbe.hpp
+++ b/src/probes/BaseProbe.hpp
@@ -318,6 +318,11 @@ class BaseProbe : public BaseObject {
    int setNumValues(int n);
 
    /**
+    * Returns the probeOutputFilename parameter
+    */
+   char const *getProbeOutputFilename() { return probeOutputFilename; }
+
+   /**
     * Returns a pointer to the buffer containing the probeValues.
     */
    double *getValuesBuffer() { return probeValues; }

--- a/src/probes/ColumnEnergyProbe.hpp
+++ b/src/probes/ColumnEnergyProbe.hpp
@@ -84,11 +84,9 @@ class ColumnEnergyProbe : public ColProbe {
     */
    int initializeColumnEnergyProbe(const char *probename, HyPerCol *hc);
 
-   /**
-    * Prints column headings, "time,index,energy" to outputStream.
-    * If
-    */
-   virtual int outputHeader();
+   virtual int initOutputStream(const char *filename) override;
+
+   virtual int registerData(Checkpointer *checkpointer, std::string const &objName) override;
 
    /**
     * Implements the needRecalc method.  Always returns true, in the expectation
@@ -118,6 +116,14 @@ class ColumnEnergyProbe : public ColProbe {
    int mSkipTimer        = 0;
    int mSkipInterval     = 0;
    double mLastTimeValue = -1;
+
+   // A vector of PrintStreams, one for each batch element.
+   // This is a hack, to work around the problem arising with an MPI block with batch dimension > 1.
+   // In this situation, several processes have the outputStream defined in BaseProbe writing to
+   // the same file, causing collisions.
+   //
+   // The correct solution to fix this, and other issues, is to overhaul the interface for probes.
+   std::vector<PrintStream *> mOutputBatchElements;
 }; // end class ColumnEnergyProbe
 
 } // end namespace PV


### PR DESCRIPTION
This pull request works around an issue where multiple processes could write ColumnEnergyProbe outputs to the same file. This issue arose as a consequence of removing the batch_sweep directories. With this pull request, the ColumnEnergyProbe writes the energy of each batch element to its own file. If the ColumnEnergyProbe's probeOutputFilename parameter is "Energy.txt", the files will be "Energy_batchElement_0.txt", "Energy_batchElement_1.txt", etc. The files are written to the outputPath directory. If MPIBlocks are being used, the files are written to the block_col*row*elem* directory in the outputPath directory.

