### PR TITLE
CUDNN_PATH default

### DIFF
--- a/cmake/FindCUDNN.cmake
+++ b/cmake/FindCUDNN.cmake
@@ -31,28 +31,6 @@ foreach(PATH_HINT ${CUDNN_PATH})
   endif()
 endforeach()
 
-if (APPLE)
-  list(APPEND CUDNN_HEADER_SEARCH_PATHS /usr/local/cudnn-7.0/include)
-  list(APPEND CUDNN_HEADER_SEARCH_PATHS /usr/local/cudnn-6.5/include)
-
-  list(APPEND CUDNN_LIBRARY_SEARCH_PATHS /usr/local/cudnn-7.0/lib)
-  list(APPEND CUDNN_LIBRARY_SEARCH_PATHS /usr/local/cudnn-7.0/lib64)
-  list(APPEND CUDNN_LIBRARY_SEARCH_PATHS /usr/local/cudnn-6.5/lib)
-  list(APPEND CUDNN_LIBRARY_SEARCH_PATHS /usr/local/cudnn-6.5/lib64)
-
-else()
-  list(APPEND CUDNN_HEADER_SEARCH_PATHS /nh/compneuro/Data/cuDNN/cudnn-7.0-linux-x64-v4/include)
-  list(APPEND CUDNN_HEADER_SEARCH_PATHS /nh/compneuro/Data/cuDNN/cudnn-7.0-linux-x64-v3/include)
-  list(APPEND CUDNN_HEADER_SEARCH_PATHS /nh/compneuro/Data/cuDNN/cudnn-6.5-linux-x64-R2-rc1/include)
-
-  list(APPEND CUDNN_LIBRARY_SEARCH_PATHS /nh/compneuro/Data/cuDNN/cudnn-7.0-linux-x64-v4/lib)
-  list(APPEND CUDNN_LIBRARY_SEARCH_PATHS /nh/compneuro/Data/cuDNN/cudnn-7.0-linux-x64-v4/lib64)
-  list(APPEND CUDNN_LIBRARY_SEARCH_PATHS /nh/compneuro/Data/cuDNN/cudnn-7.0-linux-x64-v3/lib)
-  list(APPEND CUDNN_LIBRARY_SEARCH_PATHS /nh/compneuro/Data/cuDNN/cudnn-7.0-linux-x64-v3/lib64)
-  list(APPEND CUDNN_LIBRARY_SEARCH_PATHS /nh/compneuro/Data/cuDNN/cudnn-6.5-linux-x64-R2-rc1/lib)
-  list(APPEND CUDNN_LIBRARY_SEARCH_PATHS /nh/compneuro/Data/cuDNN/cudnn-6.5-linux-x64-R2-rc1/lib64)
-endif()
-
 find_path(CUDNN_INCLUDE_DIR
   NAMES cudnn.h
   PATHS ${CUDNN_HEADER_SEARCH_PATHS}

--- a/cmake/PVConfigProject.cmake
+++ b/cmake/PVConfigProject.cmake
@@ -46,8 +46,7 @@ macro(pv_config_project)
   set(CUDA_DEBUG_FLAGS "${CUDA_BASE_FLAGS};-Xptxas;-v;-keep;-lineinfo;-g;-G")
   
   # CUDNN path hints
-  set(APPLE_CUDNN_PATH_HINT "/usr/local/cudnn-7.0" "/usr/local/cudnn")
-  set(LINUX_CUDNN_PATH_HINT "/nh/compneuro/Data/cuDNN/cudnn-7.0-linux-x64-v4/" "/cuDNN/cudnn-7.0-linux-x64-v4" "/usr/local/cudnn")
+  set(CUDNN_PATH_HINT "/usr/local/cudnn")
   
   # Help strings
   set(PV_DIR_HELP "The core PetaVision directory")
@@ -223,11 +222,7 @@ macro(pv_config_project)
       message(WARNING "-- CUDA cannot be used with the default Xcode compiler. Disabling CUDA build")
       set(PV_USE_CUDA OFF)
     else()
-      if(APPLE)
-        set(CUDNN_PATH ${APPLE_CUDNN_PATH_HINT} CACHE PATH "${PV_CUDNN_PATH_HELP}")
-      else()
-        set(CUDNN_PATH ${LINUX_CUDNN_PATH_HINT} CACHE PATH "${PV_CUDNN_PATH_HELP}")
-      endif()
+      set(CUDNN_PATH ${CUDNN_PATH_HINT} CACHE PATH "${PV_CUDNN_PATH_HELP}")
       
       find_package(CUDA)
       find_package(CUDNN)


### PR DESCRIPTION
This pull request eliminates the machine-specific paths in CUDNN_PATH. The default CUDNN_PATH is /usr/local/cudnn. If cuDNN is installed somewhere else, it should be possible to change CUDNN_PATH, CUDN_INCLUDE_DIR, and/or CUDNN_LIBRARY in cmake to use the correct location.