### PR TITLE
DelaysToFeaturesTest

### DIFF
--- a/tests/DelaysToFeaturesTest/src/DelayTestProbe.hpp
+++ b/tests/DelaysToFeaturesTest/src/DelayTestProbe.hpp
@@ -17,7 +17,7 @@ class DelayTestProbe : public PV::StatsProbe {
    DelayTestProbe(const char *probeName, HyPerCol *hc);
    virtual ~DelayTestProbe();
 
-   virtual int outputState(double timed);
+   virtual int outputState(double timestamp);
 
   protected:
    int initDelayTestProbe(const char *probeName, HyPerCol *hc);


### PR DESCRIPTION
This pull request replaces the assert statements in DelaysToFeaturesTest with FatalIf macros, and rearranges the condition being tested, to be hopefully more intuitive. The functioning of the test did not otherwise change.