### PR TITLE
FilenameParsingGroundTruth layer fix

### DIFF
--- a/src/columns/Factory.cpp
+++ b/src/columns/Factory.cpp
@@ -111,11 +111,6 @@ Factory::Factory() { registerCoreKeywords(); }
 int Factory::registerCoreKeywords() {
    keywordHandlerList = std::vector<KeywordHandler *>();
 
-   registerKeyword("Image", Factory::create<BaseInputDeprecatedError>);
-   registerKeyword("Movie", Factory::create<BaseInputDeprecatedError>);
-   registerKeyword("ImagePvp", Factory::create<BaseInputDeprecatedError>);
-   registerKeyword("MoviePvp", Factory::create<BaseInputDeprecatedError>);
-
    registerKeyword("ANNErrorLayer", Factory::create<ANNErrorLayer>);
    registerKeyword("ANNLayer", Factory::create<ANNLayer>);
    registerKeyword("ANNSquaredLayer", Factory::create<ANNSquaredLayer>);

--- a/src/layers/ImageLayer.cpp
+++ b/src/layers/ImageLayer.cpp
@@ -29,6 +29,15 @@ int ImageLayer::countInputImages() {
    }
 }
 
+std::string const &ImageLayer::getCurrentFilename(int batchElement) const {
+   if (mUsingFileList) {
+      return mFileList.at(mBatchIndexer->getIndex(batchElement));
+   }
+   else {
+      return getInputPath();
+   }
+}
+
 void ImageLayer::populateFileList() {
    if (mMPIBlock->getRank() == 0) {
       std::string line;

--- a/src/layers/ImageLayer.hpp
+++ b/src/layers/ImageLayer.hpp
@@ -18,6 +18,7 @@ class ImageLayer : public InputLayer {
   public:
    ImageLayer(const char *name, HyPerCol *hc);
    virtual ~ImageLayer() {}
+   virtual std::string const &getCurrentFilename(int batchElement) const override;
 
   protected:
    std::unique_ptr<Image> mImage = nullptr;

--- a/src/layers/InputLayer.cpp
+++ b/src/layers/InputLayer.cpp
@@ -753,26 +753,4 @@ void InputLayer::ioParam_writeFrameToTimestamp(enum ParamsIOFlag ioFlag) {
    }
 }
 
-BaseInputDeprecatedError::BaseInputDeprecatedError(const char *name, HyPerCol *hc) {
-   Fatal() << "Movie, Image, MoviePvp, and ImagePvp are deprecated.\n"
-           << "Use ImageLayer or PvpLayer instead. These replacements\n"
-           << "accept the same parameters with the following changes:\n"
-           << "  - ImageLayer assumes any inputPath ending in .txt is\n"
-           << "    a Movie, and behaves accordingly. Set displayPeriod\n"
-           << "    to 0 to display a single image within a file list.\n"
-           << "    If inputPath ends in .png, .jpg, or .bmp, the layer\n"
-           << "    displays a single Image.\n"
-           << "  - PvpLayer no longer has the parameter pvpFrameIndex.\n"
-           << "    Instead, use start_frame_index to specify which\n"
-           << "    index to display. If displayPeriod != 0, PvpLayer\n"
-           << "    behaves like a MoviePvp instead of an ImagePvp.\n"
-           << "  - Jitter has been removed. Parameters related to it\n"
-           << "    will be ignored.\n"
-           << "  - useImageBCflag is now useInputBCflag.\n"
-           << "  - batchMethod now expects byFile or byList instead of\n"
-           << "    byImage or byMovie. bySpecified has not changed.\n"
-           << "  - FilenameParsingGroundTruthLayer now acceps a param\n"
-           << "    called inputLayerName instead of movieLayerName.\n";
-}
-
 } // end namespace PV

--- a/src/layers/InputLayer.hpp
+++ b/src/layers/InputLayer.hpp
@@ -263,10 +263,6 @@ class InputLayer : public HyPerLayer {
    std::vector<int> mSkipFrameIndex;
 };
 
-class BaseInputDeprecatedError : public BaseObject {
-  public:
-   BaseInputDeprecatedError(const char *name, HyPerCol *hc);
-};
-}
+} // end namespace PV
 
 #endif


### PR DESCRIPTION
This pull request restores the behavior of ImageLayer::getCurrentFilename() that I mistakenly removed in an earlier commit. If using a list of files, getCurrentFilename returns the current filename; otherwise, it returns the input path. It also deletes some long-obsolete code.