### PR TITLE
Probes overhaul

### DIFF
--- a/src/components/AdaptiveTimeScaleController.cpp
+++ b/src/components/AdaptiveTimeScaleController.cpp
@@ -82,15 +82,13 @@ std::vector<double> AdaptiveTimeScaleController::calcTimesteps(
    return mTimeScaleInfo.mTimeScale;
 }
 
-void AdaptiveTimeScaleController::writeTimestepInfo(double timeValue, PrintStream &stream) {
-   if (mWriteTimeScaleFieldnames) {
-      stream.printf("sim_time = %f\n", timeValue);
-   }
-   else {
-      stream.printf("%f, ", timeValue);
-   }
+void AdaptiveTimeScaleController::writeTimestepInfo(
+      double timeValue,
+      std::vector<PrintStream *> &streams) {
    for (int b = 0; b < mBatchWidth; b++) {
+      auto stream = *streams.at(b);
       if (mWriteTimeScaleFieldnames) {
+         stream.printf("sim_time = %f\n", timeValue);
          stream.printf(
                "\tbatch = %d, timeScale = %10.8f, timeScaleTrue = %10.8f",
                b,
@@ -98,6 +96,7 @@ void AdaptiveTimeScaleController::writeTimestepInfo(double timeValue, PrintStrea
                mTimeScaleInfo.mTimeScaleTrue[b]);
       }
       else {
+         stream.printf("%f, ", timeValue);
          stream.printf(
                "%d, %10.8f, %10.8f",
                b,
@@ -110,8 +109,8 @@ void AdaptiveTimeScaleController::writeTimestepInfo(double timeValue, PrintStrea
       else {
          stream.printf(", %10.8f\n", mTimeScaleInfo.mTimeScaleMax[b]);
       }
+      stream.flush();
    }
-   stream.flush();
 }
 
 void CheckpointEntryTimeScaleInfo::write(

--- a/src/components/AdaptiveTimeScaleController.hpp
+++ b/src/components/AdaptiveTimeScaleController.hpp
@@ -39,7 +39,7 @@ class AdaptiveTimeScaleController : public CheckpointerDataInterface {
    virtual int registerData(Checkpointer *checkpointer) override;
    virtual std::vector<double>
    calcTimesteps(double timeValue, std::vector<double> const &rawTimeScales);
-   void writeTimestepInfo(double timeValue, PrintStream &stream);
+   void writeTimestepInfo(double timeValue, std::vector<PrintStream *> &streams);
 
   private:
    void calcTimeScaleTrue(double timeValue);

--- a/src/connections/HyPerConn.cpp
+++ b/src/connections/HyPerConn.cpp
@@ -102,14 +102,10 @@ HyPerConn::~HyPerConn() {
    if (batchSkip) {
       free(batchSkip);
    }
+
+   delete mOutputStateStream;
 }
 
-//!
-/*!
- *
- *
- *
- */
 int HyPerConn::initialize_base() {
    nxp            = 1;
    nyp            = 1;

--- a/src/layers/InputLayer.cpp
+++ b/src/layers/InputLayer.cpp
@@ -13,7 +13,10 @@ namespace PV {
 
 InputLayer::InputLayer(const char *name, HyPerCol *hc) { initialize(name, hc); }
 
-InputLayer::~InputLayer() { delete mBorderExchanger; }
+InputLayer::~InputLayer() {
+   delete mBorderExchanger;
+   delete mTimestampStream;
+}
 
 int InputLayer::initialize(const char *name, HyPerCol *hc) {
    int status = HyPerLayer::initialize(name, hc);

--- a/src/probes/AbstractNormProbe.cpp
+++ b/src/probes/AbstractNormProbe.cpp
@@ -11,11 +11,11 @@
 
 namespace PV {
 
-AbstractNormProbe::AbstractNormProbe() : LayerProbe() { initAbstractNormProbe_base(); }
+AbstractNormProbe::AbstractNormProbe() : LayerProbe() { initialize_base(); }
 
-AbstractNormProbe::AbstractNormProbe(const char *probeName, HyPerCol *hc) : LayerProbe() {
-   initAbstractNormProbe_base();
-   initAbstractNormProbe(probeName, hc);
+AbstractNormProbe::AbstractNormProbe(const char *name, HyPerCol *hc) : LayerProbe() {
+   initialize_base();
+   initialize(name, hc);
 }
 
 AbstractNormProbe::~AbstractNormProbe() {
@@ -26,7 +26,7 @@ AbstractNormProbe::~AbstractNormProbe() {
    // Don't free maskLayer, which belongs to the HyPerCol.
 }
 
-int AbstractNormProbe::initAbstractNormProbe_base() {
+int AbstractNormProbe::initialize_base() {
    normDescription   = NULL;
    maskLayerName     = NULL;
    maskLayer         = NULL;
@@ -35,8 +35,8 @@ int AbstractNormProbe::initAbstractNormProbe_base() {
    return PV_SUCCESS;
 }
 
-int AbstractNormProbe::initAbstractNormProbe(const char *probeName, HyPerCol *hc) {
-   int status = LayerProbe::initialize(probeName, hc);
+int AbstractNormProbe::initialize(const char *name, HyPerCol *hc) {
+   int status = LayerProbe::initialize(name, hc);
    if (status == PV_SUCCESS) {
       status = setNormDescription();
    }
@@ -146,11 +146,11 @@ int AbstractNormProbe::calcValues(double timeValue) {
 int AbstractNormProbe::outputState(double timevalue) {
    getValues(timevalue);
    double *valuesBuffer = this->getValuesBuffer();
-   if (outputStream != NULL) {
+   if (!mOutputStreams.empty()) {
       int nBatch = getNumValues();
       int nk     = getTargetLayer()->getNumGlobalNeurons();
       for (int b = 0; b < nBatch; b++) {
-         outputStream->printf(
+         output(b).printf(
                "%st = %6.3f b = %d numNeurons = %8d %s = %f",
                getMessage(),
                timevalue,
@@ -158,7 +158,7 @@ int AbstractNormProbe::outputState(double timevalue) {
                nk,
                getNormDescription(),
                valuesBuffer[b]);
-         output() << std::endl;
+         output(b) << std::endl;
       }
    }
    return PV_SUCCESS;

--- a/src/probes/AbstractNormProbe.hpp
+++ b/src/probes/AbstractNormProbe.hpp
@@ -27,7 +27,7 @@ namespace PV {
  */
 class AbstractNormProbe : public LayerProbe {
   public:
-   AbstractNormProbe(const char *probeName, HyPerCol *hc);
+   AbstractNormProbe(const char *name, HyPerCol *hc);
    virtual ~AbstractNormProbe();
 
    /**
@@ -44,7 +44,7 @@ class AbstractNormProbe : public LayerProbe {
 
   protected:
    AbstractNormProbe();
-   int initAbstractNormProbe(const char *probeName, HyPerCol *hc);
+   int initialize(const char *name, HyPerCol *hc);
 
    /**
     * Called during initialization, sets the member variable normDescription.
@@ -133,7 +133,7 @@ class AbstractNormProbe : public LayerProbe {
    char const *getNormDescription() { return normDescription; }
 
   private:
-   int initAbstractNormProbe_base();
+   int initialize_base();
 
   private:
    char *normDescription;

--- a/src/probes/AdaptiveTimeScaleProbe.cpp
+++ b/src/probes/AdaptiveTimeScaleProbe.cpp
@@ -174,8 +174,8 @@ int AdaptiveTimeScaleProbe::calcValues(double timeValue) {
 }
 
 int AdaptiveTimeScaleProbe::outputState(double timeValue) {
-   if (outputStream) {
-      mAdaptiveTimeScaleController->writeTimestepInfo(timeValue, output());
+   if (!mOutputStreams.empty()) {
+      mAdaptiveTimeScaleController->writeTimestepInfo(timeValue, mOutputStreams);
    }
    return PV_SUCCESS;
 }

--- a/src/probes/BaseConnectionProbe.hpp
+++ b/src/probes/BaseConnectionProbe.hpp
@@ -18,7 +18,7 @@ class BaseConnectionProbe : public BaseProbe {
 
    // Methods
   public:
-   BaseConnectionProbe(const char *probeName, HyPerCol *hc);
+   BaseConnectionProbe(const char *name, HyPerCol *hc);
    virtual ~BaseConnectionProbe();
 
    virtual int communicateInitInfo(CommunicateInitInfoMessage const *message) override;
@@ -28,8 +28,15 @@ class BaseConnectionProbe : public BaseProbe {
   protected:
    BaseConnectionProbe(); // Default constructor, can only be called by derived
    // classes
-   int initialize(const char *probeName, HyPerCol *hc);
+   int initialize(const char *name, HyPerCol *hc);
    virtual void ioParam_targetName(enum ParamsIOFlag ioFlag) override;
+
+   /**
+    * The root process of each MPIBlock sets the vector of PrintStreams to
+    * size one, since all batch elements use the same weights. The output file
+    * is the probeOutputFile name, if that is set; otherwise it is the logfile.
+    */
+   virtual void initOutputStreams(const char *filename, Checkpointer *checkpointer) override;
 
   private:
    int initialize_base();

--- a/src/probes/BaseHyPerConnProbe.cpp
+++ b/src/probes/BaseHyPerConnProbe.cpp
@@ -9,9 +9,9 @@
 
 namespace PV {
 
-BaseHyPerConnProbe::BaseHyPerConnProbe(const char *probeName, HyPerCol *hc) {
+BaseHyPerConnProbe::BaseHyPerConnProbe(const char *name, HyPerCol *hc) {
    initialize_base();
-   initialize(probeName, hc);
+   initialize(name, hc);
 }
 
 BaseHyPerConnProbe::BaseHyPerConnProbe() { initialize_base(); }
@@ -21,8 +21,8 @@ int BaseHyPerConnProbe::initialize_base() {
    return PV_SUCCESS;
 }
 
-int BaseHyPerConnProbe::initialize(const char *probeName, HyPerCol *hc) {
-   return BaseConnectionProbe::initialize(probeName, hc);
+int BaseHyPerConnProbe::initialize(const char *name, HyPerCol *hc) {
+   return BaseConnectionProbe::initialize(name, hc);
 }
 
 int BaseHyPerConnProbe::communicateInitInfo(CommunicateInitInfoMessage const *message) {

--- a/src/probes/BaseHyPerConnProbe.hpp
+++ b/src/probes/BaseHyPerConnProbe.hpp
@@ -15,7 +15,7 @@ namespace PV {
 
 class BaseHyPerConnProbe : public BaseConnectionProbe {
   public:
-   BaseHyPerConnProbe(const char *probeName, HyPerCol *hc);
+   BaseHyPerConnProbe(const char *name, HyPerCol *hc);
    virtual ~BaseHyPerConnProbe();
 
    virtual int communicateInitInfo(CommunicateInitInfoMessage const *message) override;
@@ -24,7 +24,7 @@ class BaseHyPerConnProbe : public BaseConnectionProbe {
 
   protected:
    BaseHyPerConnProbe();
-   int initialize(const char *probeName, HyPerCol *hc);
+   int initialize(const char *name, HyPerCol *hc);
    virtual bool needRecalc(double timevalue) override;
 
    /**

--- a/src/probes/BaseProbe.cpp
+++ b/src/probes/BaseProbe.cpp
@@ -139,13 +139,10 @@ void BaseProbe::ioParam_triggerLayerName(enum ParamsIOFlag ioFlag) {
    }
 }
 
-// triggerFlag was deprecated Oct 7, 2015.
-// Setting triggerLayerName to a nonempty string has the effect of
-// triggerFlag=true, and
+// triggerFlag was deprecated Oct 7, 2015, and marked obsolete Jun 9, 2017.
+// Setting triggerLayerName to a nonempty string has the effect of triggerFlag=true, and
 // setting triggerLayerName to NULL or "" has the effect of triggerFlag=false.
-// While triggerFlag is being deprecated, it is an error for triggerFlag to be
-// false
-// and triggerLayerName to be a nonempty string.
+// For a reasonable fade-out time, it is an error for triggerFlag to be defined in params.
 void BaseProbe::ioParam_triggerFlag(enum ParamsIOFlag ioFlag) {
    assert(!parent->parameters()->presentAndNotBeenRead(name, "triggerLayerName"));
    if (ioFlag == PARAMS_IO_READ && parent->parameters()->present(name, "triggerFlag")) {
@@ -153,27 +150,13 @@ void BaseProbe::ioParam_triggerFlag(enum ParamsIOFlag ioFlag) {
       parent->parameters()->ioParamValue(
             ioFlag, name, "triggerFlag", &flagFromParams, flagFromParams);
       if (parent->columnId() == 0) {
-         WarnLog(triggerFlagDeprecated);
-         triggerFlagDeprecated.printf("%s: triggerFlag has been deprecated.\n", getDescription_c());
+         Fatal(triggerFlagDeprecated);
          triggerFlagDeprecated.printf(
-               "   If triggerLayerName is a nonempty "
-               "string, triggering will be on;\n");
+               "%s: triggerFlag is obsolete for probes.\n", getDescription_c());
+         triggerFlagDeprecated.printf(
+               "   If triggerLayerName is a nonempty string, triggering will be on;\n");
          triggerFlagDeprecated.printf(
                "   if triggerLayerName is empty or null, triggering will be off.\n");
-         if (flagFromParams != triggerFlag) {
-            ErrorLog(triggerFlagError);
-            triggerFlagError.printf("%s: triggerLayerName=", getDescription_c());
-            if (triggerLayerName) {
-               triggerFlagError.printf("\"%s\"", triggerLayerName);
-            }
-            else {
-               triggerFlagError.printf("NULL");
-            }
-            triggerFlagError.printf(
-                  " implies triggerFlag=%s but triggerFlag was set in params to %s\n",
-                  triggerFlag ? "true" : "false",
-                  flagFromParams ? "true" : "false");
-         }
       }
    }
 }

--- a/src/probes/BaseProbe.hpp
+++ b/src/probes/BaseProbe.hpp
@@ -141,7 +141,7 @@ class BaseProbe : public BaseObject {
 
   protected:
    BaseProbe();
-   int initialize(const char *probeName, HyPerCol *hc);
+   int initialize(const char *name, HyPerCol *hc);
    virtual int ioParamsFillGroup(enum ParamsIOFlag ioFlag);
 
    /**
@@ -209,59 +209,57 @@ class BaseProbe : public BaseObject {
 
    /**
     * @brief coefficient: If energyProbe is set, the coefficient parameter
-    * specifies
-    * that ColumnEnergyProbe multiplies the result of this probe's getValues()
-    * method
-    * by coefficient when computing the error.
+    * specifies that ColumnEnergyProbe multiplies the result of this probe's
+    * getValues() method by coefficient when computing the error.
     * @details Note that coefficient does not affect the value returned by the
-    * getValue() or
-    * getValues() method.
+    * getValue() or getValues() method.
     */
    virtual void ioParam_coefficient(enum ParamsIOFlag ioFlag);
    /** @} */
 
-   virtual int initOutputStream(const char *filename, Checkpointer *checkpointer);
+   /**
+    * Called by registerData. If the MPIBlock row index and column index are
+    * zero, this method sets a vector of PrintStreams whose size is the local
+    * batch width. If probeOutputFile is being used, the elements of the vector
+    * are FileStreams with filenames based on probeOutputFile: the global batch
+    * index will be inserted in the probeOutputFile before the extension (or at
+    * the end if there is no extension). If the MPIBlock row and column indices
+    * are not both zero, the vector of PrintStreams will be empty - these
+    * processes should communicate with the row=0,column=0 as needed.
+    */
+   virtual void initOutputStreams(const char *filename, Checkpointer *checkpointer);
 
    /**
     * A pure virtual method for that should return true if the quantities being
-    * measured
-    * by the probe have changed since the last time the quantities were
+    * measured by the probe have changed since the last time the quantities were
     * calculated.
     * Typically, an implementation of needRecalc() will check the lastUpdateTime
-    * of
-    * the object being probed, and return true if that value is greater than the
-    * lastUpdateTime member variable.
+    * of the object being probed, and return true if that value is greater than
+    * the lastUpdateTime member variable.
     * needRecalc() is called by getValues(double) (and hence by getValue() and
-    * the other
-    * flavors of getValues).
+    * the other flavors of getValues).
     * Note that there is a single needRecalc that applies to all getNumValues()
     * quantities.
     */
    virtual bool needRecalc(double timevalue) = 0;
 
    /**
-    * A pure virtual method that should return the simulation time for the values
-    * that calcValues()
-    * would compute if it were called instead.  The reason that this time might
-    * be different from
-    * the simuluation time at which referenceUpdate was called, is that
-    * calcValues might be called
-    * either before or after the update of whatever object the probe is attached
-    * to.
+    * A pure virtual method that should return the simulation time for the
+    * values that calcValues() would compute if it were called instead.
+    * The reason that this time might be different from the simuluation time at
+    * which referenceUpdate was called, is that calcValues might be called
+    * either before or after the update of the object the probe is attached to.
     *
     * The getValues() method calls this function after calling calcValues(),
     * and stores the result in the lastUpdateTime member variable.  Typically,
-    * the implementation
-    * of needRecalc() will return true if lastUpdateTime is less than the value
-    * returned by
-    * referenceUpdateTime, and false otherwise.
+    * the implementation of needRecalc() will return true if lastUpdateTime is
+    * less than the value returned by referenceUpdateTime, and false otherwise.
     */
    virtual double referenceUpdateTime() const = 0;
 
    /**
     * A pure virtual method to calculate the values of the probe.  calcValues()
-    * can
-    * assume that needRecalc() has been called and returned true.
+    * can assume that needRecalc() has been called and returned true.
     * It should write the computed values into the buffer of member variable
     * 'probeValues'.
     */
@@ -269,9 +267,8 @@ class BaseProbe : public BaseObject {
 
    /**
     * If needRecalc() returns true, getValues(double) updates the probeValues
-    * buffer
-    * (by calling calcValues) and sets lastUpdateTime to the timevalue input
-    * argument.
+    * buffer (by calling calcValues) and sets lastUpdateTime to the timevalue
+    * input argument.
     */
    int getValues(double timevalue);
 
@@ -287,33 +284,25 @@ class BaseProbe : public BaseObject {
    virtual int initMessage(const char *msg);
 
    /**
-    * Returns a pointer to the PrintStream used by outputState.
+    * Returns a reference to the PrintStream for the given batch element
     */
-   PrintStream *getOutputStream() { return outputStream; }
-
-   /**
-    * Returns a reference to the ostream that outputState writes to.
-    */
-   PrintStream &output() { return *outputStream; }
+   PrintStream &output(int b) { return *mOutputStreams.at(b); }
 
    /**
     * initNumValues is called by initialize.
     * BaseProbe::initNumValues sets numValues to the parent HyPerCol's
     * getNBatch().
     * Derived classes can override initNumValues to initialize numValues to a
-    * different
-    * value.
+    * different value.
     */
    virtual int initNumValues();
 
    /**
     * Sets the numValues member variable (returned by getNumValues()) and
-    * reallocates
-    * the probeValues member variable to hold numValues double-precision values.
-    * If the reallocation fails, the probeValues buffer is left unchanged, errno
-    * is
-    * set (by a realloc() call), and PV_FAILURE is returned.
-    * Otherwise, PV_SUCCESS is returned.
+    * reallocates the probeValues member variable to hold numValues
+    * double-precision values. If the reallocation fails, the probeValues
+    * buffer is left unchanged, errno is set (by a realloc() call),
+    * and PV_FAILURE is returned. Otherwise, PV_SUCCESS is returned.
     */
    int setNumValues(int n);
 
@@ -336,7 +325,7 @@ class BaseProbe : public BaseObject {
     * Returns true if a probeOutputFile is being used.
     * Otherwise, returns false (indicating output is going to getOutputStream().
     */
-   inline bool isWritingToFile() const { return writingToFile; }
+   inline bool isWritingToFile() const { return probeOutputFilename != nullptr; }
 
    /**
     * If there is a triggering layer, needUpdate returns true when the triggering
@@ -355,7 +344,9 @@ class BaseProbe : public BaseObject {
 
    // Member variables
   protected:
-   PrintStream *outputStream;
+   // A vector of PrintStreams, one for each batch element.
+   std::vector<PrintStream *> mOutputStreams;
+
    bool triggerFlag;
    char *triggerLayerName;
    HyPerLayer *triggerLayer;
@@ -374,7 +365,6 @@ class BaseProbe : public BaseObject {
    double *probeValues;
    double lastUpdateTime; // The time of the last time calcValues was called.
    bool textOutputFlag;
-   bool writingToFile; // true outputStream is a FileStream
    bool mInitInfoCommunicatedFlag    = false;
    bool mDataStructuresAllocatedFlag = false;
 };

--- a/src/probes/ColProbe.cpp
+++ b/src/probes/ColProbe.cpp
@@ -16,9 +16,9 @@ ColProbe::ColProbe() { // Default constructor to be called by derived classes.
    initialize_base();
 }
 
-ColProbe::ColProbe(const char *probeName, HyPerCol *hc) {
+ColProbe::ColProbe(const char *name, HyPerCol *hc) {
    initialize_base();
-   initialize(probeName, hc);
+   initialize(name, hc);
 }
 
 ColProbe::~ColProbe() {}
@@ -28,8 +28,8 @@ int ColProbe::initialize_base() {
    return PV_SUCCESS;
 }
 
-int ColProbe::initialize(const char *probeName, HyPerCol *hc) {
-   int status = BaseProbe::initialize(probeName, hc);
+int ColProbe::initialize(const char *name, HyPerCol *hc) {
+   int status = BaseProbe::initialize(name, hc);
    if (status == PV_SUCCESS) {
       this->parent->insertProbe(this);
    }
@@ -47,12 +47,9 @@ void ColProbe::ioParam_targetName(enum ParamsIOFlag ioFlag) {
    }
 }
 
-int ColProbe::initOutputStream(const char *filename, Checkpointer *checkpointer) {
-   int status = BaseProbe::initOutputStream(filename, checkpointer);
-   if (status != PV_SUCCESS) {
-      status = outputHeader();
-   }
-   return status;
+void ColProbe::initOutputStreams(const char *filename, Checkpointer *checkpointer) {
+   BaseProbe::initOutputStreams(filename, checkpointer);
+   outputHeader();
 }
 
 int ColProbe::communicateInitInfo(CommunicateInitInfoMessage const *message) {

--- a/src/probes/ColProbe.hpp
+++ b/src/probes/ColProbe.hpp
@@ -40,7 +40,7 @@ class ColProbe : public BaseProbe {
    /**
     * Public constructor for the ColProbe class.
     */
-   ColProbe(const char *probeName, HyPerCol *hc);
+   ColProbe(const char *name, HyPerCol *hc);
 
    /**
     * Destructor for the ColProbe class.
@@ -74,7 +74,7 @@ class ColProbe : public BaseProbe {
     * depend on other param groups.  It is called by the public constructor
     * and should be called by the initializer of any derived classes.
     */
-   int initialize(const char *probeName, HyPerCol *hc);
+   int initialize(const char *name, HyPerCol *hc);
 
    /**
     * Reads parameters from the params file/writes parameters to the output
@@ -100,16 +100,16 @@ class ColProbe : public BaseProbe {
    virtual void ioParam_targetName(enum ParamsIOFlag ioFlag) override;
 
    /**
-    * Calls BaseProbe::initOutputStream and then calls outputHeader()
+    * Calls BaseProbe::initOutputStreams and then calls outputHeader()
     */
-   virtual int initOutputStream(const char *filename, Checkpointer *checkpointer) override;
+   virtual void initOutputStreams(const char *filename, Checkpointer *checkpointer) override;
 
    /**
     * Called by initialize_stream after opening the stream member variable.
     * Derived classes can override this method to write header data to the output
     * file.
     */
-   virtual int outputHeader() { return PV_SUCCESS; }
+   virtual void outputHeader() {}
 
   private:
    /**

--- a/src/probes/ColumnEnergyProbe.cpp
+++ b/src/probes/ColumnEnergyProbe.cpp
@@ -25,10 +25,6 @@ ColumnEnergyProbe::ColumnEnergyProbe(const char *probename, HyPerCol *hc) : ColP
 } // end ColumnEnergyProbe::ColumnEnergyProbe(const char *, HyPerCol *)
 
 ColumnEnergyProbe::~ColumnEnergyProbe() {
-   for (int b = 0; b < mOutputBatchElements.size(); b++) {
-      delete mOutputBatchElements[b];
-   }
-
    // Don't delete terms[k]; the BaseProbes belong to the layer or connection.
    free(terms);
 } // end ColumnEnergyProbe::~ColumnEnergyProbe()
@@ -55,51 +51,17 @@ int ColumnEnergyProbe::initializeColumnEnergyProbe(const char *probename, HyPerC
    return ColProbe::initialize(probename, hc);
 }
 
-int ColumnEnergyProbe::initOutputStream(const char *filename, Checkpointer *checkpointer) {
-   return PV_SUCCESS;
-}
-
-int ColumnEnergyProbe::registerData(Checkpointer *checkpointer) {
-   MPIBlock const *mpiBlock = checkpointer->getMPIBlock();
-   int blockColumnIndex     = mpiBlock->getColumnIndex();
-   int blockRowIndex        = mpiBlock->getRowIndex();
-   if (blockColumnIndex == 0 and blockRowIndex == 0) {
-      int localBatchWidth  = parent->getNBatch();
-      int mpiBatchIndex    = mpiBlock->getStartBatch() + mpiBlock->getBatchIndex();
-      int localBatchOffset = localBatchWidth * mpiBatchIndex;
-      mOutputBatchElements.resize(localBatchWidth);
-      char const *probeOutputFilename = getProbeOutputFilename();
-      if (probeOutputFilename) {
-         std::string path(probeOutputFilename);
-         auto extensionStart = path.rfind('.');
-         std::string extension;
-         if (extensionStart != std::string::npos) {
-            extension = path.substr(extensionStart);
-            path      = path.substr(0, extensionStart);
-         }
-         std::ios_base::openmode mode = std::ios_base::out;
-         if (!checkpointer->getCheckpointReadDirectory().empty()) {
-            mode |= std::ios_base::app;
-         }
-         for (int b = 0; b < localBatchWidth; b++) {
-            int globalBatchIndex         = b + localBatchOffset;
-            std::string batchPath        = path;
-            std::string batchIndexString = std::to_string(globalBatchIndex);
-            batchPath.append("_batchElement_").append(batchIndexString).append(extension);
-            batchPath = checkpointer->makeOutputPathFilename(batchPath);
-            auto fs   = new FileStream(batchPath.c_str(), mode, checkpointer->doesVerifyWrites());
-            mOutputBatchElements[b] = fs;
-            *fs << "time,index,energy\n";
-         }
-      }
-      else {
-         for (int b = 0; b < localBatchWidth; b++) {
-            mOutputBatchElements[b] = new PrintStream(PV::getOutputStream());
-         }
-         *mOutputBatchElements[0] << "Probe_name,time,index,energy\n";
+void ColumnEnergyProbe::outputHeader() {
+   if (isWritingToFile()) {
+      for (auto &s : mOutputStreams) {
+         *s << "time,index,energy\n";
       }
    }
-   return PV_SUCCESS;
+   else {
+      if (!mOutputStreams.empty()) {
+         *mOutputStreams[0] << "Probe_name,time,index,energy\n";
+      }
+   }
 }
 
 int ColumnEnergyProbe::addTerm(BaseProbe *probe) {
@@ -207,17 +169,17 @@ int ColumnEnergyProbe::calcValues(double timevalue) {
 
 int ColumnEnergyProbe::outputState(double timevalue) {
    getValues(timevalue);
-   if (mOutputBatchElements.empty()) {
+   if (mOutputStreams.empty()) {
       return PV_SUCCESS;
    }
 
    double *valuesBuffer = getValuesBuffer();
    int nbatch           = this->getNumValues();
-   pvAssert(nbatch == (int)mOutputBatchElements.size());
+   pvAssert(nbatch == (int)mOutputStreams.size());
    char const *probeOutputFilename = getProbeOutputFilename();
    for (int b = 0; b < nbatch; b++) {
-      auto stream = *mOutputBatchElements[b];
-      if (probeOutputFilename == nullptr) {
+      auto stream = *mOutputStreams[b];
+      if (!isWritingToFile()) {
          stream << "\"" << name << "\","; // lack of \n is deliberate
       }
       stream.printf("%10f, %d, %10.9f\n", timevalue, b, valuesBuffer[b]);

--- a/src/probes/ColumnEnergyProbe.hpp
+++ b/src/probes/ColumnEnergyProbe.hpp
@@ -84,9 +84,7 @@ class ColumnEnergyProbe : public ColProbe {
     */
    int initializeColumnEnergyProbe(const char *probename, HyPerCol *hc);
 
-   virtual int initOutputStream(const char *filename, Checkpointer *checkpointer) override;
-
-   virtual int registerData(Checkpointer *checkpointer) override;
+   virtual void outputHeader() override;
 
    /**
     * Implements the needRecalc method.  Always returns true, in the expectation
@@ -116,14 +114,6 @@ class ColumnEnergyProbe : public ColProbe {
    int mSkipTimer        = 0;
    int mSkipInterval     = 0;
    double mLastTimeValue = -1;
-
-   // A vector of PrintStreams, one for each batch element.
-   // This is a hack, to work around the problem arising with an MPI block with batch dimension > 1.
-   // In this situation, several processes have the outputStream defined in BaseProbe writing to
-   // the same file, causing collisions.
-   //
-   // The correct solution to fix this, and other issues, is to overhaul the interface for probes.
-   std::vector<PrintStream *> mOutputBatchElements;
 }; // end class ColumnEnergyProbe
 
 } // end namespace PV

--- a/src/probes/FirmThresholdCostFnLCAProbe.cpp
+++ b/src/probes/FirmThresholdCostFnLCAProbe.cpp
@@ -10,9 +10,9 @@
 
 namespace PV {
 
-FirmThresholdCostFnLCAProbe::FirmThresholdCostFnLCAProbe(const char *probeName, HyPerCol *hc) {
+FirmThresholdCostFnLCAProbe::FirmThresholdCostFnLCAProbe(const char *name, HyPerCol *hc) {
    initialize_base();
-   initFirmThresholdCostFnLCAProbe(probeName, hc);
+   initialize(name, hc);
 }
 
 FirmThresholdCostFnLCAProbe::FirmThresholdCostFnLCAProbe() { initialize_base(); }

--- a/src/probes/FirmThresholdCostFnLCAProbe.hpp
+++ b/src/probes/FirmThresholdCostFnLCAProbe.hpp
@@ -23,14 +23,14 @@ namespace PV {
  */
 class FirmThresholdCostFnLCAProbe : public FirmThresholdCostFnProbe {
   public:
-   FirmThresholdCostFnLCAProbe(const char *probeName, HyPerCol *hc);
+   FirmThresholdCostFnLCAProbe(const char *name, HyPerCol *hc);
    virtual int communicateInitInfo(CommunicateInitInfoMessage const *message) override;
    virtual ~FirmThresholdCostFnLCAProbe() {}
 
   protected:
    FirmThresholdCostFnLCAProbe();
-   int initFirmThresholdCostFnLCAProbe(const char *probeName, HyPerCol *hc) {
-      return initFirmThresholdCostFnProbe(probeName, hc);
+   int initFirmThresholdCostFnLCAProbe(const char *name, HyPerCol *hc) {
+      return FirmThresholdCostFnProbe::initialize(name, hc);
    }
 
    /**

--- a/src/probes/FirmThresholdCostFnProbe.cpp
+++ b/src/probes/FirmThresholdCostFnProbe.cpp
@@ -11,17 +11,15 @@
 
 namespace PV {
 
-FirmThresholdCostFnProbe::FirmThresholdCostFnProbe() : AbstractNormProbe() {
-   initFirmThresholdCostFnProbe_base();
-}
+FirmThresholdCostFnProbe::FirmThresholdCostFnProbe() : AbstractNormProbe() { initialize_base(); }
 
-FirmThresholdCostFnProbe::FirmThresholdCostFnProbe(const char *probeName, HyPerCol *hc)
+FirmThresholdCostFnProbe::FirmThresholdCostFnProbe(const char *name, HyPerCol *hc)
       : AbstractNormProbe() {
-   initFirmThresholdCostFnProbe_base();
-   initFirmThresholdCostFnProbe(probeName, hc);
+   initialize_base();
+   initialize(name, hc);
 }
 
-int FirmThresholdCostFnProbe::initFirmThresholdCostFnProbe_base() {
+int FirmThresholdCostFnProbe::initialize_base() {
    VThresh = (float)0;
    VWidth  = (float)0;
    return PV_SUCCESS;
@@ -29,8 +27,8 @@ int FirmThresholdCostFnProbe::initFirmThresholdCostFnProbe_base() {
 
 FirmThresholdCostFnProbe::~FirmThresholdCostFnProbe() {}
 
-int FirmThresholdCostFnProbe::initFirmThresholdCostFnProbe(const char *probeName, HyPerCol *hc) {
-   return initAbstractNormProbe(probeName, hc);
+int FirmThresholdCostFnProbe::initialize(const char *name, HyPerCol *hc) {
+   return AbstractNormProbe::initialize(name, hc);
 }
 
 int FirmThresholdCostFnProbe::ioParamsFillGroup(enum ParamsIOFlag ioFlag) {

--- a/src/probes/FirmThresholdCostFnProbe.hpp
+++ b/src/probes/FirmThresholdCostFnProbe.hpp
@@ -32,14 +32,14 @@ namespace PV {
  */
 class FirmThresholdCostFnProbe : public AbstractNormProbe {
   public:
-   FirmThresholdCostFnProbe(const char *probeName, HyPerCol *hc);
+   FirmThresholdCostFnProbe(const char *name, HyPerCol *hc);
    virtual ~FirmThresholdCostFnProbe();
 
    virtual int communicateInitInfo(CommunicateInitInfoMessage const *message) override;
 
   protected:
    FirmThresholdCostFnProbe();
-   int initFirmThresholdCostFnProbe(const char *probeName, HyPerCol *hc);
+   int initialize(const char *name, HyPerCol *hc);
    virtual double getValueInternal(double timevalue, int index) override;
    virtual int ioParamsFillGroup(enum ParamsIOFlag ioFlag) override;
 
@@ -74,7 +74,7 @@ class FirmThresholdCostFnProbe : public AbstractNormProbe {
    virtual int setNormDescription() override;
 
   private:
-   int initFirmThresholdCostFnProbe_base();
+   int initialize_base();
 
    // Member variables
   protected:

--- a/src/probes/KernelProbe.cpp
+++ b/src/probes/KernelProbe.cpp
@@ -101,9 +101,9 @@ int KernelProbe::allocateDataStructures() {
             getTargetConn()->numberOfAxonalArborLists() - 1);
    }
 
-   if (outputStream) {
-      *outputStream << "Probe \"" << name << "\", kernel index " << getKernelIndex()
-                    << ", arbor index " << getArbor() << ".\n";
+   if (!mOutputStreams.empty()) {
+      output(0) << "Probe \"" << name << "\", kernel index " << getKernelIndex() << ", arbor index "
+                << getArbor() << ".\n";
    }
    if (getOutputPatchIndices()) {
       patchIndices(getTargetHyPerConn());
@@ -115,8 +115,9 @@ int KernelProbe::allocateDataStructures() {
 int KernelProbe::outputState(double timed) {
    Communicator *icComm = parent->getCommunicator();
    const int rank       = icComm->commRank();
-   if (rank != 0)
+   if (mOutputStreams.empty()) {
       return PV_SUCCESS;
+   }
    assert(getTargetConn() != NULL);
    int nxp       = getTargetHyPerConn()->xPatchSize();
    int nyp       = getTargetHyPerConn()->yPatchSize();
@@ -128,20 +129,20 @@ int KernelProbe::outputState(double timed) {
          outputPlasticIncr
                ? getTargetHyPerConn()->get_dwDataStart(arborID) + patchSize * kernelIndex
                : NULL;
-   output() << "Time " << timed << ", Conn \"" << getTargetConn()->getName() << ", nxp=" << nxp
-            << ", nyp=" << nyp << ", nfp=" << nfp << "\n";
+   output(0) << "Time " << timed << ", Conn \"" << getTargetConn()->getName() << ", nxp=" << nxp
+             << ", nyp=" << nyp << ", nfp=" << nfp << "\n";
    for (int f = 0; f < nfp; f++) {
       for (int y = 0; y < nyp; y++) {
          for (int x = 0; x < nxp; x++) {
             int k = kIndex(x, y, f, nxp, nyp, nfp);
-            output() << "    x=" << x << ", y=" << y << ", f=" << f << " (index " << k << "):";
+            output(0) << "    x=" << x << ", y=" << y << ", f=" << f << " (index " << k << "):";
             if (getOutputWeights()) {
-               output() << "  weight=" << wdata[k];
+               output(0) << "  weight=" << wdata[k];
             }
             if (getOutputPlasticIncr()) {
-               output() << "  dw=" << dwdata[k];
+               output(0) << "  dw=" << dwdata[k];
             }
-            output() << "\n";
+            output(0) << "\n";
          }
       }
    }
@@ -150,6 +151,7 @@ int KernelProbe::outputState(double timed) {
 }
 
 int KernelProbe::patchIndices(HyPerConn *conn) {
+   pvAssert(!mOutputStreams.empty());
    int nxp     = conn->xPatchSize();
    int nyp     = conn->yPatchSize();
    int nfp     = conn->fPatchSize();
@@ -169,10 +171,10 @@ int KernelProbe::patchIndices(HyPerConn *conn) {
       int kxPre   = kxPos(kPre, nxPreExt, nyPreExt, nfPre) - loc->halo.lt;
       int kyPre   = kyPos(kPre, nxPreExt, nyPreExt, nfPre) - loc->halo.up;
       int kfPre   = featureIndex(kPre, nxPreExt, nyPreExt, nfPre);
-      output() << "    presynaptic neuron " << kPre;
-      output() << " (x=" << kxPre << ", y=" << kyPre << ", f=" << kfPre;
-      output() << ") uses kernel index " << conn->patchIndexToDataIndex(kPre);
-      output() << ", starting at x=" << xOffset << ", y=" << yOffset << "\n";
+      output(0) << "    presynaptic neuron " << kPre;
+      output(0) << " (x=" << kxPre << ", y=" << kyPre << ", f=" << kfPre;
+      output(0) << ") uses kernel index " << conn->patchIndexToDataIndex(kPre);
+      output(0) << ", starting at x=" << xOffset << ", y=" << yOffset << "\n";
    }
    return PV_SUCCESS;
 }

--- a/src/probes/L0NormLCAProbe.cpp
+++ b/src/probes/L0NormLCAProbe.cpp
@@ -10,9 +10,9 @@
 
 namespace PV {
 
-L0NormLCAProbe::L0NormLCAProbe(const char *probeName, HyPerCol *hc) {
+L0NormLCAProbe::L0NormLCAProbe(const char *name, HyPerCol *hc) {
    initialize_base();
-   initL0NormLCAProbe(probeName, hc);
+   initialize(name, hc);
 }
 
 L0NormLCAProbe::L0NormLCAProbe() { initialize_base(); }

--- a/src/probes/L0NormLCAProbe.hpp
+++ b/src/probes/L0NormLCAProbe.hpp
@@ -22,15 +22,13 @@ namespace PV {
  */
 class L0NormLCAProbe : public L0NormProbe {
   public:
-   L0NormLCAProbe(const char *probeName, HyPerCol *hc);
+   L0NormLCAProbe(const char *name, HyPerCol *hc);
    virtual int communicateInitInfo(CommunicateInitInfoMessage const *message) override;
    virtual ~L0NormLCAProbe() {}
 
   protected:
    L0NormLCAProbe();
-   int initL0NormLCAProbe(const char *probeName, HyPerCol *hc) {
-      return initL0NormProbe(probeName, hc);
-   }
+   int initialize(const char *name, HyPerCol *hc) { return L0NormProbe::initialize(name, hc); }
 
    /**
     * L0NormLCAProbe does not read coefficient from its own params group,

--- a/src/probes/L0NormProbe.cpp
+++ b/src/probes/L0NormProbe.cpp
@@ -10,17 +10,17 @@
 
 namespace PV {
 
-L0NormProbe::L0NormProbe() : AbstractNormProbe() { initL0NormProbe_base(); }
+L0NormProbe::L0NormProbe() : AbstractNormProbe() { initialize_base(); }
 
-L0NormProbe::L0NormProbe(const char *probeName, HyPerCol *hc) : AbstractNormProbe() {
-   initL0NormProbe_base();
-   initL0NormProbe(probeName, hc);
+L0NormProbe::L0NormProbe(const char *name, HyPerCol *hc) : AbstractNormProbe() {
+   initialize_base();
+   initialize(name, hc);
 }
 
 L0NormProbe::~L0NormProbe() {}
 
-int L0NormProbe::initL0NormProbe(const char *probeName, HyPerCol *hc) {
-   return initAbstractNormProbe(probeName, hc);
+int L0NormProbe::initialize(const char *name, HyPerCol *hc) {
+   return AbstractNormProbe::initialize(name, hc);
 }
 
 int L0NormProbe::ioParamsFillGroup(enum ParamsIOFlag ioFlag) {

--- a/src/probes/L0NormProbe.hpp
+++ b/src/probes/L0NormProbe.hpp
@@ -19,12 +19,12 @@ namespace PV {
  */
 class L0NormProbe : public AbstractNormProbe {
   public:
-   L0NormProbe(const char *probeName, HyPerCol *hc);
+   L0NormProbe(const char *name, HyPerCol *hc);
    virtual ~L0NormProbe();
 
   protected:
    L0NormProbe();
-   int initL0NormProbe(const char *probeName, HyPerCol *hc);
+   int initialize(const char *name, HyPerCol *hc);
    virtual double getValueInternal(double timevalue, int index) override;
 
    virtual int ioParamsFillGroup(enum ParamsIOFlag ioFlag) override;
@@ -50,7 +50,7 @@ class L0NormProbe : public AbstractNormProbe {
    virtual int setNormDescription() override;
 
   private:
-   int initL0NormProbe_base() { return PV_SUCCESS; }
+   int initialize_base() { return PV_SUCCESS; }
 
   protected:
    float nnzThreshold;

--- a/src/probes/L1NormLCAProbe.cpp
+++ b/src/probes/L1NormLCAProbe.cpp
@@ -10,9 +10,9 @@
 
 namespace PV {
 
-L1NormLCAProbe::L1NormLCAProbe(const char *probeName, HyPerCol *hc) {
+L1NormLCAProbe::L1NormLCAProbe(const char *name, HyPerCol *hc) {
    initialize_base();
-   initL1NormLCAProbe(probeName, hc);
+   initialize(name, hc);
 }
 
 L1NormLCAProbe::L1NormLCAProbe() { initialize_base(); }

--- a/src/probes/L1NormLCAProbe.hpp
+++ b/src/probes/L1NormLCAProbe.hpp
@@ -21,15 +21,13 @@ namespace PV {
  */
 class L1NormLCAProbe : public L1NormProbe {
   public:
-   L1NormLCAProbe(const char *probeName, HyPerCol *hc);
+   L1NormLCAProbe(const char *name, HyPerCol *hc);
    virtual int communicateInitInfo(CommunicateInitInfoMessage const *message) override;
    virtual ~L1NormLCAProbe() {}
 
   protected:
    L1NormLCAProbe();
-   int initL1NormLCAProbe(const char *probeName, HyPerCol *hc) {
-      return initL1NormProbe(probeName, hc);
-   }
+   int initialize(const char *name, HyPerCol *hc) { return L1NormProbe::initialize(name, hc); }
 
    /**
     * L1NormLCAProbe does not read coefficient from its own params group,

--- a/src/probes/L1NormProbe.cpp
+++ b/src/probes/L1NormProbe.cpp
@@ -12,17 +12,17 @@
 
 namespace PV {
 
-L1NormProbe::L1NormProbe() : AbstractNormProbe() { initL1NormProbe_base(); }
+L1NormProbe::L1NormProbe() : AbstractNormProbe() { initialize_base(); }
 
-L1NormProbe::L1NormProbe(const char *probeName, HyPerCol *hc) : AbstractNormProbe() {
-   initL1NormProbe_base();
-   initL1NormProbe(probeName, hc);
+L1NormProbe::L1NormProbe(const char *name, HyPerCol *hc) : AbstractNormProbe() {
+   initialize_base();
+   initialize(name, hc);
 }
 
 L1NormProbe::~L1NormProbe() {}
 
-int L1NormProbe::initL1NormProbe(const char *probeName, HyPerCol *hc) {
-   return initAbstractNormProbe(probeName, hc);
+int L1NormProbe::initialize(const char *name, HyPerCol *hc) {
+   return AbstractNormProbe::initialize(name, hc);
 }
 
 double L1NormProbe::getValueInternal(double timevalue, int index) {

--- a/src/probes/L1NormProbe.hpp
+++ b/src/probes/L1NormProbe.hpp
@@ -16,12 +16,12 @@ namespace PV {
  */
 class L1NormProbe : public AbstractNormProbe {
   public:
-   L1NormProbe(const char *probeName, HyPerCol *hc);
+   L1NormProbe(const char *name, HyPerCol *hc);
    virtual ~L1NormProbe();
 
   protected:
    L1NormProbe();
-   int initL1NormProbe(const char *probeName, HyPerCol *hc);
+   int initialize(const char *name, HyPerCol *hc);
 
    /**
     * For each MPI process, getValueInternal returns the sum of the absolute
@@ -37,7 +37,7 @@ class L1NormProbe : public AbstractNormProbe {
    virtual int setNormDescription() override;
 
   private:
-   int initL1NormProbe_base() { return PV_SUCCESS; }
+   int initialize_base() { return PV_SUCCESS; }
 }; // end class L1NormProbe
 
 } // end namespace PV

--- a/src/probes/L2ConnProbe.cpp
+++ b/src/probes/L2ConnProbe.cpp
@@ -20,8 +20,9 @@ int L2ConnProbe::initialize_base() { return PV_SUCCESS; }
 int L2ConnProbe::outputState(double timed) {
    Communicator *icComm = parent->getCommunicator();
    const int rank       = icComm->commRank();
-   if (rank != 0)
+   if (mOutputStreams.empty()) {
       return PV_SUCCESS;
+   }
    assert(getTargetConn() != NULL);
    int nxp       = getTargetHyPerConn()->xPatchSize();
    int nyp       = getTargetHyPerConn()->yPatchSize();
@@ -58,9 +59,10 @@ int L2ConnProbe::outputState(double timed) {
             }
          }
       }
-      output() << "t=" << timed << ", f=" << kernelIndex << ", squaredL2=" << sumsq << "\n";
+      output(0) << "t=" << timed << ", f=" << kernelIndex << ", squaredL2=" << sumsq << "\n";
    }
 
    return PV_SUCCESS;
 }
-};
+
+} // end namespace PV

--- a/src/probes/L2NormProbe.cpp
+++ b/src/probes/L2NormProbe.cpp
@@ -10,22 +10,22 @@
 
 namespace PV {
 
-L2NormProbe::L2NormProbe() : AbstractNormProbe() { initL2NormProbe_base(); }
+L2NormProbe::L2NormProbe() : AbstractNormProbe() { initialize_base(); }
 
-L2NormProbe::L2NormProbe(const char *probeName, HyPerCol *hc) : AbstractNormProbe() {
-   initL2NormProbe_base();
-   initL2NormProbe(probeName, hc);
+L2NormProbe::L2NormProbe(const char *name, HyPerCol *hc) : AbstractNormProbe() {
+   initialize_base();
+   initialize(name, hc);
 }
 
 L2NormProbe::~L2NormProbe() {}
 
-int L2NormProbe::initL2NormProbe_base() {
+int L2NormProbe::initialize_base() {
    exponent = 1.0;
    return PV_SUCCESS;
 }
 
-int L2NormProbe::initL2NormProbe(const char *probeName, HyPerCol *hc) {
-   return initAbstractNormProbe(probeName, hc);
+int L2NormProbe::initialize(const char *name, HyPerCol *hc) {
+   return AbstractNormProbe::initialize(name, hc);
 }
 
 int L2NormProbe::ioParamsFillGroup(enum ParamsIOFlag ioFlag) {

--- a/src/probes/L2NormProbe.hpp
+++ b/src/probes/L2NormProbe.hpp
@@ -19,12 +19,12 @@ namespace PV {
  */
 class L2NormProbe : public AbstractNormProbe {
   public:
-   L2NormProbe(const char *probeName, HyPerCol *hc);
+   L2NormProbe(const char *name, HyPerCol *hc);
    virtual ~L2NormProbe();
 
   protected:
    L2NormProbe();
-   int initL2NormProbe(const char *probeName, HyPerCol *hc);
+   int initialize(const char *name, HyPerCol *hc);
 
    /**
     * Overrides AbstractNormProbe::setNormDescription().
@@ -68,7 +68,7 @@ class L2NormProbe : public AbstractNormProbe {
    /** @} */
 
   private:
-   int initL2NormProbe_base();
+   int initialize_base();
 
    // Member variables
    double exponent;

--- a/src/probes/LayerProbe.cpp
+++ b/src/probes/LayerProbe.cpp
@@ -19,9 +19,9 @@ LayerProbe::LayerProbe() {
 /**
  * @filename
  */
-LayerProbe::LayerProbe(const char *probeName, HyPerCol *hc) {
+LayerProbe::LayerProbe(const char *name, HyPerCol *hc) {
    initialize_base();
-   initialize(probeName, hc);
+   initialize(name, hc);
 }
 
 LayerProbe::~LayerProbe() {}
@@ -35,8 +35,8 @@ int LayerProbe::initialize_base() {
  * @filename
  * @layer
  */
-int LayerProbe::initialize(const char *probeName, HyPerCol *hc) {
-   int status = BaseProbe::initialize(probeName, hc);
+int LayerProbe::initialize(const char *name, HyPerCol *hc) {
+   int status = BaseProbe::initialize(name, hc);
    return status;
 }
 

--- a/src/probes/LayerProbe.hpp
+++ b/src/probes/LayerProbe.hpp
@@ -26,7 +26,7 @@ class LayerProbe : public BaseProbe {
 
    // Methods
   public:
-   LayerProbe(const char *probeName, HyPerCol *hc);
+   LayerProbe(const char *name, HyPerCol *hc);
    virtual ~LayerProbe();
 
    /**
@@ -42,7 +42,7 @@ class LayerProbe : public BaseProbe {
 
   protected:
    LayerProbe();
-   int initialize(const char *probeName, HyPerCol *hc);
+   int initialize(const char *name, HyPerCol *hc);
 
    /**
     * List of parameters for the LayerProbe class

--- a/src/probes/PointLIFProbe.cpp
+++ b/src/probes/PointLIFProbe.cpp
@@ -17,29 +17,25 @@
 namespace PV {
 
 PointLIFProbe::PointLIFProbe() : PointProbe() {
-   initPointLIFProbe_base();
+   initialize_base();
    // Derived classes of PointLIFProbe should use this PointLIFProbe constructor,
    // and call
-   // initPointLIFProbe during their initialization.
+   // PointLIFProbe::initialize during their initialization.
 }
 
-/**
- * @probeName
- * @hc
- */
-PointLIFProbe::PointLIFProbe(const char *probeName, HyPerCol *hc) : PointProbe() {
-   initPointLIFProbe_base();
-   initialize(probeName, hc);
+PointLIFProbe::PointLIFProbe(const char *name, HyPerCol *hc) : PointProbe() {
+   initialize_base();
+   initialize(name, hc);
 }
 
-int PointLIFProbe::initPointLIFProbe_base() {
+int PointLIFProbe::initialize_base() {
    writeTime = 0.0;
    writeStep = 0.0;
    return PV_SUCCESS;
 }
 
-int PointLIFProbe::initialize(const char *probeName, HyPerCol *hc) {
-   int status = PointProbe::initialize(probeName, hc);
+int PointLIFProbe::initialize(const char *name, HyPerCol *hc) {
+   int status = PointProbe::initialize(name, hc);
    writeTime  = parent->getStartTime();
    return status;
 }
@@ -161,20 +157,19 @@ int PointLIFProbe::calcValues(double timevalue) {
  * "restricted"
  *     frame.
  */
-int PointLIFProbe::writeState(double timed) {
-   if (parent->columnId() == 0 && timed >= writeTime) {
-      pvAssert(outputStream);
+int PointLIFProbe::writeState(double timevalue) {
+   if (!mOutputStreams.empty() and timevalue >= writeTime) {
       writeTime += writeStep;
       PVLayerLoc const *loc = getTargetLayer()->getLayerLoc();
       const int k           = kIndex(xLoc, yLoc, fLoc, loc->nxGlobal, loc->nyGlobal, loc->nf);
       double *valuesBuffer  = getValuesBuffer();
-      outputStream->printf(
+      output(0).printf(
             "%s t=%.1f %d"
             "G_E=" CONDUCTANCE_PRINT_FORMAT " G_I=" CONDUCTANCE_PRINT_FORMAT
             " G_IB=" CONDUCTANCE_PRINT_FORMAT " V=" CONDUCTANCE_PRINT_FORMAT
             " Vth=" CONDUCTANCE_PRINT_FORMAT " a=%.1f",
             getMessage(),
-            timed,
+            timevalue,
             k,
             valuesBuffer[0],
             valuesBuffer[1],
@@ -182,7 +177,7 @@ int PointLIFProbe::writeState(double timed) {
             valuesBuffer[3],
             valuesBuffer[4],
             valuesBuffer[5]);
-      output() << std::endl;
+      output(0) << std::endl;
    }
    return PV_SUCCESS;
 }

--- a/src/probes/PointLIFProbe.hpp
+++ b/src/probes/PointLIFProbe.hpp
@@ -14,13 +14,11 @@ namespace PV {
 
 class PointLIFProbe : public PointProbe {
   public:
-   PointLIFProbe(const char *probeName, HyPerCol *hc);
-
-   virtual int writeState(double timed) override;
+   PointLIFProbe(const char *name, HyPerCol *hc);
 
   protected:
    PointLIFProbe();
-   int initialize(const char *probeName, HyPerCol *hc);
+   int initialize(const char *name, HyPerCol *hc);
    virtual int ioParamsFillGroup(enum ParamsIOFlag ioFlag) override;
    virtual void ioParam_writeStep(enum ParamsIOFlag ioFlag);
 
@@ -40,8 +38,10 @@ class PointLIFProbe : public PointProbe {
     */
    virtual int calcValues(double timevalue) override;
 
+   virtual int writeState(double timevalue) override;
+
   private:
-   int initPointLIFProbe_base();
+   int initialize_base();
 
   protected:
    double writeTime; // time of next output

--- a/src/probes/PointProbe.hpp
+++ b/src/probes/PointProbe.hpp
@@ -14,7 +14,7 @@ namespace PV {
 
 class PointProbe : public PV::LayerProbe {
   public:
-   PointProbe(const char *probeName, HyPerCol *hc);
+   PointProbe(const char *name, HyPerCol *hc);
    virtual ~PointProbe();
 
    virtual int communicateInitInfo(CommunicateInitInfoMessage const *message) override;
@@ -28,13 +28,21 @@ class PointProbe : public PV::LayerProbe {
    int batchLoc;
 
    PointProbe();
-   int initialize(const char *probeName, HyPerCol *hc);
+   int initialize(const char *name, HyPerCol *hc);
    virtual int ioParamsFillGroup(enum ParamsIOFlag ioFlag) override;
    virtual void ioParam_xLoc(enum ParamsIOFlag ioFlag);
    virtual void ioParam_yLoc(enum ParamsIOFlag ioFlag);
    virtual void ioParam_fLoc(enum ParamsIOFlag ioFlag);
    virtual void ioParam_batchLoc(enum ParamsIOFlag ioFlag);
-   virtual int writeState(double timef);
+
+   /**
+    * Overrides initOutputStreams. A process whose restricted region contains
+    * the indicated point has an mOutputStreams vector whose length is the
+    * local batch width. Other processes have an empty mOutputStreams vector.
+    */
+   virtual void initOutputStreams(const char *filename, Checkpointer *checkpointer) override;
+
+   virtual int writeState(double timevalue);
 
    /**
     * Overrides initNumValues() to set numValues to 2 (membrane potential and
@@ -56,7 +64,7 @@ class PointProbe : public PV::LayerProbe {
    virtual int calcValues(double timevalue) override;
 
   private:
-   int initPointProbe_base();
+   int initialize_base();
 
    /**
     * A convenience method to return probeValues[0] (the membrane potential).

--- a/src/probes/QuotientColProbe.cpp
+++ b/src/probes/QuotientColProbe.cpp
@@ -45,11 +45,10 @@ int QuotientColProbe::initializeQuotientColProbe(const char *probename, HyPerCol
    return ColProbe::initialize(probename, hc);
 }
 
-int QuotientColProbe::outputHeader() {
-   if (outputStream) {
-      output() << "Probe_name,time,index," << valueDescription;
+void QuotientColProbe::outputHeader() {
+   for (auto &s : mOutputStreams) {
+      *s << "Probe_name,time,index," << valueDescription;
    }
-   return PV_SUCCESS;
 }
 
 int QuotientColProbe::ioParamsFillGroup(enum ParamsIOFlag ioFlag) {
@@ -152,17 +151,17 @@ double QuotientColProbe::referenceUpdateTime() const { return parent->simulation
 
 int QuotientColProbe::outputState(double timevalue) {
    getValues(timevalue);
-   if (this->parent->getCommunicator()->commRank() != 0)
+   if (mOutputStreams.empty()) {
       return PV_SUCCESS;
+   }
    double *valuesBuffer = getValuesBuffer();
    int numValues        = this->getNumValues();
    for (int b = 0; b < numValues; b++) {
       if (isWritingToFile()) {
-         output() << "\"" << valueDescription << "\",";
+         output(b) << "\"" << valueDescription << "\",";
       }
-      output() << timevalue << "," << b << "," << valuesBuffer[b] << "\n";
+      output(b) << timevalue << "," << b << "," << valuesBuffer[b] << std::endl;
    }
-   output().flush();
    return PV_SUCCESS;
 } // end QuotientColProbe::outputState(float, HyPerCol *)
 

--- a/src/probes/QuotientColProbe.hpp
+++ b/src/probes/QuotientColProbe.hpp
@@ -118,7 +118,7 @@ class QuotientColProbe : public ColProbe {
     */
    virtual int calcValues(double timeValue) override;
 
-   virtual int outputHeader() override;
+   virtual void outputHeader() override;
 
   private:
    /**

--- a/src/probes/RequireAllZeroActivityProbe.cpp
+++ b/src/probes/RequireAllZeroActivityProbe.cpp
@@ -9,19 +9,17 @@
 
 namespace PV {
 
-RequireAllZeroActivityProbe::RequireAllZeroActivityProbe(const char *probeName, HyPerCol *hc) {
+RequireAllZeroActivityProbe::RequireAllZeroActivityProbe(const char *name, HyPerCol *hc) {
    initialize_base();
-   initRequireAllZeroActivityProbe(probeName, hc);
+   initialize(name, hc);
 }
 
 RequireAllZeroActivityProbe::RequireAllZeroActivityProbe() { initialize_base(); }
 
 int RequireAllZeroActivityProbe::initialize_base() { return PV_SUCCESS; }
 
-int RequireAllZeroActivityProbe::initRequireAllZeroActivityProbe(
-      const char *probeName,
-      HyPerCol *hc) {
-   int status = StatsProbe::initStatsProbe(probeName, hc);
+int RequireAllZeroActivityProbe::initialize(const char *name, HyPerCol *hc) {
+   int status = StatsProbe::initialize(name, hc);
    return status;
 }
 

--- a/src/probes/RequireAllZeroActivityProbe.hpp
+++ b/src/probes/RequireAllZeroActivityProbe.hpp
@@ -24,7 +24,7 @@ namespace PV {
 
 class RequireAllZeroActivityProbe : public PV::StatsProbe {
   public:
-   RequireAllZeroActivityProbe(const char *probeName, HyPerCol *hc);
+   RequireAllZeroActivityProbe(const char *name, HyPerCol *hc);
    virtual ~RequireAllZeroActivityProbe();
    virtual int outputState(double timed) override;
 
@@ -34,7 +34,7 @@ class RequireAllZeroActivityProbe : public PV::StatsProbe {
   protected:
    RequireAllZeroActivityProbe();
    int ioParamsFillGroup(enum ParamsIOFlag ioFlag) override;
-   int initRequireAllZeroActivityProbe(const char *probeName, HyPerCol *hc);
+   int initialize(const char *name, HyPerCol *hc);
    virtual void ioParam_buffer(enum ParamsIOFlag ioFlag) override;
 
    /**

--- a/src/probes/StatsProbe.hpp
+++ b/src/probes/StatsProbe.hpp
@@ -14,7 +14,7 @@ namespace PV {
 
 class StatsProbe : public PV::LayerProbe {
   public:
-   StatsProbe(const char *probeName, HyPerCol *hc);
+   StatsProbe(const char *name, HyPerCol *hc);
    virtual ~StatsProbe();
 
    virtual int outputState(double timef) override;
@@ -22,7 +22,7 @@ class StatsProbe : public PV::LayerProbe {
 
   protected:
    StatsProbe();
-   int initStatsProbe(const char *probeName, HyPerCol *hc);
+   int initialize(const char *name, HyPerCol *hc);
    virtual int ioParamsFillGroup(enum ParamsIOFlag ioFlag) override;
    virtual void ioParam_buffer(enum ParamsIOFlag ioFlag);
    virtual void ioParam_nnzThreshold(enum ParamsIOFlag ioFlag);
@@ -70,7 +70,7 @@ class StatsProbe : public PV::LayerProbe {
    Timer *comptimer; // A timer for the basic computation of outputState
 
   private:
-   int initStatsProbe_base();
+   int initialize_base();
    void resetStats();
 }; // end class StatsProbe
 }

--- a/src/structures/Buffer.tpp
+++ b/src/structures/Buffer.tpp
@@ -163,36 +163,38 @@ void Buffer<T>::translate(int xShift, int yShift) {
 
 template <class T>
 int Buffer<T>::getAnchorX(enum Anchor anchor, int smallerWidth, int biggerWidth) {
+   int resultX;
    switch (anchor) {
       case NORTHWEST:
       case WEST:
-      case SOUTHWEST: return 0;
+      case SOUTHWEST: resultX = 0; break;
       case NORTH:
       case CENTER:
-      case SOUTH: return biggerWidth / 2 - smallerWidth / 2;
+      case SOUTH: resultX = biggerWidth / 2 - smallerWidth / 2; break;
       case NORTHEAST:
       case EAST:
-      case SOUTHEAST: return biggerWidth - smallerWidth;
-      default: return 0;
+      case SOUTHEAST: resultX = biggerWidth - smallerWidth; break;
+      default: resultX        = 0; break;
    }
-   return 0; // Statement included to suppress warnings about missing return type.
+   return resultX;
 }
 
 template <class T>
 int Buffer<T>::getAnchorY(enum Anchor anchor, int smallerHeight, int biggerHeight) {
+   int resultY;
    switch (anchor) {
       case NORTHWEST:
       case NORTH:
-      case NORTHEAST: return 0;
+      case NORTHEAST: resultY = 0; break;
       case WEST:
       case CENTER:
-      case EAST: return biggerHeight / 2 - smallerHeight / 2;
+      case EAST: resultY = biggerHeight / 2 - smallerHeight / 2; break;
       case SOUTHWEST:
       case SOUTH:
-      case SOUTHEAST: return biggerHeight - smallerHeight;
-      default: return 0;
+      case SOUTHEAST: resultY = biggerHeight - smallerHeight; break;
+      default: resultY        = 0; break;
    }
-   return 0; // Statement included to suppress warnings about missing return type.
+   return resultY;
 }
 
 } // end namespace PV

--- a/tests/ArborSystemTest/src/ArborTestForOnesProbe.cpp
+++ b/tests/ArborSystemTest/src/ArborTestForOnesProbe.cpp
@@ -13,17 +13,17 @@
 
 namespace PV {
 
-ArborTestForOnesProbe::ArborTestForOnesProbe(const char *probeName, HyPerCol *hc) : StatsProbe() {
-   initArborTestForOnesProbe_base();
-   initArborTestForOnesProbe(probeName, hc);
+ArborTestForOnesProbe::ArborTestForOnesProbe(const char *name, HyPerCol *hc) : StatsProbe() {
+   initialize_base();
+   initialize(name, hc);
 }
 
 ArborTestForOnesProbe::~ArborTestForOnesProbe() {}
 
-int ArborTestForOnesProbe::initArborTestForOnesProbe_base() { return PV_SUCCESS; }
+int ArborTestForOnesProbe::initialize_base() { return PV_SUCCESS; }
 
-int ArborTestForOnesProbe::initArborTestForOnesProbe(const char *probeName, HyPerCol *hc) {
-   return initStatsProbe(probeName, hc);
+int ArborTestForOnesProbe::initialize(const char *name, HyPerCol *hc) {
+   return StatsProbe::initialize(name, hc);
 }
 
 int ArborTestForOnesProbe::outputState(double timed) {

--- a/tests/ArborSystemTest/src/ArborTestForOnesProbe.hpp
+++ b/tests/ArborSystemTest/src/ArborTestForOnesProbe.hpp
@@ -14,16 +14,16 @@ namespace PV {
 
 class ArborTestForOnesProbe : public PV::StatsProbe {
   public:
-   ArborTestForOnesProbe(const char *probeName, HyPerCol *hc);
+   ArborTestForOnesProbe(const char *name, HyPerCol *hc);
    virtual ~ArborTestForOnesProbe();
 
    virtual int outputState(double timed) override;
 
   protected:
-   int initArborTestForOnesProbe(const char *probeName, HyPerCol *hc);
+   int initialize(const char *name, HyPerCol *hc);
 
   private:
-   int initArborTestForOnesProbe_base();
+   int initialize_base();
 };
 
 } /* namespace PV */

--- a/tests/ArborSystemTest/src/ArborTestProbe.cpp
+++ b/tests/ArborSystemTest/src/ArborTestProbe.cpp
@@ -13,17 +13,17 @@
 
 namespace PV {
 
-ArborTestProbe::ArborTestProbe(const char *probeName, HyPerCol *hc) : StatsProbe() {
-   initArborTestProbe_base();
-   initArborTestProbe(probeName, hc);
+ArborTestProbe::ArborTestProbe(const char *name, HyPerCol *hc) : StatsProbe() {
+   initialize_base();
+   initialize(name, hc);
 }
 
 ArborTestProbe::~ArborTestProbe() {}
 
-int ArborTestProbe::initArborTestProbe_base() { return PV_SUCCESS; }
+int ArborTestProbe::initialize_base() { return PV_SUCCESS; }
 
-int ArborTestProbe::initArborTestProbe(const char *probeName, HyPerCol *hc) {
-   return initStatsProbe(probeName, hc);
+int ArborTestProbe::initialize(const char *name, HyPerCol *hc) {
+   return StatsProbe::initialize(name, hc);
 }
 
 void ArborTestProbe::ioParam_buffer(enum ParamsIOFlag ioFlag) {

--- a/tests/ArborSystemTest/src/ArborTestProbe.hpp
+++ b/tests/ArborSystemTest/src/ArborTestProbe.hpp
@@ -14,17 +14,17 @@ namespace PV {
 
 class ArborTestProbe : public PV::StatsProbe {
   public:
-   ArborTestProbe(const char *probeName, HyPerCol *hc);
+   ArborTestProbe(const char *name, HyPerCol *hc);
    virtual ~ArborTestProbe();
 
    virtual int outputState(double timed) override;
 
   protected:
-   int initArborTestProbe(const char *probeName, HyPerCol *hc);
+   int initialize(const char *name, HyPerCol *hc);
    virtual void ioParam_buffer(enum ParamsIOFlag ioFlag) override;
 
   private:
-   int initArborTestProbe_base();
+   int initialize_base();
 };
 
 } /* namespace PV */

--- a/tests/CloneHyPerConnTest/src/CloneHyPerConnTestProbe.cpp
+++ b/tests/CloneHyPerConnTest/src/CloneHyPerConnTestProbe.cpp
@@ -13,16 +13,15 @@
 
 namespace PV {
 
-CloneHyPerConnTestProbe::CloneHyPerConnTestProbe(const char *probeName, HyPerCol *hc)
-      : StatsProbe() {
-   initCloneHyPerConnTestProbe_base();
-   initCloneHyPerConnTestProbe(probeName, hc);
+CloneHyPerConnTestProbe::CloneHyPerConnTestProbe(const char *name, HyPerCol *hc) : StatsProbe() {
+   initialize_base();
+   initialize(name, hc);
 }
 
-int CloneHyPerConnTestProbe::initCloneHyPerConnTestProbe_base() { return PV_SUCCESS; }
+int CloneHyPerConnTestProbe::initialize_base() { return PV_SUCCESS; }
 
-int CloneHyPerConnTestProbe::initCloneHyPerConnTestProbe(const char *probeName, HyPerCol *hc) {
-   return initStatsProbe(probeName, hc);
+int CloneHyPerConnTestProbe::initialize(const char *name, HyPerCol *hc) {
+   return StatsProbe::initialize(name, hc);
 }
 
 int CloneHyPerConnTestProbe::outputState(double timed) {

--- a/tests/CloneHyPerConnTest/src/CloneHyPerConnTestProbe.hpp
+++ b/tests/CloneHyPerConnTest/src/CloneHyPerConnTestProbe.hpp
@@ -14,15 +14,15 @@ namespace PV {
 
 class CloneHyPerConnTestProbe : public PV::StatsProbe {
   public:
-   CloneHyPerConnTestProbe(const char *probeName, HyPerCol *hc);
+   CloneHyPerConnTestProbe(const char *name, HyPerCol *hc);
 
    virtual int outputState(double timed) override;
 
   protected:
-   int initCloneHyPerConnTestProbe(const char *probeName, HyPerCol *hc);
+   int initialize(const char *name, HyPerCol *hc);
 
   private:
-   int initCloneHyPerConnTestProbe_base();
+   int initialize_base();
 };
 
 } /* namespace PV */

--- a/tests/CloneKernelConnTest/src/CloneKernelConnTestProbe.cpp
+++ b/tests/CloneKernelConnTest/src/CloneKernelConnTestProbe.cpp
@@ -13,16 +13,15 @@
 
 namespace PV {
 
-CloneKernelConnTestProbe::CloneKernelConnTestProbe(const char *probeName, HyPerCol *hc)
-      : StatsProbe() {
-   initCloneKernelConnTestProbe_base();
-   initCloneKernelConnTestProbe(probeName, hc);
+CloneKernelConnTestProbe::CloneKernelConnTestProbe(const char *name, HyPerCol *hc) : StatsProbe() {
+   initialize_base();
+   initialize(name, hc);
 }
 
-int CloneKernelConnTestProbe::initCloneKernelConnTestProbe_base() { return PV_SUCCESS; }
+int CloneKernelConnTestProbe::initialize_base() { return PV_SUCCESS; }
 
-int CloneKernelConnTestProbe::initCloneKernelConnTestProbe(const char *probeName, HyPerCol *hc) {
-   return initStatsProbe(probeName, hc);
+int CloneKernelConnTestProbe::initialize(const char *name, HyPerCol *hc) {
+   return StatsProbe::initialize(name, hc);
 }
 
 int CloneKernelConnTestProbe::outputState(double timed) {

--- a/tests/CloneKernelConnTest/src/CloneKernelConnTestProbe.hpp
+++ b/tests/CloneKernelConnTest/src/CloneKernelConnTestProbe.hpp
@@ -14,15 +14,15 @@ namespace PV {
 
 class CloneKernelConnTestProbe : public PV::StatsProbe {
   public:
-   CloneKernelConnTestProbe(const char *probeName, HyPerCol *hc);
+   CloneKernelConnTestProbe(const char *name, HyPerCol *hc);
 
    virtual int outputState(double timed) override;
 
   protected:
-   int initCloneKernelConnTestProbe(const char *probeName, HyPerCol *hc);
+   int initialize(const char *name, HyPerCol *hc);
 
   private:
-   int initCloneKernelConnTestProbe_base();
+   int initialize_base();
 };
 
 } /* namespace PV */

--- a/tests/DatastoreDelayTest/src/DatastoreDelayTestProbe.cpp
+++ b/tests/DatastoreDelayTest/src/DatastoreDelayTestProbe.cpp
@@ -11,24 +11,18 @@
 
 namespace PV {
 
-/**
- * @filename
- * @type
- * @msg
- */
-DatastoreDelayTestProbe::DatastoreDelayTestProbe(const char *probeName, HyPerCol *hc)
-      : StatsProbe() {
-   initDatastoreDelayTestProbe(probeName, hc);
+DatastoreDelayTestProbe::DatastoreDelayTestProbe(const char *name, HyPerCol *hc) : StatsProbe() {
+   initialize(name, hc);
 }
 
-int DatastoreDelayTestProbe::initDatastoreDelayTestProbe(const char *probeName, HyPerCol *hc) {
-   initStatsProbe(probeName, hc);
+int DatastoreDelayTestProbe::initialize(const char *name, HyPerCol *hc) {
+   StatsProbe::initialize(name, hc);
    return PV_SUCCESS;
 }
 
 void DatastoreDelayTestProbe::ioParam_buffer(enum ParamsIOFlag ioFlag) {
    if (ioFlag == PARAMS_IO_READ) {
-      requireType(BufActivity);
+      requireType(BufV);
    }
 }
 
@@ -44,60 +38,53 @@ int DatastoreDelayTestProbe::communicateInitInfo(CommunicateInitInfoMessage cons
    return status;
 }
 
-/**
- * @time
- * @l
- */
 int DatastoreDelayTestProbe::outputState(double timed) {
-   HyPerLayer *l        = getTargetLayer();
-   Communicator *icComm = parent->getCommunicator();
-   const int rcvProc    = 0;
-   if (icComm->commRank() != rcvProc) {
+   HyPerLayer *l = getTargetLayer();
+   if (mOutputStreams.empty()) {
       return PV_SUCCESS;
    }
-   int status         = PV_SUCCESS;
-   float correctValue = mNumDelayLevels * (mNumDelayLevels + 1) / 2;
-   for (int k = 0; k < l->getNumNeuronsAllBatches(); k++) {
-      float *V = l->getV();
-      for (int k = 0; k < l->getNumNeuronsAllBatches(); k++) {
-         float v = V[k];
-         if (v < correctValue) {
-            if (timed >= mNumDelayLevels + 1) {
-               outputStream->printf(
-                     "%s: time %f, neuron %d: value is %f instead of %d\n",
-                     l->getDescription_c(),
-                     timed,
-                     k,
-                     (double)V[k],
-                     (int)correctValue);
-               status = PV_FAILURE;
-            }
-         }
-         else if (v == correctValue) {
-            if (timed < mNumDelayLevels + 1) {
-               outputStream->printf(
-                     "%s: time %f, neuron %d has value %f, but should not reach it until %d\n",
-                     l->getDescription_c(),
-                     timed,
-                     k,
-                     (double)v,
-                     mNumDelayLevels + 1);
-               status = PV_FAILURE;
-            }
-         }
-         else { // v > correctValue
-            outputStream->printf(
-                  "%s: time %f, neuron %d: value is %f but no neuron should ever get above %d\n",
-                  l->getDescription_c(),
-                  timed,
-                  k,
-                  (double)v,
-                  (int)correctValue);
-            status = PV_FAILURE;
-         }
+   int status          = PV_SUCCESS;
+   float correctValue  = mNumDelayLevels * (mNumDelayLevels + 1) / 2;
+   int localBatchWidth = getTargetLayer()->getLayerLoc()->nbatch;
+   int globalBatchOffset =
+         localBatchWidth * (getMPIBlock()->getStartBatch() + getMPIBlock()->getBatchIndex());
+   for (int b = 0; b < localBatchWidth; b++) {
+      int globalBatchIndex = b + globalBatchOffset;
+      if (fMax[b] > correctValue) {
+         output(0).printf(
+               "%s: time %f: batch element %d has a neuron with value %f but no neuron should ever "
+               "get above %d\n",
+               l->getDescription_c(),
+               timed,
+               globalBatchIndex,
+               (double)fMax[b],
+               (int)correctValue);
+         status = PV_FAILURE;
+      }
+      if (fMax[b] == correctValue and timed < mNumDelayLevels + 1) {
+         output(0).printf(
+               "%s: time %f: batch element %d has a neuron with value %f but should not reach it "
+               "until time %d\n",
+               l->getDescription_c(),
+               timed,
+               globalBatchIndex,
+               (double)fMax[b],
+               mNumDelayLevels + 1);
+         status = PV_FAILURE;
+      }
+      if (fMin[b] < correctValue and timed >= mNumDelayLevels + 1) {
+         output(b).printf(
+               "%s: time %f, a neuron in batch element %d has value %f instead of %d.\n",
+               l->getDescription_c(),
+               timed,
+               globalBatchIndex,
+               (double)fMin[b],
+               (int)correctValue);
+         status = PV_FAILURE;
       }
    }
-   FatalIf(!(status == PV_SUCCESS), "Test failed.\n");
+
+   FatalIf(status != PV_SUCCESS, "Test failed.\n");
    return PV_SUCCESS;
 }
 

--- a/tests/DatastoreDelayTest/src/DatastoreDelayTestProbe.hpp
+++ b/tests/DatastoreDelayTest/src/DatastoreDelayTestProbe.hpp
@@ -15,16 +15,18 @@
 namespace PV {
 
 class DatastoreDelayTestProbe : public StatsProbe {
+  protected:
+   virtual void ioParam_buffer(enum ParamsIOFlag ioFlag) override;
+
   public:
-   DatastoreDelayTestProbe(const char *probename, HyPerCol *hc);
+   DatastoreDelayTestProbe(const char *name, HyPerCol *hc);
 
    virtual int outputState(double timed) override;
 
    virtual ~DatastoreDelayTestProbe();
 
   protected:
-   int initDatastoreDelayTestProbe(const char *probename, HyPerCol *hc);
-   virtual void ioParam_buffer(enum ParamsIOFlag ioFlag) override;
+   int initialize(const char *name, HyPerCol *hc);
    virtual int communicateInitInfo(CommunicateInitInfoMessage const *message) override;
 
    // Data members

--- a/tests/DelaysToFeaturesTest/src/DelayTestProbe.cpp
+++ b/tests/DelaysToFeaturesTest/src/DelayTestProbe.cpp
@@ -13,17 +13,17 @@
 
 namespace PV {
 
-DelayTestProbe::DelayTestProbe(const char *probeName, HyPerCol *hc) : StatsProbe() {
-   initDelayTestProbe_base();
-   initDelayTestProbe(probeName, hc);
+DelayTestProbe::DelayTestProbe(const char *name, HyPerCol *hc) : StatsProbe() {
+   initialize_base();
+   initialize(name, hc);
 }
 
 DelayTestProbe::~DelayTestProbe() {}
 
-int DelayTestProbe::initDelayTestProbe_base() { return PV_SUCCESS; }
+int DelayTestProbe::initialize_base() { return PV_SUCCESS; }
 
-int DelayTestProbe::initDelayTestProbe(const char *probeName, HyPerCol *hc) {
-   return initStatsProbe(probeName, hc);
+int DelayTestProbe::initialize(const char *name, HyPerCol *hc) {
+   return StatsProbe::initialize(name, hc);
 }
 
 int DelayTestProbe::outputState(double timestamp) {

--- a/tests/DelaysToFeaturesTest/src/DelayTestProbe.hpp
+++ b/tests/DelaysToFeaturesTest/src/DelayTestProbe.hpp
@@ -14,16 +14,16 @@ namespace PV {
 
 class DelayTestProbe : public PV::StatsProbe {
   public:
-   DelayTestProbe(const char *probeName, HyPerCol *hc);
+   DelayTestProbe(const char *name, HyPerCol *hc);
    virtual ~DelayTestProbe();
 
    virtual int outputState(double timestamp) override;
 
   protected:
-   int initDelayTestProbe(const char *probeName, HyPerCol *hc);
+   int initialize(const char *name, HyPerCol *hc);
 
   private:
-   int initDelayTestProbe_base();
+   int initialize_base();
 };
 
 } /* namespace PV */

--- a/tests/FilenameParsingTest/src/FilenameParsingProbe.cpp
+++ b/tests/FilenameParsingTest/src/FilenameParsingProbe.cpp
@@ -12,17 +12,17 @@ FilenameParsingProbe::FilenameParsingProbe() { initialize_base(); }
 /**
  * @filename
  */
-FilenameParsingProbe::FilenameParsingProbe(const char *probeName, PV::HyPerCol *hc) {
+FilenameParsingProbe::FilenameParsingProbe(const char *name, PV::HyPerCol *hc) {
    initialize_base();
-   initialize(probeName, hc);
+   initialize(name, hc);
 }
 
 FilenameParsingProbe::~FilenameParsingProbe() {}
 
 int FilenameParsingProbe::initialize_base() { return PV_SUCCESS; }
 
-int FilenameParsingProbe::initialize(const char *probeName, PV::HyPerCol *hc) {
-   int status = LayerProbe::initialize(probeName, hc);
+int FilenameParsingProbe::initialize(const char *name, PV::HyPerCol *hc) {
+   int status = LayerProbe::initialize(name, hc);
    return status;
 }
 

--- a/tests/FilenameParsingTest/src/FilenameParsingProbe.hpp
+++ b/tests/FilenameParsingTest/src/FilenameParsingProbe.hpp
@@ -18,12 +18,12 @@ class FilenameParsingProbe : public PV::LayerProbe {
 
    // Methods
   public:
-   FilenameParsingProbe(const char *probeName, PV::HyPerCol *hc);
+   FilenameParsingProbe(const char *name, PV::HyPerCol *hc);
    virtual ~FilenameParsingProbe();
 
   protected:
    FilenameParsingProbe();
-   int initialize(const char *probeName, PV::HyPerCol *hc);
+   int initialize(const char *name, PV::HyPerCol *hc);
    virtual int communicateInitInfo(PV::CommunicateInitInfoMessage const *message) override;
    virtual int calcValues(double timevalue) override { return 0; }
    virtual int outputState(double timestamp) override;

--- a/tests/GPUSystemTest/src/GPUSystemTestProbe.cpp
+++ b/tests/GPUSystemTest/src/GPUSystemTestProbe.cpp
@@ -10,15 +10,15 @@
 #include <utils/PVLog.hpp>
 
 namespace PV {
-GPUSystemTestProbe::GPUSystemTestProbe(const char *probeName, HyPerCol *hc) : StatsProbe() {
-   initGPUSystemTestProbe_base();
-   initGPUSystemTestProbe(probeName, hc);
+GPUSystemTestProbe::GPUSystemTestProbe(const char *name, HyPerCol *hc) : StatsProbe() {
+   initialize_base();
+   initialize(name, hc);
 }
 
-int GPUSystemTestProbe::initGPUSystemTestProbe_base() { return PV_SUCCESS; }
+int GPUSystemTestProbe::initialize_base() { return PV_SUCCESS; }
 
-int GPUSystemTestProbe::initGPUSystemTestProbe(const char *probeName, HyPerCol *hc) {
-   return initStatsProbe(probeName, hc);
+int GPUSystemTestProbe::initialize(const char *name, HyPerCol *hc) {
+   return StatsProbe::initialize(name, hc);
 }
 
 void GPUSystemTestProbe::ioParam_buffer(enum ParamsIOFlag ioFlag) { requireType(BufActivity); }

--- a/tests/GPUSystemTest/src/GPUSystemTestProbe.hpp
+++ b/tests/GPUSystemTest/src/GPUSystemTestProbe.hpp
@@ -11,16 +11,16 @@ namespace PV {
 
 class GPUSystemTestProbe : public PV::StatsProbe {
   public:
-   GPUSystemTestProbe(const char *probeName, HyPerCol *hc);
+   GPUSystemTestProbe(const char *name, HyPerCol *hc);
 
    virtual int outputState(double timed) override;
 
   protected:
-   int initGPUSystemTestProbe(const char *probeName, HyPerCol *hc);
+   int initialize(const char *name, HyPerCol *hc);
    void ioParam_buffer(enum ParamsIOFlag ioFlag) override;
 
   private:
-   int initGPUSystemTestProbe_base();
+   int initialize_base();
 };
 }
 #endif

--- a/tests/GPUSystemTest/src/identicalBatchProbe.cpp
+++ b/tests/GPUSystemTest/src/identicalBatchProbe.cpp
@@ -10,15 +10,15 @@
 #include <utils/PVLog.hpp>
 
 namespace PV {
-identicalBatchProbe::identicalBatchProbe(const char *probeName, HyPerCol *hc) : StatsProbe() {
+identicalBatchProbe::identicalBatchProbe(const char *name, HyPerCol *hc) : StatsProbe() {
    initidenticalBatchProbe_base();
-   initidenticalBatchProbe(probeName, hc);
+   initidenticalBatchProbe(name, hc);
 }
 
 int identicalBatchProbe::initidenticalBatchProbe_base() { return PV_SUCCESS; }
 
-int identicalBatchProbe::initidenticalBatchProbe(const char *probeName, HyPerCol *hc) {
-   return initStatsProbe(probeName, hc);
+int identicalBatchProbe::initidenticalBatchProbe(const char *name, HyPerCol *hc) {
+   return StatsProbe::initialize(name, hc);
 }
 
 void identicalBatchProbe::ioParam_buffer(enum ParamsIOFlag ioFlag) { requireType(BufActivity); }

--- a/tests/GPUSystemTest/src/identicalBatchProbe.hpp
+++ b/tests/GPUSystemTest/src/identicalBatchProbe.hpp
@@ -11,12 +11,12 @@ namespace PV {
 
 class identicalBatchProbe : public PV::StatsProbe {
   public:
-   identicalBatchProbe(const char *probeName, HyPerCol *hc);
+   identicalBatchProbe(const char *name, HyPerCol *hc);
 
    virtual int outputState(double timed) override;
 
   protected:
-   int initidenticalBatchProbe(const char *probeName, HyPerCol *hc);
+   int initidenticalBatchProbe(const char *name, HyPerCol *hc);
    void ioParam_buffer(enum ParamsIOFlag ioFlag) override;
 
   private:

--- a/tests/GroupNormalizationTest/src/AllConstantValueProbe.cpp
+++ b/tests/GroupNormalizationTest/src/AllConstantValueProbe.cpp
@@ -7,9 +7,9 @@
 
 namespace PV {
 
-AllConstantValueProbe::AllConstantValueProbe(char const *probeName, HyPerCol *hc) {
+AllConstantValueProbe::AllConstantValueProbe(char const *name, HyPerCol *hc) {
    initialize_base();
-   initAllConstantValueProbe(probeName, hc);
+   initialize(name, hc);
 }
 
 AllConstantValueProbe::AllConstantValueProbe() { initialize_base(); }
@@ -19,8 +19,8 @@ int AllConstantValueProbe::initialize_base() {
    return PV_SUCCESS;
 }
 
-int AllConstantValueProbe::initAllConstantValueProbe(char const *probeName, HyPerCol *hc) {
-   return StatsProbe::initStatsProbe(probeName, hc);
+int AllConstantValueProbe::initialize(char const *name, HyPerCol *hc) {
+   return StatsProbe::initialize(name, hc);
 }
 
 int AllConstantValueProbe::ioParamsFillGroup(enum ParamsIOFlag ioFlag) {
@@ -36,11 +36,21 @@ void AllConstantValueProbe::ioParam_correctValue(enum ParamsIOFlag ioFlag) {
 
 int AllConstantValueProbe::outputState(double timed) {
    int status = StatsProbe::outputState(timed);
-   if (this->parent->columnId() == 0) {
-      for (int b = 0; b < this->parent->getNBatch(); b++) {
-         if (timed > 0
-             && (fMin[b] < correctValue - nnzThreshold || fMax[b] > correctValue + nnzThreshold)) {
-            outputStream->printf(
+   if (timed <= 0) {
+      return status;
+   }
+   if (!mOutputStreams.empty()) {
+      int nbatch = getTargetLayer()->getLayerLoc()->nbatch;
+      FatalIf(
+            nbatch != (int)mOutputStreams.size(),
+            "Number of output streams for %s does not agree with local batch width.\n",
+            getDescription_c());
+      int globalBatchOffset =
+            nbatch * (getMPIBlock()->getStartBatch() + getMPIBlock()->getBatchIndex());
+      for (int b = 0; b < nbatch; b++) {
+         int globalBatchIndex = globalBatchOffset + b;
+         if (fMin[b] < correctValue - nnzThreshold or fMax[b] > correctValue + nnzThreshold) {
+            output(b).printf(
                   "     Values outside of tolerance nnzThreshold=%f\n", (double)nnzThreshold);
             ErrorLog().printf(
                   "t=%f: fMin=%f, fMax=%f; values more than nnzThreshold=%g away from correct "

--- a/tests/GroupNormalizationTest/src/AllConstantValueProbe.hpp
+++ b/tests/GroupNormalizationTest/src/AllConstantValueProbe.hpp
@@ -13,7 +13,7 @@ namespace PV {
 
 class AllConstantValueProbe : public StatsProbe {
   public:
-   AllConstantValueProbe(const char *probeName, HyPerCol *hc);
+   AllConstantValueProbe(const char *name, HyPerCol *hc);
    ~AllConstantValueProbe();
 
    float getCorrectValue() { return correctValue; }
@@ -22,7 +22,7 @@ class AllConstantValueProbe : public StatsProbe {
 
   protected:
    AllConstantValueProbe();
-   int initAllConstantValueProbe(const char *probeName, HyPerCol *hc);
+   int initialize(const char *name, HyPerCol *hc);
    virtual int ioParamsFillGroup(enum ParamsIOFlag ioFlag) override;
    virtual void ioParam_correctValue(enum ParamsIOFlag ioFlag);
 

--- a/tests/HyPerConnCheckpointerTest/src/HyPerConnCheckpointerTestProbe.cpp
+++ b/tests/HyPerConnCheckpointerTest/src/HyPerConnCheckpointerTestProbe.cpp
@@ -11,19 +11,17 @@
 
 HyPerConnCheckpointerTestProbe::HyPerConnCheckpointerTestProbe() { initialize_base(); }
 
-HyPerConnCheckpointerTestProbe::HyPerConnCheckpointerTestProbe(
-      const char *probeName,
-      PV::HyPerCol *hc) {
+HyPerConnCheckpointerTestProbe::HyPerConnCheckpointerTestProbe(const char *name, PV::HyPerCol *hc) {
    initialize_base();
-   initialize(probeName, hc);
+   initialize(name, hc);
 }
 
 HyPerConnCheckpointerTestProbe::~HyPerConnCheckpointerTestProbe() {}
 
 int HyPerConnCheckpointerTestProbe::initialize_base() { return PV_SUCCESS; }
 
-int HyPerConnCheckpointerTestProbe::initialize(const char *probeName, PV::HyPerCol *hc) {
-   int status = PV::ColProbe::initialize(probeName, hc);
+int HyPerConnCheckpointerTestProbe::initialize(const char *name, PV::HyPerCol *hc) {
+   int status = PV::ColProbe::initialize(name, hc);
    FatalIf(parent->getDeltaTime() != 1.0, "This test assumes that the HyPerCol dt is 1.0.\n");
    return status;
 }
@@ -173,8 +171,8 @@ int HyPerConnCheckpointerTestProbe::outputState(double timevalue) {
 
    if (failed) {
       std::string errorMsg(getDescription() + " failed at t = " + std::to_string(timevalue) + "\n");
-      if (outputStream) {
-         outputStream->printf(errorMsg.c_str());
+      if (!mOutputStreams.empty()) {
+         output(0).printf(errorMsg.c_str());
       }
       if (isWritingToFile()) { // print error message to screen/log file as well.
          ErrorLog() << errorMsg;
@@ -182,8 +180,8 @@ int HyPerConnCheckpointerTestProbe::outputState(double timevalue) {
       mTestFailed = true;
    }
    else {
-      if (outputStream) {
-         outputStream->printf(
+      if (!mOutputStreams.empty()) {
+         output(0).printf(
                "%s found all correct values at time %f\n", getDescription_c(), timevalue);
       }
    }
@@ -205,12 +203,16 @@ bool HyPerConnCheckpointerTestProbe::verifyLayer(
    PV::Buffer<float> globalBuffer = PV::BufferUtils::gather(
          comm->getLocalMPIBlock(), localBuffer, inputLoc->nx, inputLoc->ny, 0, 0);
    if (comm->commRank() == 0) {
+      FatalIf(
+            mOutputStreams.empty(),
+            "%s has empty mOutputStreams in root process.\n",
+            getDescription_c());
       globalBuffer.crop(inputLoc->nxGlobal, inputLoc->nyGlobal, PV::Buffer<float>::CENTER);
       std::vector<float> globalVector = globalBuffer.asVector();
       int const numInputNeurons       = globalVector.size();
       for (int k = 0; k < numInputNeurons; k++) {
          if (globalVector[k] != correctValue) {
-            outputStream->printf(
+            output(0).printf(
                   "Time %f, %s neuron %d is %f, instead of the expected %f.\n",
                   timevalue,
                   layer->getName(),
@@ -231,9 +233,13 @@ bool HyPerConnCheckpointerTestProbe::verifyConnection(
    bool failed = false;
 
    if (parent->getCommunicator()->commRank() == 0) {
+      FatalIf(
+            mOutputStreams.empty(),
+            "%s has empty mOutputStreams in root process.\n",
+            getDescription_c());
       float observedWeightValue = connection->get_wDataStart(0)[0];
       if (observedWeightValue != correctValue) {
-         outputStream->printf(
+         output(0).printf(
                "Time %f, weight is %f, instead of the expected %f.\n",
                timevalue,
                (double)observedWeightValue,

--- a/tests/HyPerConnCheckpointerTest/src/HyPerConnCheckpointerTestProbe.hpp
+++ b/tests/HyPerConnCheckpointerTest/src/HyPerConnCheckpointerTestProbe.hpp
@@ -20,7 +20,7 @@ class HyPerConnCheckpointerTestProbe : public PV::ColProbe {
    /**
     * Public constructor for the HyPerConnCheckpointerTestProbe class.
     */
-   HyPerConnCheckpointerTestProbe(const char *probeName, PV::HyPerCol *hc);
+   HyPerConnCheckpointerTestProbe(const char *name, PV::HyPerCol *hc);
 
    /**
     * Destructor for the HyPerConnCheckpointerTestProbe class.
@@ -36,7 +36,7 @@ class HyPerConnCheckpointerTestProbe : public PV::ColProbe {
    bool getTestFailed() const { return mTestFailed; }
 
   protected:
-   int initialize(const char *probeName, PV::HyPerCol *hc);
+   int initialize(const char *name, PV::HyPerCol *hc);
    virtual void ioParam_textOutputFlag(enum PV::ParamsIOFlag ioFlag) override;
    virtual int communicateInitInfo(PV::CommunicateInitInfoMessage const *message) override;
    virtual int readStateFromCheckpoint(PV::Checkpointer *checkpointer) override;

--- a/tests/InitWeightsTest/src/InitWeightTestProbe.cpp
+++ b/tests/InitWeightsTest/src/InitWeightTestProbe.cpp
@@ -13,14 +13,14 @@
 
 namespace PV {
 
-InitWeightTestProbe::InitWeightTestProbe(const char *probeName, HyPerCol *hc) : StatsProbe() {
-   initInitWeightTestProbe(probeName, hc);
+InitWeightTestProbe::InitWeightTestProbe(const char *name, HyPerCol *hc) : StatsProbe() {
+   initialize(name, hc);
 }
 
-int InitWeightTestProbe::initInitWeightTestProbe_base() { return PV_SUCCESS; }
+int InitWeightTestProbe::initialize_base() { return PV_SUCCESS; }
 
-int InitWeightTestProbe::initInitWeightTestProbe(const char *probeName, HyPerCol *hc) {
-   return initStatsProbe(probeName, hc);
+int InitWeightTestProbe::initialize(const char *name, HyPerCol *hc) {
+   return StatsProbe::initialize(name, hc);
 }
 
 void InitWeightTestProbe::ioParam_buffer(enum ParamsIOFlag ioFlag) { requireType(BufActivity); }

--- a/tests/InitWeightsTest/src/InitWeightTestProbe.hpp
+++ b/tests/InitWeightsTest/src/InitWeightTestProbe.hpp
@@ -14,16 +14,16 @@ namespace PV {
 
 class InitWeightTestProbe : public PV::StatsProbe {
   public:
-   InitWeightTestProbe(const char *probeName, HyPerCol *hc);
+   InitWeightTestProbe(const char *name, HyPerCol *hc);
 
    virtual int outputState(double timef) override;
 
   protected:
-   int initInitWeightTestProbe(const char *probeName, HyPerCol *hc);
+   int initialize(const char *name, HyPerCol *hc);
    virtual void ioParam_buffer(enum ParamsIOFlag ioFlag) override;
 
   private:
-   int initInitWeightTestProbe_base();
+   int initialize_base();
 };
 
 } /* namespace PV */

--- a/tests/InputLayerNormalizeTest/src/CheckStatsProbe.cpp
+++ b/tests/InputLayerNormalizeTest/src/CheckStatsProbe.cpp
@@ -55,7 +55,7 @@ CheckStatsProbe::~CheckStatsProbe() {}
 int CheckStatsProbe::initialize_base() { return PV_SUCCESS; }
 
 int CheckStatsProbe::initialize(char const *name, PV::HyPerCol *hc) {
-   return StatsProbe::initStatsProbe(name, hc);
+   return StatsProbe::initialize(name, hc);
 }
 
 int CheckStatsProbe::ioParamsFillGroup(enum PV::ParamsIOFlag ioFlag) {

--- a/tests/KernelTest/src/KernelTestProbe.cpp
+++ b/tests/KernelTest/src/KernelTestProbe.cpp
@@ -13,14 +13,14 @@
 
 namespace PV {
 
-KernelTestProbe::KernelTestProbe(const char *probeName, HyPerCol *hc) : StatsProbe() {
-   initKernelTestProbe(probeName, hc);
+KernelTestProbe::KernelTestProbe(const char *name, HyPerCol *hc) : StatsProbe() {
+   initialize(name, hc);
 }
 
-int KernelTestProbe::initKernelTestProbe_base() { return PV_SUCCESS; }
+int KernelTestProbe::initialize_base() { return PV_SUCCESS; }
 
-int KernelTestProbe::initKernelTestProbe(const char *probeName, HyPerCol *hc) {
-   return initStatsProbe(probeName, hc);
+int KernelTestProbe::initialize(const char *name, HyPerCol *hc) {
+   return StatsProbe::initialize(name, hc);
 }
 
 void KernelTestProbe::ioParam_buffer(enum ParamsIOFlag ioFlag) { requireType(BufActivity); }

--- a/tests/KernelTest/src/KernelTestProbe.hpp
+++ b/tests/KernelTest/src/KernelTestProbe.hpp
@@ -14,16 +14,16 @@ namespace PV {
 
 class KernelTestProbe : public PV::StatsProbe {
   public:
-   KernelTestProbe(const char *probeName, HyPerCol *hc);
+   KernelTestProbe(const char *name, HyPerCol *hc);
 
    virtual int outputState(double timed) override;
 
   protected:
-   int initKernelTestProbe(const char *probeName, HyPerCol *hc);
+   int initialize(const char *name, HyPerCol *hc);
    void ioParam_buffer(enum ParamsIOFlag ioFlag) override;
 
   private:
-   int initKernelTestProbe_base();
+   int initialize_base();
 };
 
 } /* namespace PV */

--- a/tests/LIFTest/src/LIFTestProbe.hpp
+++ b/tests/LIFTest/src/LIFTestProbe.hpp
@@ -15,7 +15,7 @@ namespace PV {
 
 class LIFTestProbe : public StatsProbe {
   public:
-   LIFTestProbe(const char *probeName, HyPerCol *hc);
+   LIFTestProbe(const char *name, HyPerCol *hc);
    virtual ~LIFTestProbe();
 
    virtual int communicateInitInfo(CommunicateInitInfoMessage const *message) override;
@@ -24,11 +24,11 @@ class LIFTestProbe : public StatsProbe {
 
   protected:
    LIFTestProbe();
-   int initLIFTestProbe(const char *probeName, HyPerCol *hc);
+   int initialize(const char *name, HyPerCol *hc);
    virtual int ioParamsFillGroup(enum ParamsIOFlag ioFlag) override;
    virtual void ioParam_endingTime(enum ParamsIOFlag ioFlag);
    virtual void ioParam_tolerance(enum ParamsIOFlag ioFlag);
-   virtual int initOutputStream(const char *filename, Checkpointer *checkpointer) override;
+   virtual void initOutputStreams(const char *filename, Checkpointer *checkpointer) override;
 
   private:
    int initialize_base();

--- a/tests/LayerPhaseTest/src/LayerPhaseTestProbe.cpp
+++ b/tests/LayerPhaseTest/src/LayerPhaseTestProbe.cpp
@@ -9,15 +9,15 @@
 
 namespace PV {
 
-LayerPhaseTestProbe::LayerPhaseTestProbe(const char *probeName, HyPerCol *hc) : StatsProbe() {
-   initLayerPhaseTestProbe_base();
-   initLayerPhaseTestProbe(probeName, hc);
+LayerPhaseTestProbe::LayerPhaseTestProbe(const char *name, HyPerCol *hc) : StatsProbe() {
+   initialize_base();
+   initialize(name, hc);
 }
 
-int LayerPhaseTestProbe::initLayerPhaseTestProbe_base() { return PV_SUCCESS; }
+int LayerPhaseTestProbe::initialize_base() { return PV_SUCCESS; }
 
-int LayerPhaseTestProbe::initLayerPhaseTestProbe(const char *probeName, HyPerCol *hc) {
-   return initStatsProbe(probeName, hc);
+int LayerPhaseTestProbe::initialize(const char *name, HyPerCol *hc) {
+   return StatsProbe::initialize(name, hc);
 }
 
 int LayerPhaseTestProbe::ioParamsFillGroup(enum ParamsIOFlag ioFlag) {

--- a/tests/LayerPhaseTest/src/LayerPhaseTestProbe.hpp
+++ b/tests/LayerPhaseTest/src/LayerPhaseTestProbe.hpp
@@ -17,19 +17,19 @@ namespace PV {
 
 class LayerPhaseTestProbe : public PV::StatsProbe {
   public:
-   LayerPhaseTestProbe(const char *probeName, HyPerCol *hc);
+   LayerPhaseTestProbe(const char *name, HyPerCol *hc);
 
    virtual int outputState(double timed) override;
 
   protected:
-   int initLayerPhaseTestProbe(const char *probeName, HyPerCol *hc);
+   int initialize(const char *name, HyPerCol *hc);
    virtual int ioParamsFillGroup(enum ParamsIOFlag ioFlag) override;
    virtual void ioParam_buffer(enum ParamsIOFlag ioFlag) override;
    virtual void ioParam_equilibriumValue(enum ParamsIOFlag ioFlag);
    virtual void ioParam_equilibriumTime(enum ParamsIOFlag ioFlag);
 
   private:
-   int initLayerPhaseTestProbe_base();
+   int initialize_base();
 
   protected:
    float equilibriumValue;

--- a/tests/MPITest/src/MPITestProbe.cpp
+++ b/tests/MPITest/src/MPITestProbe.cpp
@@ -13,29 +13,17 @@
 
 namespace PV {
 
-/**
- * @probeName
- * @hc
- */
-MPITestProbe::MPITestProbe(const char *probeName, HyPerCol *hc) : StatsProbe() {
-   initMPITestProbe(probeName, hc);
+MPITestProbe::MPITestProbe(const char *name, HyPerCol *hc) : StatsProbe() { initialize(name, hc); }
+
+int MPITestProbe::initialize_base() { return PV_SUCCESS; }
+
+int MPITestProbe::initialize(const char *name, HyPerCol *hc) {
+   return StatsProbe::initialize(name, hc);
 }
 
-int MPITestProbe::initMPITestProbe_base() { return PV_SUCCESS; }
-
-int MPITestProbe::initMPITestProbe(const char *probeName, HyPerCol *hc) {
-   return initStatsProbe(probeName, hc);
-}
-
-/**
- * @time
- * @l
- */
 int MPITestProbe::outputState(double timed) {
-   int status           = StatsProbe::outputState(timed);
-   Communicator *icComm = parent->getCommunicator();
-   const int rcvProc    = 0;
-   if (icComm->commRank() != rcvProc) {
+   int status = StatsProbe::outputState(timed);
+   if (mOutputStreams.empty()) {
       return status;
    }
    float tol = 1e-4f;
@@ -61,29 +49,34 @@ int MPITestProbe::outputState(double timed) {
    }
    float ave_global_xpos = (min_global_xpos + max_global_xpos) / 2.0f;
 
-   outputStream->printf(
-         "%s min_global_xpos==%f ave_global_xpos==%f max_global_xpos==%f",
-         getMessage(),
-         (double)min_global_xpos,
-         (double)ave_global_xpos,
-         (double)max_global_xpos);
-   output() << std::endl;
-   for (int b = 0; b < parent->getNBatch(); b++) {
+   for (int b = 0; b < (int)mOutputStreams.size(); b++) {
       if (timed > 3.0) {
+         output(b) << std::endl;
+         output(b).printf(
+               "%s min_global_xpos==%f ave_global_xpos==%f max_global_xpos==%f",
+               getMessage(),
+               (double)min_global_xpos,
+               (double)ave_global_xpos,
+               (double)max_global_xpos);
          FatalIf(
-               !((fMin[b] / min_global_xpos > (1 - tol))
-                 && (fMin[b] / min_global_xpos < (1 + tol))),
-               "Test failed.\n");
+               (fMin[b] / min_global_xpos <= (1 - tol)) or (fMin[b] / min_global_xpos >= (1 + tol)),
+               "%s fMin differs from %f.\n",
+               getDescription_c(),
+               (double)min_global_xpos);
          FatalIf(
-               !((fMax[b] / max_global_xpos > (1 - tol))
-                 && (fMax[b] / max_global_xpos < (1 + tol))),
-               "Test failed.\n");
+               (fMax[b] / max_global_xpos <= (1 - tol)) or (fMax[b] / max_global_xpos >= (1 + tol)),
+               "%s fMax differs from %f.\n",
+               getDescription_c(),
+               (double)max_global_xpos);
          FatalIf(
-               !((avg[b] / ave_global_xpos > (1 - tol)) && (avg[b] / ave_global_xpos < (1 + tol))),
-               "Test failed.\n");
+               (avg[b] / ave_global_xpos <= (1 - tol)) or (avg[b] / ave_global_xpos >= (1 + tol)),
+               "%s average differs from %f.\n",
+               getDescription_c(),
+               (double)ave_global_xpos);
       }
    }
 
    return status;
 }
-}
+
+} // end namespace PV

--- a/tests/MPITest/src/MPITestProbe.hpp
+++ b/tests/MPITest/src/MPITestProbe.hpp
@@ -14,15 +14,15 @@ namespace PV {
 
 class MPITestProbe : public PV::StatsProbe {
   public:
-   MPITestProbe(const char *probeName, HyPerCol *hc);
+   MPITestProbe(const char *name, HyPerCol *hc);
 
    virtual int outputState(double timed) override;
 
   protected:
-   int initMPITestProbe(const char *probeName, HyPerCol *hc);
+   int initialize(const char *name, HyPerCol *hc);
 
   private:
-   int initMPITestProbe_base();
+   int initialize_base();
 }; // end class MPITestProbe
 
 } // end namespace PV

--- a/tests/MomentumConnSimpleCheckpointerTest/src/MomentumConnSimpleCheckpointerTestProbe.hpp
+++ b/tests/MomentumConnSimpleCheckpointerTest/src/MomentumConnSimpleCheckpointerTestProbe.hpp
@@ -20,7 +20,7 @@ class MomentumConnSimpleCheckpointerTestProbe : public PV::ColProbe {
    /**
     * Public constructor for the MomentumConnSimpleCheckpointerTestProbe class.
     */
-   MomentumConnSimpleCheckpointerTestProbe(const char *probeName, PV::HyPerCol *hc);
+   MomentumConnSimpleCheckpointerTestProbe(const char *name, PV::HyPerCol *hc);
 
    /**
     * Destructor for the MomentumConnSimpleCheckpointerTestProbe class.
@@ -36,7 +36,7 @@ class MomentumConnSimpleCheckpointerTestProbe : public PV::ColProbe {
    bool getTestFailed() const { return mTestFailed; }
 
   protected:
-   int initialize(const char *probeName, PV::HyPerCol *hc);
+   int initialize(const char *name, PV::HyPerCol *hc);
    virtual void ioParam_textOutputFlag(enum PV::ParamsIOFlag ioFlag) override;
    virtual int communicateInitInfo(PV::CommunicateInitInfoMessage const *message) override;
    virtual int readStateFromCheckpoint(PV::Checkpointer *checkpointer) override;

--- a/tests/MomentumConnViscosityCheckpointerTest/src/MomentumConnViscosityCheckpointerTestProbe.cpp
+++ b/tests/MomentumConnViscosityCheckpointerTest/src/MomentumConnViscosityCheckpointerTestProbe.cpp
@@ -14,20 +14,18 @@ MomentumConnViscosityCheckpointerTestProbe::MomentumConnViscosityCheckpointerTes
 }
 
 MomentumConnViscosityCheckpointerTestProbe::MomentumConnViscosityCheckpointerTestProbe(
-      const char *probeName,
+      const char *name,
       PV::HyPerCol *hc) {
    initialize_base();
-   initialize(probeName, hc);
+   initialize(name, hc);
 }
 
 MomentumConnViscosityCheckpointerTestProbe::~MomentumConnViscosityCheckpointerTestProbe() {}
 
 int MomentumConnViscosityCheckpointerTestProbe::initialize_base() { return PV_SUCCESS; }
 
-int MomentumConnViscosityCheckpointerTestProbe::initialize(
-      const char *probeName,
-      PV::HyPerCol *hc) {
-   int status = PV::ColProbe::initialize(probeName, hc);
+int MomentumConnViscosityCheckpointerTestProbe::initialize(const char *name, PV::HyPerCol *hc) {
+   int status = PV::ColProbe::initialize(name, hc);
    FatalIf(parent->getDeltaTime() != 1.0, "This test assumes that the HyPerCol dt is 1.0.\n");
    return status;
 }
@@ -188,8 +186,8 @@ int MomentumConnViscosityCheckpointerTestProbe::outputState(double timevalue) {
 
    if (failed) {
       std::string errorMsg(getDescription() + " failed at t = " + std::to_string(timevalue) + "\n");
-      if (outputStream) {
-         outputStream->printf(errorMsg.c_str());
+      if (!mOutputStreams.empty()) {
+         output(0).printf(errorMsg.c_str());
       }
       if (isWritingToFile()) { // print error message to screen/log file as well.
          ErrorLog() << errorMsg;
@@ -197,8 +195,8 @@ int MomentumConnViscosityCheckpointerTestProbe::outputState(double timevalue) {
       mTestFailed = true;
    }
    else {
-      if (outputStream) {
-         outputStream->printf(
+      if (!mOutputStreams.empty()) {
+         output(0).printf(
                "%s found all correct values at time %f\n", getDescription_c(), timevalue);
       }
    }
@@ -228,9 +226,17 @@ bool MomentumConnViscosityCheckpointerTestProbe::verifyConnValue(
       float observed,
       float correct,
       char const *valueDescription) {
+   FatalIf(
+         parent->getCommunicator()->commRank() != 0,
+         "%s called verifyConnValue from nonroot process.\n",
+         getDescription_c());
+   FatalIf(
+         mOutputStreams.empty(),
+         "%s has empty mOutputStreams in root process.\n",
+         getDescription_c());
    bool failed;
    if (observed != correct) {
-      outputStream->printf(
+      output(0).printf(
             "Time %f, %s is %f, instead of the expected %f.\n",
             timevalue,
             valueDescription,
@@ -259,12 +265,16 @@ bool MomentumConnViscosityCheckpointerTestProbe::verifyLayer(
    PV::Buffer<float> globalBuffer = PV::BufferUtils::gather(
          comm->getLocalMPIBlock(), localBuffer, inputLoc->nx, inputLoc->ny, 0, 0);
    if (comm->commRank() == 0) {
+      FatalIf(
+            mOutputStreams.empty(),
+            "%s has empty mOutputStreams in root process.\n",
+            getDescription_c());
       globalBuffer.crop(inputLoc->nxGlobal, inputLoc->nyGlobal, PV::Buffer<float>::CENTER);
       std::vector<float> globalVector = globalBuffer.asVector();
       int const numInputNeurons       = globalVector.size();
       for (int k = 0; k < numInputNeurons; k++) {
          if (globalVector[k] != correctValue) {
-            outputStream->printf(
+            output(0).printf(
                   "Time %f, %s neuron %d is %f, instead of the expected %f.\n",
                   timevalue,
                   layer->getName(),

--- a/tests/MomentumConnViscosityCheckpointerTest/src/MomentumConnViscosityCheckpointerTestProbe.hpp
+++ b/tests/MomentumConnViscosityCheckpointerTest/src/MomentumConnViscosityCheckpointerTestProbe.hpp
@@ -20,7 +20,7 @@ class MomentumConnViscosityCheckpointerTestProbe : public PV::ColProbe {
    /**
     * Public constructor for the MomentumConnViscosityCheckpointerTestProbe class.
     */
-   MomentumConnViscosityCheckpointerTestProbe(const char *probeName, PV::HyPerCol *hc);
+   MomentumConnViscosityCheckpointerTestProbe(const char *name, PV::HyPerCol *hc);
 
    /**
     * Destructor for the MomentumConnViscosityCheckpointerTestProbe class.
@@ -36,7 +36,7 @@ class MomentumConnViscosityCheckpointerTestProbe : public PV::ColProbe {
    bool getTestFailed() const { return mTestFailed; }
 
   protected:
-   int initialize(const char *probeName, PV::HyPerCol *hc);
+   int initialize(const char *name, PV::HyPerCol *hc);
    virtual void ioParam_textOutputFlag(enum PV::ParamsIOFlag ioFlag) override;
    virtual int communicateInitInfo(PV::CommunicateInitInfoMessage const *message) override;
    virtual int readStateFromCheckpoint(PV::Checkpointer *checkpointer) override;

--- a/tests/MomentumTest/src/MomentumConnTestProbe.cpp
+++ b/tests/MomentumTest/src/MomentumConnTestProbe.cpp
@@ -39,14 +39,12 @@ void MomentumConnTestProbe::ioParam_isViscosity(enum ParamsIOFlag ioFlag) {
  * @timef
  */
 int MomentumConnTestProbe::outputState(double timed) {
-   HyPerConn *c         = getTargetHyPerConn();
-   Communicator *icComm = parent->getCommunicator();
-   const int rcvProc    = 0;
-   if (icComm->commRank() != rcvProc) {
+   HyPerConn *c = getTargetHyPerConn();
+   FatalIf(c == nullptr, "%s has targetConnection set to null.\n", getDescription_c());
+   if (mOutputStreams.empty()) {
       return PV_SUCCESS;
    }
-   FatalIf(!(getTargetConn() != NULL), "Test failed.\n");
-   outputStream->printf("    Time %f, %s:\n", timed, getTargetConn()->getDescription_c());
+   output(0).printf("    Time %f, %s:\n", timed, getTargetConn()->getDescription_c());
    const float *w  = c->get_wDataHead(getArbor(), getKernelIndex());
    const float *dw = c->get_dwDataHead(getArbor(), getKernelIndex());
    if (getOutputPlasticIncr() && dw == NULL) {
@@ -84,8 +82,7 @@ int MomentumConnTestProbe::outputState(double timed) {
       if (fabs(((double)(wObserved - wCorrect)) / timed) > 1e-4) {
          int y = kyPos(k, nxp, nyp, nfp);
          int f = featureIndex(k, nxp, nyp, nfp);
-         outputStream->printf(
-               "        w = %f, should be %f\n", (double)wObserved, (double)wCorrect);
+         output(0).printf("        w = %f, should be %f\n", (double)wObserved, (double)wCorrect);
          exit(-1);
       }
    }

--- a/tests/NormalizeSubclassSystemTest/src/NormalizeL3.cpp
+++ b/tests/NormalizeSubclassSystemTest/src/NormalizeL3.cpp
@@ -7,9 +7,9 @@
 
 namespace PV {
 
-NormalizeL3::NormalizeL3(char const *probeName, HyPerCol *hc) {
+NormalizeL3::NormalizeL3(char const *name, HyPerCol *hc) {
    initialize_base();
-   initialize(probeName, hc);
+   initialize(name, hc);
 }
 
 NormalizeL3::NormalizeL3() { initialize_base(); }

--- a/tests/NormalizeSubclassSystemTest/src/NormalizeL3.hpp
+++ b/tests/NormalizeSubclassSystemTest/src/NormalizeL3.hpp
@@ -13,7 +13,7 @@ namespace PV {
 
 class NormalizeL3 : public NormalizeMultiply {
   public:
-   NormalizeL3(const char *probeName, HyPerCol *hc);
+   NormalizeL3(const char *name, HyPerCol *hc);
    ~NormalizeL3();
    virtual int ioParamsFillGroup(enum ParamsIOFlag ioFlag) override;
    virtual int normalizeWeights() override;

--- a/tests/ParameterSweepTest/src/ParameterSweepTestProbe.cpp
+++ b/tests/ParameterSweepTest/src/ParameterSweepTestProbe.cpp
@@ -9,14 +9,14 @@
 
 namespace PV {
 
-ParameterSweepTestProbe::ParameterSweepTestProbe(const char *probeName, HyPerCol *hc) {
-   initParameterSweepTestProbe(probeName, hc);
+ParameterSweepTestProbe::ParameterSweepTestProbe(const char *name, HyPerCol *hc) {
+   initialize(name, hc);
 }
 
 ParameterSweepTestProbe::~ParameterSweepTestProbe() {}
 
-int ParameterSweepTestProbe::initParameterSweepTestProbe(const char *probeName, HyPerCol *hc) {
-   int status = initStatsProbe(probeName, hc);
+int ParameterSweepTestProbe::initialize(const char *name, HyPerCol *hc) {
+   int status = StatsProbe::initialize(name, hc);
    return status;
 }
 

--- a/tests/ParameterSweepTest/src/ParameterSweepTestProbe.hpp
+++ b/tests/ParameterSweepTest/src/ParameterSweepTestProbe.hpp
@@ -17,13 +17,13 @@ namespace PV {
 
 class ParameterSweepTestProbe : public StatsProbe {
   public:
-   ParameterSweepTestProbe(const char *probeName, HyPerCol *hc);
+   ParameterSweepTestProbe(const char *name, HyPerCol *hc);
    virtual ~ParameterSweepTestProbe();
 
    virtual int outputState(double timed) override;
 
   protected:
-   int initParameterSweepTestProbe(const char *probeName, HyPerCol *hc);
+   int initialize(const char *name, HyPerCol *hc);
    virtual int ioParamsFillGroup(enum ParamsIOFlag ioFlag) override;
    virtual void ioParam_buffer(enum ParamsIOFlag ioFlag) override;
    virtual void ioParam_expectedSum(enum ParamsIOFlag ioFlag);

--- a/tests/PointProbeTest/src/TestPointProbe.cpp
+++ b/tests/PointProbeTest/src/TestPointProbe.cpp
@@ -12,12 +12,12 @@
 namespace PV {
 
 TestPointProbe::TestPointProbe() {
-   // Default constructor for derived classes.  Derived classes should call initTestPointProbe from
+   // Default constructor for derived classes.  Derived classes should call initialize from
    // their init-method.
 }
 
-TestPointProbe::TestPointProbe(const char *probeName, HyPerCol *hc) : PointProbe() {
-   initialize(probeName, hc);
+TestPointProbe::TestPointProbe(const char *name, HyPerCol *hc) : PointProbe() {
+   initialize(name, hc);
 }
 
 TestPointProbe::~TestPointProbe() {}

--- a/tests/PointProbeTest/src/TestPointProbe.hpp
+++ b/tests/PointProbeTest/src/TestPointProbe.hpp
@@ -12,7 +12,7 @@ namespace PV {
 
 class TestPointProbe : public PV::PointProbe {
   public:
-   TestPointProbe(const char *probeName, HyPerCol *hc);
+   TestPointProbe(const char *name, HyPerCol *hc);
    virtual ~TestPointProbe();
 
   protected:

--- a/tests/PoolingConnCheckpointerTest/src/PoolingConnCheckpointerTestProbe.cpp
+++ b/tests/PoolingConnCheckpointerTest/src/PoolingConnCheckpointerTestProbe.cpp
@@ -14,18 +14,18 @@
 PoolingConnCheckpointerTestProbe::PoolingConnCheckpointerTestProbe() { initialize_base(); }
 
 PoolingConnCheckpointerTestProbe::PoolingConnCheckpointerTestProbe(
-      const char *probeName,
+      const char *name,
       PV::HyPerCol *hc) {
    initialize_base();
-   initialize(probeName, hc);
+   initialize(name, hc);
 }
 
 PoolingConnCheckpointerTestProbe::~PoolingConnCheckpointerTestProbe() {}
 
 int PoolingConnCheckpointerTestProbe::initialize_base() { return PV_SUCCESS; }
 
-int PoolingConnCheckpointerTestProbe::initialize(const char *probeName, PV::HyPerCol *hc) {
-   int status = PV::ColProbe::initialize(probeName, hc);
+int PoolingConnCheckpointerTestProbe::initialize(const char *name, PV::HyPerCol *hc) {
+   int status = PV::ColProbe::initialize(name, hc);
    FatalIf(parent->getDeltaTime() != 1.0, "This test assumes that the HyPerCol dt is 1.0.\n");
    return status;
 }
@@ -56,6 +56,7 @@ int PoolingConnCheckpointerTestProbe::communicateInitInfo(
    if (initConnection(message) == PV_POSTPONE) {
       return PV_POSTPONE;
    }
+   FatalIf(parent->getNBatch() > 1, "PoolingConnCheckpointerTestProbe requires nbatch = 1.\n");
    return status;
 }
 
@@ -171,8 +172,8 @@ int PoolingConnCheckpointerTestProbe::outputState(double timevalue) {
 
    if (failed) {
       std::string errorMsg(getDescription() + " failed at t = " + std::to_string(timevalue) + "\n");
-      if (outputStream) {
-         outputStream->printf(errorMsg.c_str());
+      if (!mOutputStreams.empty()) {
+         output(0).printf(errorMsg.c_str());
       }
       if (isWritingToFile()) { // print error message to screen/log file as well.
          ErrorLog() << errorMsg;
@@ -180,8 +181,8 @@ int PoolingConnCheckpointerTestProbe::outputState(double timevalue) {
       mTestFailed = true;
    }
    else {
-      if (outputStream) {
-         outputStream->printf(
+      if (!mOutputStreams.empty()) {
+         output(0).printf(
                "%s found all correct values at time %f\n", getDescription_c(), timevalue);
       }
    }

--- a/tests/PoolingConnCheckpointerTest/src/PoolingConnCheckpointerTestProbe.hpp
+++ b/tests/PoolingConnCheckpointerTest/src/PoolingConnCheckpointerTestProbe.hpp
@@ -20,7 +20,7 @@ class PoolingConnCheckpointerTestProbe : public PV::ColProbe {
    /**
     * Public constructor for the PoolingConnCheckpointerTestProbe class.
     */
-   PoolingConnCheckpointerTestProbe(const char *probeName, PV::HyPerCol *hc);
+   PoolingConnCheckpointerTestProbe(const char *name, PV::HyPerCol *hc);
 
    /**
     * Destructor for the PoolingConnCheckpointerTestProbe class.
@@ -36,7 +36,7 @@ class PoolingConnCheckpointerTestProbe : public PV::ColProbe {
    bool getTestFailed() const { return mTestFailed; }
 
   protected:
-   int initialize(const char *probeName, PV::HyPerCol *hc);
+   int initialize(const char *name, PV::HyPerCol *hc);
    virtual void ioParam_textOutputFlag(enum PV::ParamsIOFlag ioFlag) override;
    virtual int communicateInitInfo(PV::CommunicateInitInfoMessage const *message) override;
    virtual int readStateFromCheckpoint(PV::Checkpointer *checkpointer) override;

--- a/tests/ReceiveFromPostTest/src/ReceiveFromPostProbe.cpp
+++ b/tests/ReceiveFromPostTest/src/ReceiveFromPostProbe.cpp
@@ -10,18 +10,18 @@
 #include <utils/PVLog.hpp>
 
 namespace PV {
-ReceiveFromPostProbe::ReceiveFromPostProbe(const char *probeName, HyPerCol *hc) : StatsProbe() {
-   initReceiveFromPostProbe_base();
-   initReceiveFromPostProbe(probeName, hc);
+ReceiveFromPostProbe::ReceiveFromPostProbe(const char *name, HyPerCol *hc) : StatsProbe() {
+   initialize_base();
+   initialize(name, hc);
 }
 
-int ReceiveFromPostProbe::initReceiveFromPostProbe_base() {
+int ReceiveFromPostProbe::initialize_base() {
    tolerance = (float)1e-3f;
    return PV_SUCCESS;
 }
 
-int ReceiveFromPostProbe::initReceiveFromPostProbe(const char *probeName, HyPerCol *hc) {
-   return initStatsProbe(probeName, hc);
+int ReceiveFromPostProbe::initialize(const char *name, HyPerCol *hc) {
+   return StatsProbe::initialize(name, hc);
 }
 
 int ReceiveFromPostProbe::ioParamsFillGroup(enum ParamsIOFlag ioFlag) {

--- a/tests/ReceiveFromPostTest/src/ReceiveFromPostProbe.hpp
+++ b/tests/ReceiveFromPostTest/src/ReceiveFromPostProbe.hpp
@@ -11,18 +11,18 @@ namespace PV {
 
 class ReceiveFromPostProbe : public PV::StatsProbe {
   public:
-   ReceiveFromPostProbe(const char *probeName, HyPerCol *hc);
+   ReceiveFromPostProbe(const char *name, HyPerCol *hc);
 
    virtual int outputState(double timed) override;
 
   protected:
-   int initReceiveFromPostProbe(const char *probeName, HyPerCol *hc);
+   int initialize(const char *name, HyPerCol *hc);
    int ioParamsFillGroup(enum ParamsIOFlag ioFlag) override;
    void ioParam_buffer(enum ParamsIOFlag ioFlag) override;
    void ioParam_tolerance(enum ParamsIOFlag ioFlag);
 
   private:
-   int initReceiveFromPostProbe_base();
+   int initialize_base();
 
    // Member variables
   protected:

--- a/tests/RescaleLayerTest/src/RescaleLayerTestProbe.cpp
+++ b/tests/RescaleLayerTest/src/RescaleLayerTestProbe.cpp
@@ -14,14 +14,14 @@
 
 namespace PV {
 
-RescaleLayerTestProbe::RescaleLayerTestProbe(const char *probeName, HyPerCol *hc) : StatsProbe() {
-   initRescaleLayerTestProbe(probeName, hc);
+RescaleLayerTestProbe::RescaleLayerTestProbe(const char *name, HyPerCol *hc) : StatsProbe() {
+   initialize(name, hc);
 }
 
-int RescaleLayerTestProbe::initRescaleLayerTestProbe_base() { return PV_SUCCESS; }
+int RescaleLayerTestProbe::initialize_base() { return PV_SUCCESS; }
 
-int RescaleLayerTestProbe::initRescaleLayerTestProbe(const char *probeName, HyPerCol *hc) {
-   return initStatsProbe(probeName, hc);
+int RescaleLayerTestProbe::initialize(const char *name, HyPerCol *hc) {
+   return StatsProbe::initialize(name, hc);
 }
 
 void RescaleLayerTestProbe::ioParam_buffer(enum ParamsIOFlag ioFlag) { requireType(BufActivity); }

--- a/tests/RescaleLayerTest/src/RescaleLayerTestProbe.hpp
+++ b/tests/RescaleLayerTest/src/RescaleLayerTestProbe.hpp
@@ -14,13 +14,13 @@ namespace PV {
 
 class RescaleLayerTestProbe : public PV::StatsProbe {
   public:
-   RescaleLayerTestProbe(const char *probeName, HyPerCol *hc);
+   RescaleLayerTestProbe(const char *name, HyPerCol *hc);
    virtual int communicateInitInfo(CommunicateInitInfoMessage const *message) override;
 
    virtual int outputState(double timed) override;
 
   protected:
-   int initRescaleLayerTestProbe(const char *probeName, HyPerCol *hc);
+   int initialize(const char *name, HyPerCol *hc);
    void ioParam_buffer(enum ParamsIOFlag ioFlag) override;
    bool colinear(
          int nx,
@@ -35,7 +35,7 @@ class RescaleLayerTestProbe : public PV::StatsProbe {
          double *stdB);
 
   private:
-   int initRescaleLayerTestProbe_base();
+   int initialize_base();
 
 }; // end class RescaleLayerTestProbe
 

--- a/tests/ResetStateOnTriggerTest/src/ResetStateOnTriggerTestProbe.hpp
+++ b/tests/ResetStateOnTriggerTest/src/ResetStateOnTriggerTestProbe.hpp
@@ -5,7 +5,7 @@
 
 class ResetStateOnTriggerTestProbe : public PV::LayerProbe {
   public:
-   ResetStateOnTriggerTestProbe(char const *probeName, PV::HyPerCol *hc);
+   ResetStateOnTriggerTestProbe(char const *name, PV::HyPerCol *hc);
    virtual ~ResetStateOnTriggerTestProbe();
 
    /**
@@ -22,7 +22,7 @@ class ResetStateOnTriggerTestProbe : public PV::LayerProbe {
 
   protected:
    ResetStateOnTriggerTestProbe();
-   int initialize(char const *probeName, PV::HyPerCol *hc);
+   int initialize(char const *name, PV::HyPerCol *hc);
 
    /**
     * Returns the number of neurons in the target layer that differ from the expected value.

--- a/tests/SegmentTest/src/AssertZerosProbe.cpp
+++ b/tests/SegmentTest/src/AssertZerosProbe.cpp
@@ -10,15 +10,15 @@
 #include <utils/PVLog.hpp>
 
 namespace PV {
-AssertZerosProbe::AssertZerosProbe(const char *probeName, HyPerCol *hc) : StatsProbe() {
-   initAssertZerosProbe_base();
-   initAssertZerosProbe(probeName, hc);
+AssertZerosProbe::AssertZerosProbe(const char *name, HyPerCol *hc) : StatsProbe() {
+   initialize_base();
+   initialize(name, hc);
 }
 
-int AssertZerosProbe::initAssertZerosProbe_base() { return PV_SUCCESS; }
+int AssertZerosProbe::initialize_base() { return PV_SUCCESS; }
 
-int AssertZerosProbe::initAssertZerosProbe(const char *probeName, HyPerCol *hc) {
-   return initStatsProbe(probeName, hc);
+int AssertZerosProbe::initialize(const char *name, HyPerCol *hc) {
+   return StatsProbe::initialize(name, hc);
 }
 
 void AssertZerosProbe::ioParam_buffer(enum ParamsIOFlag ioFlag) { requireType(BufActivity); }

--- a/tests/SegmentTest/src/AssertZerosProbe.hpp
+++ b/tests/SegmentTest/src/AssertZerosProbe.hpp
@@ -11,16 +11,16 @@ namespace PV {
 
 class AssertZerosProbe : public PV::StatsProbe {
   public:
-   AssertZerosProbe(const char *probeName, HyPerCol *hc);
+   AssertZerosProbe(const char *name, HyPerCol *hc);
 
    virtual int outputState(double timed) override;
 
   protected:
-   int initAssertZerosProbe(const char *probeName, HyPerCol *hc);
+   int initialize(const char *name, HyPerCol *hc);
    void ioParam_buffer(enum ParamsIOFlag ioFlag) override;
 
   private:
-   int initAssertZerosProbe_base();
+   int initialize_base();
 
 }; // end class AssertZerosProbe
 

--- a/tests/ShrunkenPatchTest/src/ShrunkenPatchTestProbe.cpp
+++ b/tests/ShrunkenPatchTest/src/ShrunkenPatchTestProbe.cpp
@@ -19,16 +19,16 @@ namespace PV {
  * @type
  * @msg
  */
-ShrunkenPatchTestProbe::ShrunkenPatchTestProbe(const char *probename, HyPerCol *hc) : StatsProbe() {
-   initShrunkenPatchTestProbe_base();
-   initShrunkenPatchTestProbe(probename, hc);
+ShrunkenPatchTestProbe::ShrunkenPatchTestProbe(const char *name, HyPerCol *hc) : StatsProbe() {
+   initialize_base();
+   initialize(name, hc);
 }
 
-int ShrunkenPatchTestProbe::initShrunkenPatchTestProbe_base() { return PV_SUCCESS; }
+int ShrunkenPatchTestProbe::initialize_base() { return PV_SUCCESS; }
 
-int ShrunkenPatchTestProbe::initShrunkenPatchTestProbe(const char *probename, HyPerCol *hc) {
+int ShrunkenPatchTestProbe::initialize(const char *name, HyPerCol *hc) {
    correctValues = NULL;
-   int status    = StatsProbe::initStatsProbe(probename, hc);
+   int status    = StatsProbe::initialize(name, hc);
    return status;
 }
 
@@ -100,7 +100,7 @@ int ShrunkenPatchTestProbe::outputState(double timed) {
          Fatal().printf(
                "ShrunkenPatchTestProbe \"%s\" error: nxpShrunken must be an integer multiple of "
                "layer \"%s\" nxScale=%d.\n",
-               probeName,
+               name,
                l->getName(),
                cell_size);
       }
@@ -154,8 +154,5 @@ int ShrunkenPatchTestProbe::outputState(double timed) {
    return status;
 }
 
-ShrunkenPatchTestProbe::~ShrunkenPatchTestProbe() {
-   // free(probeName);
-   free(correctValues);
-}
+ShrunkenPatchTestProbe::~ShrunkenPatchTestProbe() { free(correctValues); }
 }

--- a/tests/ShrunkenPatchTest/src/ShrunkenPatchTestProbe.hpp
+++ b/tests/ShrunkenPatchTest/src/ShrunkenPatchTestProbe.hpp
@@ -24,17 +24,16 @@ class ShrunkenPatchTestProbe : public PV::StatsProbe {
    virtual ~ShrunkenPatchTestProbe();
 
   protected:
-   int initShrunkenPatchTestProbe(const char *probename, HyPerCol *hc);
+   int initialize(const char *probename, HyPerCol *hc);
    virtual int ioParamsFillGroup(enum ParamsIOFlag ioFlag) override;
    virtual void ioParam_buffer(enum ParamsIOFlag ioFlag) override;
    virtual void ioParam_nxpShrunken(enum ParamsIOFlag ioFlag);
    virtual void ioParam_nypShrunken(enum ParamsIOFlag ioFlag);
 
   private:
-   int initShrunkenPatchTestProbe_base();
+   int initialize_base();
 
   protected:
-   char *probeName;
    int nxpShrunken;
    int nypShrunken;
    float *correctValues;

--- a/tests/StochasticReleaseTest/src/StochasticReleaseTestProbe.hpp
+++ b/tests/StochasticReleaseTest/src/StochasticReleaseTestProbe.hpp
@@ -27,7 +27,7 @@ class StochasticReleaseTestProbe : public PV::StatsProbe {
 
   protected:
    StochasticReleaseTestProbe();
-   int initStochasticReleaseTestProbe(const char *name, HyPerCol *hc);
+   int initialize(const char *name, HyPerCol *hc);
    virtual void ioParam_buffer(enum ParamsIOFlag ioFlag) override;
    void computePValues();
    void computePValues(int step, int f);

--- a/tests/WriteActivitySparseTest/src/TestNotAlwaysAllZerosProbe.cpp
+++ b/tests/WriteActivitySparseTest/src/TestNotAlwaysAllZerosProbe.cpp
@@ -16,9 +16,9 @@
 
 namespace PV {
 
-TestNotAlwaysAllZerosProbe::TestNotAlwaysAllZerosProbe(const char *probeName, HyPerCol *hc) {
-   initTestNotAlwaysAllZerosProbe_base();
-   initTestNotAlwaysAllZerosProbe(probeName, hc);
+TestNotAlwaysAllZerosProbe::TestNotAlwaysAllZerosProbe(const char *name, HyPerCol *hc) {
+   initialize_base();
+   initialize(name, hc);
 }
 
 int TestNotAlwaysAllZerosProbe::outputState(double timed) {
@@ -37,15 +37,13 @@ int TestNotAlwaysAllZerosProbe::outputState(double timed) {
    return status;
 }
 
-int TestNotAlwaysAllZerosProbe::initTestNotAlwaysAllZerosProbe_base() {
+int TestNotAlwaysAllZerosProbe::initialize_base() {
    nonzeroValueOccurred = false;
    return PV_SUCCESS;
 }
 
-int TestNotAlwaysAllZerosProbe::initTestNotAlwaysAllZerosProbe(
-      const char *probeName,
-      HyPerCol *hc) {
-   return StatsProbe::initStatsProbe(probeName, hc);
+int TestNotAlwaysAllZerosProbe::initialize(const char *name, HyPerCol *hc) {
+   return StatsProbe::initialize(name, hc);
 }
 
 void TestNotAlwaysAllZerosProbe::ioParam_buffer(enum ParamsIOFlag ioFlag) {

--- a/tests/WriteActivitySparseTest/src/TestNotAlwaysAllZerosProbe.hpp
+++ b/tests/WriteActivitySparseTest/src/TestNotAlwaysAllZerosProbe.hpp
@@ -9,17 +9,17 @@ namespace PV {
 
 class TestNotAlwaysAllZerosProbe : public StatsProbe {
   public:
-   TestNotAlwaysAllZerosProbe(const char *probeName, HyPerCol *hc);
+   TestNotAlwaysAllZerosProbe(const char *name, HyPerCol *hc);
    bool nonzeroValueHasOccurred() { return nonzeroValueOccurred; }
 
    virtual int outputState(double timed) override;
 
   protected:
-   int initTestNotAlwaysAllZerosProbe(const char *probeName, HyPerCol *hc);
+   int initialize(const char *name, HyPerCol *hc);
    virtual void ioParam_buffer(enum ParamsIOFlag ioFlag) override;
 
   private:
-   int initTestNotAlwaysAllZerosProbe_base();
+   int initialize_base();
 
    // Member variables
   protected:


### PR DESCRIPTION
This pull request overhauls the management of output streams in probes. The data member outputStream has been replaced by a vector of PrintStreams, called mOutputStreams. Generally, if a process has MPIBlock row and column index both zero, the mOutputStreams vector has a length equal to the number of batch elements per MPI process; and other processes have an empty mOutputStream. If probeOutputFile is nonempy, the global batch index is inserted into the probe's output file name. This avoids collisions where multiple processes are writing to the same file.

PointProbes are an exception: a process that contains the point and batch element being probed has an mOutputStreams vector of length one, and other processes have an empty mOutputStreams. The batch element is not inserted into the probe's output file path.

For connection probes (derived from the BaseConnection class), the root process of each MPIBlock has an mOutputStreams vector of size 1; other processes have an empty mOutputStreams vector. Because connections are the same for all batch elements, the batch index is not inserted into the probeOutputFile parameter.