### PR TITLE
ImageLayer batchwidth fix

### DIFF
--- a/src/layers/ImageLayer.cpp
+++ b/src/layers/ImageLayer.cpp
@@ -29,15 +29,6 @@ int ImageLayer::countInputImages() {
    }
 }
 
-std::string const &ImageLayer::getCurrentFilename(int batchElement) const {
-   if (mUsingFileList) {
-      return mFileList.at(mBatchIndexer->getIndex(batchElement));
-   }
-   else {
-      return getInputPath();
-   }
-}
-
 void ImageLayer::populateFileList() {
    if (mMPIBlock->getRank() == 0) {
       std::string line;

--- a/src/layers/ImageLayer.cpp
+++ b/src/layers/ImageLayer.cpp
@@ -59,10 +59,14 @@ void ImageLayer::populateFileList() {
 }
 
 Buffer<float> ImageLayer::retrieveData(int inputIndex, int batchElement) {
+   std::string filename;
    if (mUsingFileList) {
-      std::string const &filename = mFileList.at(inputIndex);
+      filename = mFileList.at(inputIndex);
    }
-   return retrieveData(getCurrentFilename(batchElement), batchElement);
+   else {
+      filename = getInputPath();
+   }
+   return retrieveData(filename, batchElement);
 }
 
 Buffer<float> ImageLayer::retrieveData(std::string filename, int batchIndex) {

--- a/src/layers/ImageLayer.cpp
+++ b/src/layers/ImageLayer.cpp
@@ -66,11 +66,8 @@ Buffer<float> ImageLayer::retrieveData(int inputIndex, int batchElement) {
    else {
       filename = getInputPath();
    }
-   return retrieveData(filename, batchElement);
-}
-
-Buffer<float> ImageLayer::retrieveData(std::string filename, int batchIndex) {
    readImage(filename);
+
    if (mImage->getFeatures() != getLayerLoc()->nf) {
       switch (getLayerLoc()->nf) {
          case 1: // Grayscale

--- a/src/layers/ImageLayer.hpp
+++ b/src/layers/ImageLayer.hpp
@@ -18,7 +18,6 @@ class ImageLayer : public InputLayer {
   public:
    ImageLayer(const char *name, HyPerCol *hc);
    virtual ~ImageLayer() {}
-   virtual std::string const &getCurrentFilename(int batchElement) const override;
 
   protected:
    std::unique_ptr<Image> mImage = nullptr;

--- a/src/layers/ImageLayer.hpp
+++ b/src/layers/ImageLayer.hpp
@@ -11,7 +11,6 @@ class ImageLayer : public InputLayer {
    ImageLayer() {}
    virtual int countInputImages() override;
    void populateFileList();
-   virtual Buffer<float> retrieveData(std::string filename, int batchIndex) override;
    virtual Buffer<float> retrieveData(int inputIndex, int batchElement) override;
    virtual std::string describeInput(int index) override;
    void readImage(std::string filename);

--- a/src/layers/InputLayer.cpp
+++ b/src/layers/InputLayer.cpp
@@ -324,17 +324,7 @@ int InputLayer::initializeV() {
 }
 
 int InputLayer::initializeActivity() {
-   if (mMPIBlock->getRank() == 0) {
-      // Fill the activity buffer, but don't advance the indices.
-      // (updateState advances the indices before retrieving the new data. That way,
-      // calling mBatchIndexer->getIndex gets the index corresponding to the
-      // current data.)
-      retrieveInput(parent->simulationTime(), 0);
-   }
-   else {
-      retrieveInput(parent->simulationTime(), 0);
-   }
-
+   retrieveInput(parent->simulationTime(), 0);
    return PV_SUCCESS;
 }
 

--- a/src/layers/InputLayer.cpp
+++ b/src/layers/InputLayer.cpp
@@ -65,7 +65,7 @@ int InputLayer::updateState(double time, double dt) {
       if (mTimestampStream) {
          std::ostringstream outStrStream;
          outStrStream.precision(15);
-         int kb0 = getLayerLoc()->kb0;
+         int kb0             = getLayerLoc()->kb0;
          int blockBatchCount = getLayerLoc()->nbatch * mMPIBlock->getBatchDimension();
          for (int b = 0; b < blockBatchCount; ++b) {
             int index = mBatchIndexer->getIndex(b);
@@ -107,7 +107,7 @@ void InputLayer::retrieveInput(double timef, double dt) {
 void InputLayer::retrieveInputAndAdvanceIndex(double timef, double dt) {
    retrieveInput(timef, dt);
    if (mBatchIndexer) {
-      int blockBatchCount  = getLayerLoc()->nbatch * mMPIBlock->getBatchDimension();
+      int blockBatchCount = getLayerLoc()->nbatch * mMPIBlock->getBatchDimension();
       for (int b = 0; b < blockBatchCount; b++) {
          mBatchIndexer->nextIndex(b);
       }

--- a/src/layers/InputLayer.hpp
+++ b/src/layers/InputLayer.hpp
@@ -139,14 +139,6 @@ class InputLayer : public HyPerLayer {
    virtual int countInputImages() = 0;
 
    /**
-    * (Deprecated) This pure virtual function gets called from nextInput by the root process
-    * only. Load the input file from disk in this method.
-    * Even if there are several MPI blocks in the x- and y-directions, this
-    * method should load the entire image.
-    */
-   virtual Buffer<float> retrieveData(std::string filename, int batchIndex) = 0;
-
-   /**
     * This pure virtual function gets called by the root process during
     * initializeActivity and during updateState. It loads the entire input
     * (scattering to nonroot processes is done by the scatterInput method)

--- a/src/layers/PvpLayer.cpp
+++ b/src/layers/PvpLayer.cpp
@@ -42,23 +42,4 @@ Buffer<float> PvpLayer::retrieveData(int inputIndex, int batchElement) {
 
    return result;
 }
-
-Buffer<float> PvpLayer::retrieveData(std::string filename, int batchIndex) {
-   int frameNumber = 0;
-
-   // If we're playing through the pvp file like a movie, use
-   // BatchIndexer to get the frame number. Otherwise, just use
-   // the start_frame_index value for this batch.
-   if (getDisplayPeriod() > 0) {
-      frameNumber = mBatchIndexer->nextIndex(batchIndex);
-   }
-   else {
-      frameNumber = getStartIndex(batchIndex);
-   }
-
-   Buffer<float> result;
-   BufferUtils::readActivityFromPvp<float>(filename.c_str(), &result, frameNumber, &sparseTable);
-
-   return result;
-}
-}
+} // end namespace PV

--- a/src/layers/PvpLayer.hpp
+++ b/src/layers/PvpLayer.hpp
@@ -11,7 +11,6 @@ class PvpLayer : public InputLayer {
   protected:
    PvpLayer() {}
    virtual int countInputImages() override;
-   virtual Buffer<float> retrieveData(std::string filename, int batchIndex) override;
    virtual Buffer<float> retrieveData(int inputIndex, int batchIndex) override;
 
   public:


### PR DESCRIPTION
This pull request fixes a bug that arises when ImageLayer is used with a batchwidth greater than 1. It also cleans up some unused code in the InputLayer hierarchy.