### PR TITLE
DatastoreDelayTest

### DIFF
--- a/mlab/util/readpvpfile.m
+++ b/mlab/util/readpvpfile.m
@@ -170,7 +170,7 @@ if isempty(errorstring)
                                 data_tmp.offset{cellindex}(p,1) = patchoffset;
                             end%for
                             if hdr.datatype==1 % byte-type.  If float-type, no rescaling took place.
-                                data_tmp.values{cellindex} = data_tmp.values{1}/255*(hdr.wMax-hdr.wMin)+hdr.wMin;
+                                data_tmp.values{cellindex} = data_tmp.values{cellindex}/255*(hdr.wMax-hdr.wMin)+hdr.wMin;
                             elseif hdr.datatype ~= 3
                                 error('readpvpfile:baddatatype',...
                                     'Weight file type requires hdr.datatype of 1 or 3; received %d',...
@@ -257,7 +257,7 @@ if isempty(errorstring)
                         data_tmp.values{cellindex}(:,:,:,p) = tempdata;
                     end%for
                     if hdr.datatype==1 % byte-type.  If float-type, no rescaling took place.
-                        data_tmp.values{cellindex} = data_tmp.values{1}/255*(hdr.wMax-hdr.wMin)+hdr.wMin;
+                        data_tmp.values{cellindex} = data_tmp.values{cellindex}/255*(hdr.wMax-hdr.wMin)+hdr.wMin;
                     elseif hdr.datatype ~= 3
                         error('readpvpfile:baddatatype',...
                             'Weight file type requires hdr.datatype of 1 or 3; received %d',...

--- a/tests/DatastoreDelayTest/input/DatastoreDelayTest.params
+++ b/tests/DatastoreDelayTest/input/DatastoreDelayTest.params
@@ -163,8 +163,8 @@ DatastoreDelayTestProbe "probe" = {
     message = "probe           ";
 };
 
-//DatastoreDelayTestProbe "probeArbor" = {
-//    targetLayer = "outputArbor";
-//    probeOutputFile = "probeArbor.txt";
-//    message = "probeArbor      ";
-//};
+DatastoreDelayTestProbe "probeArbor" = {
+    targetLayer = "outputArbor";
+    probeOutputFile = "probeArbor.txt";
+    message = "probeArbor      ";
+};


### PR DESCRIPTION
This pull request makes DatastoreDelayTest more robust. Previously, it would make sure that all data arrived by the time it should have arrived, but did not check that the data was delayed properly. With this update, the test checks that if t < 6, all neurons have values < 15; as well as that if t>=6, all neurons have values == 15.