### PR TITLE
Fixes verifyWrites issue

### DIFF
--- a/src/io/FileStream.hpp
+++ b/src/io/FileStream.hpp
@@ -41,7 +41,6 @@ class FileStream : public PrintStream {
   private:
    bool mVerifyWrites         = false;
    int const mMaxAttempts     = 5;
-   FileStream *mWriteVerifier = nullptr;
 };
 
 } /* namespace PV */


### PR DESCRIPTION
This pull request eliminates the FileStream::mVerifyWrites data member. Instead, each time a FileStream writes when verifyWrites is true, the filename is opened for reading, the data is checked, and then the filename is closed.

Previously, setting verifyWrites would create a read-only stream that would remain open for the lifetime of the FileStream. It seems that this can cause buffering issues, where the stream used by verifyWrites would not be up to date, causing fatal errors after successful writes.