### PR TITLE
No spaces in names of params groups

### DIFF
--- a/src/io/parser/params.l
+++ b/src/io/parser/params.l
@@ -12,7 +12,6 @@
 
 "#include" { return T_INCLUDE; }
 "ParameterSweep" {return T_PARAM_SWEEP; }
-"BatchSweep" {return T_BATCH_SWEEP; }
 "@"[a-zA-Z][a-zA-Z0-9_]* {
     yylval.sval = strdup(yytext);
     return T_ID_OVERWRITE;

--- a/src/io/parser/params.l
+++ b/src/io/parser/params.l
@@ -35,6 +35,7 @@
    return T_ID;
 }
 
+[\"][0-9A-Za-z][0-9A-Za-z_]*[\"] { yylval.sval = strdup(yytext); return T_GROUPID; }
 [\"][a-zA-Z0-9_ ]*[\"] { yylval.sval = strdup(yytext); return T_STRING; }
 [\"][a-zA-Z0-9_~+/.-]+[\"] { yylval.sval = strdup(yytext); return T_FILENAME; }
 

--- a/src/io/parser/params.y
+++ b/src/io/parser/params.y
@@ -152,7 +152,6 @@ int pv_parseParameters(PV::PVParams * action_handler, const char * paramBuffer, 
 %token <sval> T_FILENAME
 %token <sval> T_INCLUDE
 %token <sval> T_PARAM_SWEEP
-%token <sval> T_BATCH_SWEEP
 
 %%
 

--- a/src/io/parser/params.y
+++ b/src/io/parser/params.y
@@ -145,6 +145,7 @@ int pv_parseParameters(PV::PVParams * action_handler, const char * paramBuffer, 
 
 %union {char * sval; double dval; }
 %token <sval> T_STRING
+%token <sval> T_GROUPID
 %token <sval> T_ID
 %token <sval> T_ID_OVERWRITE
 %token <dval> T_NUMBER
@@ -170,7 +171,7 @@ pvparams_directive : T_ID '=' T_NUMBER ';'
                    */
                    ;
 
-parameter_group_id : T_ID T_STRING '='
+parameter_group_id : T_ID T_GROUPID '='
                       { handler->action_parameter_group_name($1, $2); }
                    ;
 
@@ -213,20 +214,28 @@ parameter_string_def : T_ID '=' T_STRING ';'
                         { handler->action_parameter_string_def($1,$3); }
                      | T_ID '=' T_FILENAME ';'
                         { handler->action_parameter_filename_def($1,$3); }
+                     | T_ID '=' T_GROUPID ';'
+                        { handler->action_parameter_filename_def($1,$3); }
                      | T_ID_OVERWRITE '=' T_STRING ';'
                         { handler->action_parameter_string_def_overwrite($1,$3); }
                      | T_ID_OVERWRITE '=' T_FILENAME ';'
+                        { handler->action_parameter_filename_def_overwrite($1,$3); }
+                     | T_ID_OVERWRITE '=' T_GROUPID ';'
                         { handler->action_parameter_filename_def_overwrite($1,$3); }
                      ;
 
 /*include_directive : T_INCLUDE T_ID ';'*/
 include_directive : T_INCLUDE T_STRING ';'
                         { handler->action_include_directive($2); }
+                  | T_INCLUDE T_FILENAME ';'
+                        { handler->action_include_directive($2); }
+                  | T_INCLUDE T_GROUPID ';'
+                        { handler->action_include_directive($2); }
                   ;
 
 
 /* Sweeps */
-parameter_sweep_id : T_PARAM_SWEEP T_STRING ':' T_ID '='
+parameter_sweep_id : T_PARAM_SWEEP T_GROUPID ':' T_ID '='
                       { handler->action_parameter_sweep_open($2, $4); }
 
 
@@ -236,6 +245,7 @@ parameter_sweep : parameter_sweep_id '{' parameter_sweep_values '}' ';'
 
 parameter_sweep_values : /* empty */
              | parameter_sweep_values_numbers
+             | parameter_sweep_values_groupids
              | parameter_sweep_values_strings
              | parameter_sweep_values_filenames
              ;
@@ -246,6 +256,14 @@ parameter_sweep_values_numbers : parameter_sweep_values_number
 
 parameter_sweep_values_number : T_NUMBER ';'
                        { handler->action_parameter_sweep_values_number($1); }
+                    ;
+
+parameter_sweep_values_groupids : parameter_sweep_values_groupid
+                     | parameter_sweep_values_groupids parameter_sweep_values_groupid
+                     ; /* empty not included because this leads to a reduce/reduce conflict if sweep_values is empty */
+
+parameter_sweep_values_groupid : T_GROUPID ';'
+                       { handler->action_parameter_sweep_values_string($1); }
                     ;
 
 parameter_sweep_values_strings : parameter_sweep_values_string

--- a/tests/AdjustAxonalArborsTest/input/AdjustAxonalArborsTest.params
+++ b/tests/AdjustAxonalArborsTest/input/AdjustAxonalArborsTest.params
@@ -39,7 +39,7 @@ HyPerCol "column" = {
    progressInterval = 10.0; //Program will output its progress at each progressInterval
    writeProgressToErr = false;  
    verifyWrites = true;
-   outputPath = "output";
+   outputPath = "Output";
    printParamsFilename = "pv.params";
    initializeFromCheckpointDir = "";
    checkpointWrite = false;
@@ -55,7 +55,7 @@ HyPerCol "column" = {
 
 
 // this is a input layer
-PvpLayer "input" = {
+PvpLayer "Input" = {
     nxScale = 1;  // this must be 2^n, n = ...,-2,-1,0,1,2,... 
     nyScale = 1;  // the scale is to decide how much area will be used as input. For exampel, nx * nxScale = 32. The size of input
     	      	  // cannot be larger than the input image size.
@@ -78,7 +78,7 @@ PvpLayer "input" = {
 };
 
 //an output layer
-ANNLayer "output" = {
+ANNLayer "Output" = {
     restart = 0;
     nxScale = 1; 
     nyScale = 1;
@@ -102,9 +102,9 @@ ANNLayer "output" = {
 
 //connection
 
-HyPerConn "input to output" = {
-    preLayerName = "input";
-    postLayerName = "output";
+HyPerConn "InputToOutput" = {
+    preLayerName = "Input";
+    postLayerName = "Output";
     channelCode = 0;
 
     sharedWeights = true;

--- a/tests/ArborSystemTest/input/test_arbors.params
+++ b/tests/ArborSystemTest/input/test_arbors.params
@@ -1,10 +1,10 @@
 //
-// test_kernel.params
+// test_arbors.params
 //
 // created by garkenyon: August 4, 2011
 //
 
-//  - input parameters for test_kernel.cpp for system level testing of kernels
+//  - input parameters for ArborSystemTest for system level testing of arbors
 //
 
 debugParsing = false;
@@ -221,7 +221,7 @@ ANNLayer "Lx1_4" = {
 
 //  connections: 
 
-HyPerConn "Retina to L0" = {
+HyPerConn "RetinaToL0" = {
     preLayerName = "Retina";
     postLayerName = "L0";
     channelCode = 0;
@@ -276,7 +276,7 @@ HyPerConn "Retina to L0" = {
 
 
 
-HyPerConn "L0 to Lx1" = {
+HyPerConn "L0ToLx1" = {
     preLayerName = "L0";
     postLayerName = "Lx1";
     channelCode = 0;
@@ -329,7 +329,7 @@ HyPerConn "L0 to Lx1" = {
 };
 
 
-HyPerConn "L0 to Lx2" = {
+HyPerConn "L0ToLx2" = {
     preLayerName = "L0";
     postLayerName = "Lx2";
     numAxonalArbors = 4;
@@ -382,7 +382,7 @@ HyPerConn "L0 to Lx2" = {
 };
 
 
-HyPerConn "L0 to Lx4" = {
+HyPerConn "L0ToLx4" = {
     preLayerName = "L0";
     postLayerName = "Lx4";
     numAxonalArbors = 4;
@@ -435,7 +435,7 @@ HyPerConn "L0 to Lx4" = {
 };
 
 
-HyPerConn "L0 to Lx1_2" = {
+HyPerConn "L0ToLx1_2" = {
     preLayerName = "L0";
     postLayerName = "Lx1_2";
     numAxonalArbors = 4;
@@ -488,7 +488,7 @@ HyPerConn "L0 to Lx1_2" = {
 };
 
 
-HyPerConn "L0 to Lx1_4" = {
+HyPerConn "L0ToLx1_4" = {
     preLayerName = "L0";
     postLayerName = "Lx1_4";
     numAxonalArbors = 4;
@@ -541,7 +541,7 @@ HyPerConn "L0 to Lx1_4" = {
 
 
 
-ArborTestForOnesProbe "Retina Stats File" = {
+ArborTestForOnesProbe "RetinaStatsFile" = {
     targetLayer = "Retina";
     probeOutputFile = "Retina_Stats.txt";
     message = "Retina Stats File              ";
@@ -549,7 +549,7 @@ ArborTestForOnesProbe "Retina Stats File" = {
     buffer = "Activity";
     nnzThreshold = 0;
 };
-ArborTestForOnesProbe "L0 Stats File" = {
+ArborTestForOnesProbe "L0StatsFile" = {
     targetLayer = "L0";
     probeOutputFile = "L0_Stats.txt";
     message = "L0 Stats File                 ";
@@ -557,35 +557,35 @@ ArborTestForOnesProbe "L0 Stats File" = {
     buffer = "Activity";
     nnzThreshold = 0;
 };
-ArborTestProbe "Lx1 Stats File" = {
+ArborTestProbe "Lx1StatsFile" = {
     targetLayer = "Lx1";
     probeOutputFile = "Lx1_Stats.txt";
     message = "Lx1 Stats File                ";
     triggerLayerName = NULL;
     nnzThreshold = 0;
 };
-ArborTestProbe "Lx2 Stats File" = {
+ArborTestProbe "Lx2StatsFile" = {
     targetLayer = "Lx2";
     probeOutputFile = "Lx2_Stats.txt";
     message = "Lx2 Stats File                ";
     triggerLayerName = NULL;
     nnzThreshold = 0;
 };
-ArborTestProbe "Lx4 Stats File" = {
+ArborTestProbe "Lx4StatsFile" = {
     targetLayer = "Lx4";
     probeOutputFile = "Lx4_Stats.txt";
     message = "Lx4 Stats File                ";
     triggerLayerName = NULL;
     nnzThreshold = 0;
 };
-ArborTestProbe "Lx1_2 Stats File" = {
+ArborTestProbe "Lx1_2StatsFile" = {
     targetLayer = "Lx1_2";
     probeOutputFile = "Lx1_2_Stats.txt";
     message = "Lx1_2 Stats File              ";
     triggerLayerName = NULL;
     nnzThreshold = 0;
 };
-ArborTestProbe "Lx1_4 Stats File" = {
+ArborTestProbe "Lx1_4StatsFile" = {
     targetLayer = "Lx1_4";
     probeOutputFile = "Lx1_4_Stats.txt";
     message = "Lx1_4 Stats File              ";
@@ -593,45 +593,45 @@ ArborTestProbe "Lx1_4 Stats File" = {
     nnzThreshold = 0;
 };
 
-ArborTestForOnesProbe "Retina Stats Screen" = {
+ArborTestForOnesProbe "RetinaStatsScreen" = {
     targetLayer = "Retina";
     message = "Retina Stats File             ";
     triggerLayerName = NULL;
     buffer = "Activity";
     nnzThreshold = 0;
 };
-ArborTestForOnesProbe "L0 Stats Screen" = {
+ArborTestForOnesProbe "L0StatsScreen" = {
     targetLayer = "L0";
     message = "L0 Stats Screen               ";
     triggerLayerName = NULL;
     buffer = "Activity";
     nnzThreshold = 0;
 };
-ArborTestProbe "Lx1 Stats Screen" = {
+ArborTestProbe "Lx1StatsScreen" = {
     targetLayer = "Lx1";
     message = "Lx1 Stats Screen              ";
     triggerLayerName = NULL;
     nnzThreshold = 0;
 };
-ArborTestProbe "Lx2 Stats Screen" = {
+ArborTestProbe "Lx2StatsScreen" = {
     targetLayer = "Lx2";
     message = "Lx1 Stats Screen              ";
     triggerLayerName = NULL;
     nnzThreshold = 0;
 };
-ArborTestProbe "Lx4 Stats Screen" = {
+ArborTestProbe "Lx4StatsScreen" = {
     targetLayer = "Lx4";
     message = "Lx4 Stats Screen              ";
     triggerLayerName = NULL;
     nnzThreshold = 0;
 };
-ArborTestProbe "Lx1_2 Stats Screen" = {
+ArborTestProbe "Lx1_2StatsScreen" = {
     targetLayer = "Lx1_2";
     message = "Lx1_2 Stats Screen            ";
     triggerLayerName = NULL;
     nnzThreshold = 0;
 };
-ArborTestProbe "Lx1_4 Stats Screen" = {
+ArborTestProbe "Lx1_4StatsScreen" = {
     targetLayer = "Lx1_4";
     message = "Lx1_4 Stats Screen            ";
     triggerLayerName = NULL;

--- a/tests/BatchCheckpointSystemTest/input/CheckpointParameters1.params
+++ b/tests/BatchCheckpointSystemTest/input/CheckpointParameters1.params
@@ -39,7 +39,7 @@ CPTestInputLayer "input" = {
     dataType                            = NULL;
 };
 
-HyPerLayer "output no delay" = {
+HyPerLayer "OutputNoDelay" = {
     nxScale                             = 1;
     nyScale                             = 1;
     nf                                  = 1;
@@ -55,7 +55,7 @@ HyPerLayer "output no delay" = {
     dataType                            = NULL;
 };
 
-HyPerLayer "output with delay" = {
+HyPerLayer "OutputWithDelay" = {
     nxScale                             = 1;
     nyScale                             = 1;
     nf                                  = 1;
@@ -71,7 +71,7 @@ HyPerLayer "output with delay" = {
     dataType                            = NULL;
 };
 
-HyPerLayer "output arbor" = {
+HyPerLayer "OutputArbor" = {
     nxScale                             = 1;
     nyScale                             = 1;
     nf                                  = 1;
@@ -87,7 +87,7 @@ HyPerLayer "output arbor" = {
     dataType                            = NULL;
 };
 
-HyPerLayer "output from full hyperconn" = {
+HyPerLayer "OutputFromFullHyPerConn" = {
     nxScale                             = 1;
     nyScale                             = 1;
     nf                                  = 1;
@@ -103,9 +103,9 @@ HyPerLayer "output from full hyperconn" = {
     dataType                            = NULL;
 };
 
-VaryingHyPerConn "conn no delay" = {
+VaryingHyPerConn "ConnNoDelay" = {
     preLayerName                        = "input";
-    postLayerName                       = "output no delay";
+    postLayerName                       = "OutputNoDelay";
     channelCode                         = 0;
     delay                               = [0.000000];
     numAxonalArbors                     = 1;
@@ -147,9 +147,9 @@ VaryingHyPerConn "conn no delay" = {
     gpuGroupIdx                         = 0;
 };
 
-VaryingHyPerConn "conn with delay" = {
+VaryingHyPerConn "ConnWithDelay" = {
     preLayerName                        = "input";
-    postLayerName                       = "output with delay";
+    postLayerName                       = "OutputWithDelay";
     channelCode                         = 0;
     delay                               = [2.000000];
     numAxonalArbors                     = 1;
@@ -191,9 +191,9 @@ VaryingHyPerConn "conn with delay" = {
     gpuGroupIdx                         = 0;
 };
 
-HyPerConn "input to output arbor" = {
+HyPerConn "InputToOutputArbor" = {
     preLayerName                        = "input";
-    postLayerName                       = "output arbor";
+    postLayerName                       = "OutputArbor";
     channelCode                         = 0;
     delay                               = [0.000000];
     numAxonalArbors                     = 4;
@@ -233,9 +233,9 @@ HyPerConn "input to output arbor" = {
     gpuGroupIdx                         = 0;
 };
 
-IdentConn "selfconnection for output with delay" = {
-    preLayerName                        = "output with delay";
-    postLayerName                       = "output with delay";
+IdentConn "SelfConnectionForOutputWithDelay" = {
+    preLayerName                        = "OutputWithDelay";
+    postLayerName                       = "OutputWithDelay";
     channelCode                         = 1;
     delay                               = [0.000000];
     receiveGpu                          = false;

--- a/tests/BatchCheckpointSystemTest/input/CheckpointParameters2.params
+++ b/tests/BatchCheckpointSystemTest/input/CheckpointParameters2.params
@@ -40,7 +40,7 @@ CPTestInputLayer "input" = {
     dataType                            = NULL;
 };
 
-HyPerLayer "output no delay" = {
+HyPerLayer "OutputNoDelay" = {
     nxScale                             = 1;
     nyScale                             = 1;
     nf                                  = 1;
@@ -62,7 +62,7 @@ HyPerLayer "output no delay" = {
     VWidth                              = 0;
 };
 
-HyPerLayer "output with delay" = {
+HyPerLayer "OutputWithDelay" = {
     nxScale                             = 1;
     nyScale                             = 1;
     nf                                  = 1;
@@ -79,7 +79,7 @@ HyPerLayer "output with delay" = {
     dataType                            = NULL;
 };
 
-HyPerLayer "output arbor" = {
+HyPerLayer "OutputArbor" = {
     nxScale                             = 1;
     nyScale                             = 1;
     nf                                  = 1;
@@ -96,7 +96,7 @@ HyPerLayer "output arbor" = {
     dataType                            = NULL;
 };
 
-HyPerLayer "output from full hyperconn" = {
+HyPerLayer "OutputFromFullHyPerConn" = {
     nxScale                             = 1;
     nyScale                             = 1;
     nf                                  = 1;
@@ -113,9 +113,9 @@ HyPerLayer "output from full hyperconn" = {
     dataType                            = NULL;
 };
 
-VaryingHyPerConn "conn no delay" = {
+VaryingHyPerConn "ConnNoDelay" = {
     preLayerName                        = "input";
-    postLayerName                       = "output no delay";
+    postLayerName                       = "OutputNoDelay";
     channelCode                         = 0;
     delay                               = [0.000000];
     numAxonalArbors                     = 1;
@@ -157,9 +157,9 @@ VaryingHyPerConn "conn no delay" = {
     gpuGroupIdx                         = 0;
 };
 
-VaryingHyPerConn "conn with delay" = {
+VaryingHyPerConn "ConnWithDelay" = {
     preLayerName                        = "input";
-    postLayerName                       = "output with delay";
+    postLayerName                       = "OutputWithDelay";
     channelCode                         = 0;
     delay                               = [2.000000];
     numAxonalArbors                     = 1;
@@ -201,9 +201,9 @@ VaryingHyPerConn "conn with delay" = {
     gpuGroupIdx                         = 0;
 };
 
-HyPerConn "input to output arbor" = {
+HyPerConn "InputToOutputArbor" = {
     preLayerName                        = "input";
-    postLayerName                       = "output arbor";
+    postLayerName                       = "OutputArbor";
     channelCode                         = 0;
     delay                               = [0.000000];
     numAxonalArbors                     = 4;
@@ -243,9 +243,9 @@ HyPerConn "input to output arbor" = {
     gpuGroupIdx                         = 0;
 };
 
-IdentConn "selfconnection for output with delay" = {
-    preLayerName                        = "output with delay";
-    postLayerName                       = "output with delay";
+IdentConn "SelfConnectionForOutputWithDelay" = {
+    preLayerName                        = "OutputWithDelay";
+    postLayerName                       = "OutputWithDelay";
     channelCode                         = 1;
     delay                               = [0.000000];
     receiveGpu                          = false;

--- a/tests/BatchMPICheckpointSystemTest/input/CheckpointParameters1.params
+++ b/tests/BatchMPICheckpointSystemTest/input/CheckpointParameters1.params
@@ -23,7 +23,7 @@ HyPerCol "column" = {
     nbatch                              = 4;
 };
 
-CPTestInputLayer "input" = {
+CPTestInputLayer "Input" = {
     nxScale                             = 1;
     nyScale                             = 1;
     nf                                  = 1;
@@ -39,7 +39,7 @@ CPTestInputLayer "input" = {
     dataType                            = NULL;
 };
 
-HyPerLayer "output no delay" = {
+HyPerLayer "OutputNoDelay" = {
     nxScale                             = 1;
     nyScale                             = 1;
     nf                                  = 1;
@@ -55,7 +55,7 @@ HyPerLayer "output no delay" = {
     dataType                            = NULL;
 };
 
-HyPerLayer "output with delay" = {
+HyPerLayer "OutputWithDelay" = {
     nxScale                             = 1;
     nyScale                             = 1;
     nf                                  = 1;
@@ -71,7 +71,7 @@ HyPerLayer "output with delay" = {
     dataType                            = NULL;
 };
 
-HyPerLayer "output arbor" = {
+HyPerLayer "OutputArbor" = {
     nxScale                             = 1;
     nyScale                             = 1;
     nf                                  = 1;
@@ -87,7 +87,7 @@ HyPerLayer "output arbor" = {
     dataType                            = NULL;
 };
 
-HyPerLayer "output from full hyperconn" = {
+HyPerLayer "OutputFromFullHyPerConn" = {
     nxScale                             = 1;
     nyScale                             = 1;
     nf                                  = 1;
@@ -103,9 +103,9 @@ HyPerLayer "output from full hyperconn" = {
     dataType                            = NULL;
 };
 
-VaryingHyPerConn "conn no delay" = {
-    preLayerName                        = "input";
-    postLayerName                       = "output no delay";
+VaryingHyPerConn "ConnNoDelay" = {
+    preLayerName                        = "Input";
+    postLayerName                       = "OutputNoDelay";
     channelCode                         = 0;
     delay                               = [0.000000];
     numAxonalArbors                     = 1;
@@ -147,9 +147,9 @@ VaryingHyPerConn "conn no delay" = {
     gpuGroupIdx                         = 0;
 };
 
-VaryingHyPerConn "conn with delay" = {
-    preLayerName                        = "input";
-    postLayerName                       = "output with delay";
+VaryingHyPerConn "ConnWithDelay" = {
+    preLayerName                        = "Input";
+    postLayerName                       = "OutputWithDelay";
     channelCode                         = 0;
     delay                               = [2.000000];
     numAxonalArbors                     = 1;
@@ -191,9 +191,9 @@ VaryingHyPerConn "conn with delay" = {
     gpuGroupIdx                         = 0;
 };
 
-HyPerConn "input to output arbor" = {
-    preLayerName                        = "input";
-    postLayerName                       = "output arbor";
+HyPerConn "InputToOutputArbor" = {
+    preLayerName                        = "Input";
+    postLayerName                       = "OutputArbor";
     channelCode                         = 0;
     delay                               = [0.000000];
     numAxonalArbors                     = 4;
@@ -233,9 +233,9 @@ HyPerConn "input to output arbor" = {
     gpuGroupIdx                         = 0;
 };
 
-IdentConn "selfconnection for output with delay" = {
-    preLayerName                        = "output with delay";
-    postLayerName                       = "output with delay";
+IdentConn "SelfConnectionForOutputWithDelay" = {
+    preLayerName                        = "OutputWithDelay";
+    postLayerName                       = "OutputWithDelay";
     channelCode                         = 1;
     delay                               = [0.000000];
     receiveGpu                          = false;

--- a/tests/BatchMPICheckpointSystemTest/input/CheckpointParameters2.params
+++ b/tests/BatchMPICheckpointSystemTest/input/CheckpointParameters2.params
@@ -23,7 +23,7 @@ HyPerCol "column" = {
     nbatch                              = 4;
 };
 
-CPTestInputLayer "input" = {
+CPTestInputLayer "Input" = {
     nxScale                             = 1;
     nyScale                             = 1;
     nf                                  = 1;
@@ -40,7 +40,7 @@ CPTestInputLayer "input" = {
     dataType                            = NULL;
 };
 
-HyPerLayer "output no delay" = {
+HyPerLayer "OutputNoDelay" = {
     nxScale                             = 1;
     nyScale                             = 1;
     nf                                  = 1;
@@ -57,7 +57,7 @@ HyPerLayer "output no delay" = {
     dataType                            = NULL;
 };
 
-HyPerLayer "output with delay" = {
+HyPerLayer "OutputWithDelay" = {
     nxScale                             = 1;
     nyScale                             = 1;
     nf                                  = 1;
@@ -74,7 +74,7 @@ HyPerLayer "output with delay" = {
     dataType                            = NULL;
 };
 
-HyPerLayer "output arbor" = {
+HyPerLayer "OutputArbor" = {
     nxScale                             = 1;
     nyScale                             = 1;
     nf                                  = 1;
@@ -91,7 +91,7 @@ HyPerLayer "output arbor" = {
     dataType                            = NULL;
 };
 
-HyPerLayer "output from full hyperconn" = {
+HyPerLayer "OutputFromFullHyPerConn" = {
     nxScale                             = 1;
     nyScale                             = 1;
     nf                                  = 1;
@@ -108,9 +108,9 @@ HyPerLayer "output from full hyperconn" = {
     dataType                            = NULL;
 };
 
-VaryingHyPerConn "conn no delay" = {
-    preLayerName                        = "input";
-    postLayerName                       = "output no delay";
+VaryingHyPerConn "ConnNoDelay" = {
+    preLayerName                        = "Input";
+    postLayerName                       = "OutputNoDelay";
     channelCode                         = 0;
     delay                               = [0.000000];
     numAxonalArbors                     = 1;
@@ -152,9 +152,9 @@ VaryingHyPerConn "conn no delay" = {
     gpuGroupIdx                         = 0;
 };
 
-VaryingHyPerConn "conn with delay" = {
-    preLayerName                        = "input";
-    postLayerName                       = "output with delay";
+VaryingHyPerConn "ConnWithDelay" = {
+    preLayerName                        = "Input";
+    postLayerName                       = "OutputWithDelay";
     channelCode                         = 0;
     delay                               = [2.000000];
     numAxonalArbors                     = 1;
@@ -196,9 +196,9 @@ VaryingHyPerConn "conn with delay" = {
     gpuGroupIdx                         = 0;
 };
 
-HyPerConn "input to output arbor" = {
-    preLayerName                        = "input";
-    postLayerName                       = "output arbor";
+HyPerConn "InputToOutputArbor" = {
+    preLayerName                        = "Input";
+    postLayerName                       = "OutputArbor";
     channelCode                         = 0;
     delay                               = [0.000000];
     numAxonalArbors                     = 4;
@@ -238,9 +238,9 @@ HyPerConn "input to output arbor" = {
     gpuGroupIdx                         = 0;
 };
 
-IdentConn "selfconnection for output with delay" = {
-    preLayerName                        = "output with delay";
-    postLayerName                       = "output with delay";
+IdentConn "SelfConnectionForOutputWithDelay" = {
+    preLayerName                        = "OutputWithDelay";
+    postLayerName                       = "OutputWithDelay";
     channelCode                         = 1;
     delay                               = [0.000000];
     receiveGpu                          = false;

--- a/tests/CheckpointSystemTest/input/CheckpointParameters1.params
+++ b/tests/CheckpointSystemTest/input/CheckpointParameters1.params
@@ -38,7 +38,7 @@ CPTestInputLayer "input" = {
     dataType                            = NULL;
 };
 
-HyPerLayer "output no delay" = {
+HyPerLayer "OutputNoDelay" = {
     nxScale                             = 1;
     nyScale                             = 1;
     nf                                  = 1;
@@ -54,7 +54,7 @@ HyPerLayer "output no delay" = {
     dataType                            = NULL;
 };
 
-HyPerLayer "output with delay" = {
+HyPerLayer "OutputWithDelay" = {
     nxScale                             = 1;
     nyScale                             = 1;
     nf                                  = 1;
@@ -70,7 +70,7 @@ HyPerLayer "output with delay" = {
     dataType                            = NULL;
 };
 
-HyPerLayer "output arbor" = {
+HyPerLayer "OutputArbor" = {
     nxScale                             = 1;
     nyScale                             = 1;
     nf                                  = 1;
@@ -86,7 +86,7 @@ HyPerLayer "output arbor" = {
     dataType                            = NULL;
 };
 
-HyPerLayer "output from full hyperconn" = {
+HyPerLayer "OutputFromFullHyPerConn" = {
     nxScale                             = 1;
     nyScale                             = 1;
     nf                                  = 1;
@@ -102,9 +102,9 @@ HyPerLayer "output from full hyperconn" = {
     dataType                            = NULL;
 };
 
-VaryingHyPerConn "conn no delay" = {
+VaryingHyPerConn "ConnNoDelay" = {
     preLayerName                        = "input";
-    postLayerName                       = "output no delay";
+    postLayerName                       = "OutputNoDelay";
     channelCode                         = 0;
     delay                               = [0.000000];
     numAxonalArbors                     = 1;
@@ -146,9 +146,9 @@ VaryingHyPerConn "conn no delay" = {
     gpuGroupIdx                         = 0;
 };
 
-VaryingHyPerConn "conn with delay" = {
+VaryingHyPerConn "ConnWithDelay" = {
     preLayerName                        = "input";
-    postLayerName                       = "output with delay";
+    postLayerName                       = "OutputWithDelay";
     channelCode                         = 0;
     delay                               = [2.000000];
     numAxonalArbors                     = 1;
@@ -190,9 +190,9 @@ VaryingHyPerConn "conn with delay" = {
     gpuGroupIdx                         = 0;
 };
 
-HyPerConn "input to output arbor" = {
+HyPerConn "InputToOutputArbor" = {
     preLayerName                        = "input";
-    postLayerName                       = "output arbor";
+    postLayerName                       = "OutputArbor";
     channelCode                         = 0;
     delay                               = [0.000000];
     numAxonalArbors                     = 4;
@@ -232,9 +232,9 @@ HyPerConn "input to output arbor" = {
     gpuGroupIdx                         = 0;
 };
 
-VaryingHyPerConn "full hyperconn" = {
+VaryingHyPerConn "FullHyPerConn" = {
     preLayerName                        = "input";
-    postLayerName                       = "output from full hyperconn";
+    postLayerName                       = "OutputFromFullHyPerConn";
     channelCode                         = 0;
     delay                               = [0.000000];
     numAxonalArbors                     = 1;
@@ -265,9 +265,9 @@ VaryingHyPerConn "full hyperconn" = {
     gpuGroupIdx                         = 0;
 };
 
-IdentConn "selfconnection for output with delay" = {
-    preLayerName                        = "output with delay";
-    postLayerName                       = "output with delay";
+IdentConn "SelfConnectionForOutputWithDelay" = {
+    preLayerName                        = "OutputWithDelay";
+    postLayerName                       = "OutputWithDelay";
     channelCode                         = 1;
     delay                               = [0.000000];
     receiveGpu                          = false;

--- a/tests/CheckpointSystemTest/input/CheckpointParameters2.params
+++ b/tests/CheckpointSystemTest/input/CheckpointParameters2.params
@@ -38,7 +38,7 @@ CPTestInputLayer "input" = {
     dataType                            = NULL;
 };
 
-HyPerLayer "output no delay" = {
+HyPerLayer "OutputNoDelay" = {
     nxScale                             = 1;
     nyScale                             = 1;
     nf                                  = 1;
@@ -54,7 +54,7 @@ HyPerLayer "output no delay" = {
     dataType                            = NULL;
 };
 
-HyPerLayer "output with delay" = {
+HyPerLayer "OutputWithDelay" = {
     nxScale                             = 1;
     nyScale                             = 1;
     nf                                  = 1;
@@ -70,7 +70,7 @@ HyPerLayer "output with delay" = {
     dataType                            = NULL;
 };
 
-HyPerLayer "output arbor" = {
+HyPerLayer "OutputArbor" = {
     nxScale                             = 1;
     nyScale                             = 1;
     nf                                  = 1;
@@ -86,7 +86,7 @@ HyPerLayer "output arbor" = {
     dataType                            = NULL;
 };
 
-HyPerLayer "output from full hyperconn" = {
+HyPerLayer "OutputFromFullHyPerConn" = {
     nxScale                             = 1;
     nyScale                             = 1;
     nf                                  = 1;
@@ -102,9 +102,9 @@ HyPerLayer "output from full hyperconn" = {
     dataType                            = NULL;
 };
 
-VaryingHyPerConn "conn no delay" = {
+VaryingHyPerConn "ConnNoDelay" = {
     preLayerName                        = "input";
-    postLayerName                       = "output no delay";
+    postLayerName                       = "OutputNoDelay";
     channelCode                         = 0;
     delay                               = [0.000000];
     numAxonalArbors                     = 1;
@@ -146,9 +146,9 @@ VaryingHyPerConn "conn no delay" = {
     gpuGroupIdx                         = 0;
 };
 
-VaryingHyPerConn "conn with delay" = {
+VaryingHyPerConn "ConnWithDelay" = {
     preLayerName                        = "input";
-    postLayerName                       = "output with delay";
+    postLayerName                       = "OutputWithDelay";
     channelCode                         = 0;
     delay                               = [2.000000];
     numAxonalArbors                     = 1;
@@ -190,9 +190,9 @@ VaryingHyPerConn "conn with delay" = {
     gpuGroupIdx                         = 0;
 };
 
-HyPerConn "input to output arbor" = {
+HyPerConn "InputToOutputArbor" = {
     preLayerName                        = "input";
-    postLayerName                       = "output arbor";
+    postLayerName                       = "OutputArbor";
     channelCode                         = 0;
     delay                               = [0.000000];
     numAxonalArbors                     = 4;
@@ -232,9 +232,9 @@ HyPerConn "input to output arbor" = {
     gpuGroupIdx                         = 0;
 };
 
-VaryingHyPerConn "full hyperconn" = {
+VaryingHyPerConn "FullHyPerConn" = {
     preLayerName                        = "input";
-    postLayerName                       = "output from full hyperconn";
+    postLayerName                       = "OutputFromFullHyPerConn";
     channelCode                         = 0;
     delay                               = [0.000000];
     numAxonalArbors                     = 1;
@@ -265,9 +265,9 @@ VaryingHyPerConn "full hyperconn" = {
     gpuGroupIdx                         = 0;
 };
 
-IdentConn "selfconnection for output with delay" = {
-    preLayerName                        = "output with delay";
-    postLayerName                       = "output with delay";
+IdentConn "SelfConnectionForOutputWithDelay" = {
+    preLayerName                        = "OutputWithDelay";
+    postLayerName                       = "OutputWithDelay";
     channelCode                         = 1;
     delay                               = [0.000000];
     receiveGpu                          = false;

--- a/tests/CopyConnTest/input/CopyConnInitializeNonsharedTest.params
+++ b/tests/CopyConnTest/input/CopyConnInitializeNonsharedTest.params
@@ -42,7 +42,7 @@ PvpLayer "Input" = {
 	displayPeriod                       = 0;
 };
 
-ANNLayer "OriginalConn Output" = {
+ANNLayer "OriginalConn_Output" = {
     nxScale                             = 1;
     nyScale                             = 1;
     nf                                  = 8;
@@ -62,7 +62,7 @@ ANNLayer "OriginalConn Output" = {
     VWidth                              = 0;
 };
 
-ANNLayer "CopyConn Output" = {
+ANNLayer "CopyConn_Output" = {
     nxScale                             = 1;
     nyScale                             = 1;
     nf                                  = 8;
@@ -84,7 +84,7 @@ ANNLayer "CopyConn Output" = {
 
 HyPerConn "OriginalConn" = {
     preLayerName                        = "Input";
-    postLayerName                       = "OriginalConn Output";
+    postLayerName                       = "OriginalConn_Output";
     channelCode                         = 0;
     delay                               = [0.000000];
     numAxonalArbors                     = 1;
@@ -121,7 +121,7 @@ HyPerConn "OriginalConn" = {
 
 CopyConn "CopyConn" = {
     preLayerName                        = "Input";
-    postLayerName                       = "CopyConn Output";
+    postLayerName                       = "CopyConn_Output";
     channelCode                         = 0;
     delay                               = [0.000000];
     convertRateToSpikeCount             = false;

--- a/tests/CopyConnTest/input/CopyConnInitializeTest.params
+++ b/tests/CopyConnTest/input/CopyConnInitializeTest.params
@@ -42,7 +42,7 @@ PvpLayer "Input" = {
 	displayPeriod                       = 0;
 };
 
-ANNLayer "OriginalConn Output" = {
+ANNLayer "OriginalConn_Output" = {
     nxScale                             = 1;
     nyScale                             = 1;
     nf                                  = 8;
@@ -62,7 +62,7 @@ ANNLayer "OriginalConn Output" = {
     VWidth                              = 0;
 };
 
-ANNLayer "CopyConn Output" = {
+ANNLayer "CopyConn_Output" = {
     nxScale                             = 1;
     nyScale                             = 1;
     nf                                  = 8;
@@ -84,7 +84,7 @@ ANNLayer "CopyConn Output" = {
 
 HyPerConn "OriginalConn" = {
     preLayerName                        = "Input";
-    postLayerName                       = "OriginalConn Output";
+    postLayerName                       = "OriginalConn_Output";
     channelCode                         = 0;
     delay                               = [0.000000];
     numAxonalArbors                     = 1;
@@ -121,7 +121,7 @@ HyPerConn "OriginalConn" = {
 
 CopyConn "CopyConn" = {
     preLayerName                        = "Input";
-    postLayerName                       = "CopyConn Output";
+    postLayerName                       = "CopyConn_Output";
     channelCode                         = 0;
     delay                               = [0.000000];
     convertRateToSpikeCount             = false;

--- a/tests/CopyConnTest/input/CopyConnPlasticNonsharedTest.params
+++ b/tests/CopyConnTest/input/CopyConnPlasticNonsharedTest.params
@@ -41,7 +41,7 @@ PvpLayer "Input" = {
 	displayPeriod                       = 0;
 };
 
-ANNLayer "OriginalConn Output" = {
+ANNLayer "OriginalConn_Output" = {
     nxScale                             = 1;
     nyScale                             = 1;
     nf                                  = 8;
@@ -62,7 +62,7 @@ ANNLayer "OriginalConn Output" = {
     VWidth                              = 0;
 };
 
-ANNLayer "CopyConn Output" = {
+ANNLayer "CopyConn_Output" = {
     nxScale                             = 1;
     nyScale                             = 1;
     nf                                  = 8;
@@ -85,7 +85,7 @@ ANNLayer "CopyConn Output" = {
 
 HyPerConn "OriginalConn" = {
     preLayerName                        = "Input";
-    postLayerName                       = "OriginalConn Output";
+    postLayerName                       = "OriginalConn_Output";
     channelCode                         = 0;
     delay                               = [0.000000];
     numAxonalArbors                     = 1;
@@ -130,7 +130,7 @@ HyPerConn "OriginalConn" = {
 
 CopyConn "CopyConn" = {
     preLayerName                        = "Input";
-    postLayerName                       = "CopyConn Output";
+    postLayerName                       = "CopyConn_Output";
     channelCode                         = 0;
     delay                               = [0.000000];
     convertRateToSpikeCount             = false;

--- a/tests/CopyConnTest/input/CopyConnPlasticTest.params
+++ b/tests/CopyConnTest/input/CopyConnPlasticTest.params
@@ -42,7 +42,7 @@ PvpLayer "Input" = {
 	displayPeriod                       = 0;
 };
 
-ANNLayer "OriginalConn Output" = {
+ANNLayer "OriginalConn_Output" = {
     nxScale                             = 1;
     nyScale                             = 1;
     nf                                  = 8;
@@ -63,7 +63,7 @@ ANNLayer "OriginalConn Output" = {
     VWidth                              = 0;
 };
 
-ANNLayer "CopyConn Output" = {
+ANNLayer "CopyConn_Output" = {
     nxScale                             = 1;
     nyScale                             = 1;
     nf                                  = 8;
@@ -86,7 +86,7 @@ ANNLayer "CopyConn Output" = {
 
 HyPerConn "OriginalConn" = {
     preLayerName                        = "Input";
-    postLayerName                       = "OriginalConn Output";
+    postLayerName                       = "OriginalConn_Output";
     channelCode                         = 0;
     delay                               = [0.000000];
     numAxonalArbors                     = 1;
@@ -131,7 +131,7 @@ HyPerConn "OriginalConn" = {
 
 CopyConn "CopyConn" = {
     preLayerName                        = "Input";
-    postLayerName                       = "CopyConn Output";
+    postLayerName                       = "CopyConn_Output";
     channelCode                         = 0;
     delay                               = [0.000000];
     convertRateToSpikeCount             = false;

--- a/tests/DelaysToFeaturesTest/input/test_delays.params
+++ b/tests/DelaysToFeaturesTest/input/test_delays.params
@@ -117,7 +117,7 @@ HyPerConn "delayArbor" = {
     convertRateToSpikeCount   = false;
 };
 
-DelayTestProbe "Output Stats File" = {
+DelayTestProbe "Output_Stats_File" = {
     targetLayer = "Output";
     probeOutputFile = "Output_Stats.txt";
     message = "Output Stats File             ";

--- a/tests/InitWeightsTest/input/test_initweights.params
+++ b/tests/InitWeightsTest/input/test_initweights.params
@@ -271,7 +271,7 @@ ANNLayer "L9" = {
 };
 
 // HyPerConn connections: 
-HyPerConn "Retina to L0" = {
+HyPerConn "RetinaToL0" = {
    preLayerName = "Retina";
    postLayerName = "L0";
    numAxonalArbors=1;
@@ -317,7 +317,7 @@ HyPerConn "Retina to L0" = {
    updateGSynFromPostPerspective = false;
 };
 
-HyPerConn "Retina to L1" = {
+HyPerConn "RetinaToL1" = {
    preLayerName = "Retina";
    postLayerName = "L1";
    numAxonalArbors=1;
@@ -365,7 +365,7 @@ HyPerConn "Retina to L1" = {
    updateGSynFromPostPerspective = false;
 };
 
-HyPerConn "Retina to L2" = {
+HyPerConn "RetinaToL2" = {
    preLayerName = "Retina";
    postLayerName = "L2";
    numAxonalArbors=1;
@@ -398,7 +398,7 @@ HyPerConn "Retina to L2" = {
    updateGSynFromPostPerspective = false;
 };
 
-// HyPerConn "Retina to L3" = {
+// HyPerConn "RetinaToL3" = {
 //    preLayerName = "Retina";
 //    postLayerName = "L3";
 //    numAxonalArbors=1;
@@ -454,7 +454,7 @@ HyPerConn "Retina to L2" = {
 
 // };
 // 
-// HyPerConn "Retina to L4" = {
+// HyPerConn "RetinaToL4" = {
 //    preLayerName = "Retina";
 //    postLayerName = "L4";
 //    numAxonalArbors=1;
@@ -509,7 +509,7 @@ HyPerConn "Retina to L2" = {
 // };
 
 // shared-weights connections: 
-HyPerConn "Retina to L5" = {
+HyPerConn "RetinaToL5" = {
    preLayerName = "Retina";
    postLayerName = "L5";
    numAxonalArbors=1;
@@ -554,7 +554,7 @@ HyPerConn "Retina to L5" = {
    updateGSynFromPostPerspective = false;
 };
 
-HyPerConn "Retina to L6" = {
+HyPerConn "RetinaToL6" = {
    preLayerName = "Retina";
    postLayerName = "L6";
    numAxonalArbors=1;
@@ -603,7 +603,7 @@ HyPerConn "Retina to L6" = {
    updateGSynFromPostPerspective = false;
 };
 
-HyPerConn "Retina to L7" = {
+HyPerConn "RetinaToL7" = {
    preLayerName = "Retina";
    postLayerName = "L7";
    numAxonalArbors=1;
@@ -630,7 +630,7 @@ HyPerConn "Retina to L7" = {
    updateGSynFromPostPerspective = false;
 };
 
-HyPerConn "Retina to L8" = {
+HyPerConn "RetinaToL8" = {
    preLayerName = "Retina";
    postLayerName = "L8";
    numAxonalArbors=1;
@@ -682,7 +682,7 @@ HyPerConn "Retina to L8" = {
    updateGSynFromPostPerspective = false;
 };
 
-HyPerConn "Retina to L9" = {
+HyPerConn "RetinaToL9" = {
    preLayerName = "Retina";
    postLayerName = "L9";
    numAxonalArbors=1;
@@ -734,10 +734,10 @@ HyPerConn "Retina to L9" = {
 };
 
 // HyPerConnDebugInitWeights connections: 
-HyPerConnDebugInitWeights "Retina to L0 check" = {
+HyPerConnDebugInitWeights "RetinaToL0Check" = {
    preLayerName = "Retina";
    postLayerName = "L0";
-   copiedConn = "Retina to L0";
+   copiedConn = "RetinaToL0";
    numAxonalArbors=1;
    nxp = 9; 
    nyp = 9; 
@@ -780,10 +780,10 @@ HyPerConnDebugInitWeights "Retina to L0 check" = {
    updateGSynFromPostPerspective = false;
 };
 
-HyPerConnDebugInitWeights "Retina to L1 check" = {
+HyPerConnDebugInitWeights "RetinaToL1Check" = {
    preLayerName = "Retina";
    postLayerName = "L1";
-   copiedConn = "Retina to L1";
+   copiedConn = "RetinaToL1";
    numAxonalArbors=1;
    nxp = 9; 
    nyp = 9; 
@@ -828,10 +828,10 @@ HyPerConnDebugInitWeights "Retina to L1 check" = {
    updateGSynFromPostPerspective = false;
 };
 
-HyPerConnDebugInitWeights "Retina to L2 check" = {
+HyPerConnDebugInitWeights "RetinaToL2Check" = {
    preLayerName = "Retina";
    postLayerName = "L2";
-   copiedConn = "Retina to L2";
+   copiedConn = "RetinaToL2";
    numAxonalArbors=1;
    nxp = 9; 
    nyp = 9; 
@@ -861,10 +861,10 @@ HyPerConnDebugInitWeights "Retina to L2 check" = {
    updateGSynFromPostPerspective = false;
 };
 
-// HyPerConnDebugInitWeights "Retina to L3 check" = {
+// HyPerConnDebugInitWeights "RetinaToL3Check" = {
 //    preLayerName = "Retina";
 //    postLayerName = "L3";
-//    copiedConn = "Retina to L3";
+//    copiedConn = "RetinaToL3";
 //    numAxonalArbors=1;
 //    nxp = 9; 
 //    nyp = 9; 
@@ -913,10 +913,10 @@ HyPerConnDebugInitWeights "Retina to L2 check" = {
 //    updateGSynFromPostPerspective = false;
 // };
 // 
-// HyPerConnDebugInitWeights "Retina to L4 check" = {
+// HyPerConnDebugInitWeights "RetinaToL4Check" = {
 //    preLayerName = "Retina";
 //    postLayerName = "L4";
-//    copiedConn = "Retina to L4";
+//    copiedConn = "RetinaToL4";
 //    numAxonalArbors=1;
 //    nxp = 9; 
 //    nyp = 9; 
@@ -966,10 +966,10 @@ HyPerConnDebugInitWeights "Retina to L2 check" = {
 // };
 
 // KernelConnDebugInitWeights connections: 
-KernelConnDebugInitWeights "Retina to L5 check" = {
+KernelConnDebugInitWeights "RetinaToL5Check" = {
    preLayerName = "Retina";
    postLayerName = "L5";
-   copiedConn = "Retina to L5";
+   copiedConn = "RetinaToL5";
    numAxonalArbors=1;
    nxp = 9; 
    nyp = 9; 
@@ -1010,10 +1010,10 @@ KernelConnDebugInitWeights "Retina to L5 check" = {
    updateGSynFromPostPerspective = false;
 };
 
-KernelConnDebugInitWeights "Retina to L6 check" = {
+KernelConnDebugInitWeights "RetinaToL6Check" = {
    preLayerName = "Retina";
    postLayerName = "L6";
-   copiedConn = "Retina to L6";
+   copiedConn = "RetinaToL6";
    numAxonalArbors=1;
    nxp = 9; 
    nyp = 9; 
@@ -1058,10 +1058,10 @@ KernelConnDebugInitWeights "Retina to L6 check" = {
    updateGSynFromPostPerspective = false;
 };
 
-KernelConnDebugInitWeights "Retina to L7 check" = {
+KernelConnDebugInitWeights "RetinaToL7Check" = {
    preLayerName = "Retina";
    postLayerName = "L7";
-   copiedConn = "Retina to L7";
+   copiedConn = "RetinaToL7";
    numAxonalArbors=1;
    nxp = 9; 
    nyp = 9; 
@@ -1084,10 +1084,10 @@ KernelConnDebugInitWeights "Retina to L7 check" = {
    updateGSynFromPostPerspective = false;
 };
 
-KernelConnDebugInitWeights "Retina to L8 check" = {
+KernelConnDebugInitWeights "RetinaToL8Check" = {
    preLayerName = "Retina";
    postLayerName = "L8";
-   copiedConn = "Retina to L8";
+   copiedConn = "RetinaToL8";
    numAxonalArbors=1;
    nxp = 9; 
    nyp = 9; 
@@ -1127,10 +1127,10 @@ KernelConnDebugInitWeights "Retina to L8 check" = {
    updateGSynFromPostPerspective = false;
 };
 
-KernelConnDebugInitWeights "Retina to L9 check" = {
+KernelConnDebugInitWeights "RetinaToL9Check" = {
    preLayerName = "Retina";
    postLayerName = "L9";
-   copiedConn = "Retina to L9";
+   copiedConn = "RetinaToL9";
    numAxonalArbors=1;
    nxp = 9; 
    nyp = 9; 
@@ -1170,22 +1170,22 @@ KernelConnDebugInitWeights "Retina to L9 check" = {
    updateGSynFromPostPerspective = false;
 };
 
-StatsProbe "Retina Stats File" = {
+StatsProbe "Retina_Stats_File" = {
     targetLayer = "Retina";
     probeOutputFile = "Retina_Stats.txt";
     message = "Retina Stats File      ";
 };
-InitWeightTestProbe "L0 Stats File" = {
+InitWeightTestProbe "L0StatsFile" = {
     targetLayer = "L0";
     probeOutputFile = "L0_Stats.txt";
     message = "L0 Stats File          ";
 };
-InitWeightTestProbe "L1 Stats File" = {
+InitWeightTestProbe "L1StatsFile" = {
     targetLayer = "L1";
     probeOutputFile = "L1_Stats.txt";
     message = "L1 Stats File          ";
 };
-InitWeightTestProbe "L2 Stats File" = {
+InitWeightTestProbe "L2StatsFile" = {
     targetLayer = "L2";
     probeOutputFile = "L2_Stats.txt";
     message = "L2 Stats File          ";
@@ -1200,45 +1200,45 @@ InitWeightTestProbe "L2 Stats File" = {
 //     probeOutputFile = "L4_Stats.txt";
 //     message = "L4 Stats File          ";
 // };
-InitWeightTestProbe "L5 Stats File" = {
+InitWeightTestProbe "L5StatsFile" = {
     targetLayer = "L5";
     probeOutputFile = "L5_Stats.txt";
     message = "L5 Stats File          ";
 };
-InitWeightTestProbe "L6 Stats File" = {
+InitWeightTestProbe "L6StatsFile" = {
     targetLayer = "L6";
     probeOutputFile = "L6_Stats.txt";
     message = "L6 Stats File          ";
 };
-StatsProbe "L7 Stats File" = {
+StatsProbe "L7StatsFile" = {
     targetLayer = "L7";
     probeOutputFile = "L7_Stats.txt";
     message = "L7 Stats File          ";
 };
-InitWeightTestProbe "L8 Stats File" = {
+InitWeightTestProbe "L8StatsFile" = {
     targetLayer = "L8";
     probeOutputFile = "L8_Stats.txt";
     message = "L8 Stats File          ";
 };
-InitWeightTestProbe "L9 Stats File" = {
+InitWeightTestProbe "L9StatsFile" = {
     targetLayer = "L9";
     probeOutputFile = "L9_Stats.txt";
     message = "L9 Stats File          ";
 };
 
-StatsProbe "Retina Stats Screen" = {
+StatsProbe "Retina_Stats_Screen" = {
     targetLayer = "Retina";
     message = "Retina Stats Screen    ";
 };
-InitWeightTestProbe "L0 Stats Screen" = {
+InitWeightTestProbe "L0StatsScreen" = {
     targetLayer = "L0";
     message = "L0 Stats Screen        ";
 };
-InitWeightTestProbe "L1 Stats Screen" = {
+InitWeightTestProbe "L1StatsScreen" = {
     targetLayer = "L1";
     message = "L1 Stats Screen        ";
 };
-InitWeightTestProbe "L2 Stats Screen" = {
+InitWeightTestProbe "L2StatsScreen" = {
     targetLayer = "L2";
     message = "L2 Stats Screen        ";
 };
@@ -1250,23 +1250,23 @@ InitWeightTestProbe "L2 Stats Screen" = {
 //     targetLayer = "L4";
 //     message = "L4 Stats Screen        ";
 // };
-InitWeightTestProbe "L5 Stats Screen" = {
+InitWeightTestProbe "L5StatsScreen" = {
     targetLayer = "L5";
     message = "L5 Stats Screen        ";
 };
-InitWeightTestProbe "L6 Stats Screen" = {
+InitWeightTestProbe "L6StatsScreen" = {
     targetLayer = "L6";
     message = "L6 Stats Screen        ";
 };
-StatsProbe "L7 Stats Screen" = {
+StatsProbe "L7StatsScreen" = {
     targetLayer = "L7";
     message = "L7 Stats Screen        ";
 };
-InitWeightTestProbe "L8 Stats Screen" = {
+InitWeightTestProbe "L8StatsScreen" = {
     targetLayer = "L8";
     message = "L8 Stats Screen        ";
 };
-InitWeightTestProbe "L9 Stats Screen" = {
+InitWeightTestProbe "L9StatsScreen" = {
     targetLayer = "L9";
     message = "L9 Stats Screen        ";
 };

--- a/tests/InputSystemTest/input/ImageLayerSystemTest.params
+++ b/tests/InputSystemTest/input/ImageLayerSystemTest.params
@@ -191,7 +191,7 @@ IdentConn "correctoutput_to_comparison" = {
     writeStep                        = -1;
 };
 
-RequireAllZeroActivityProbe "comparison probe" = {
+RequireAllZeroActivityProbe "comparison_probe" = {
     targetLayer = "comparison";
     message = "comparison                    ";
     probeOutputFile = NULL;

--- a/tests/InputSystemTest/input/PvpLayerSystemTest.params
+++ b/tests/InputSystemTest/input/PvpLayerSystemTest.params
@@ -188,7 +188,7 @@ IdentConn "correctoutput_to_comparison" = {
     writeStep                        = -1;
 };
 
-RequireAllZeroActivityProbe "comparison probe" = {
+RequireAllZeroActivityProbe "comparison_probe" = {
     targetLayer = "comparison";
     message = "comparison                    ";
     probeOutputFile = NULL;

--- a/tests/KernelTest/input/test_kernel.params
+++ b/tests/KernelTest/input/test_kernel.params
@@ -192,7 +192,7 @@ ANNLayer "Lx1_4" = {
 
 //  connections: 
 
-HyPerConn "Retina to L0" = {
+HyPerConn "RetinaToL0" = {
     preLayerName = "Retina";
     postLayerName = "L0";
     channelCode = 0;
@@ -230,7 +230,7 @@ HyPerConn "Retina to L0" = {
     updateGSynFromPostPerspective = false;
 };
 
-HyPerConn "L0 to Lx1" = {
+HyPerConn "L0ToLx1" = {
     preLayerName = "L0";
     postLayerName = "Lx1";
     channelCode = 0;
@@ -269,7 +269,7 @@ HyPerConn "L0 to Lx1" = {
     updateGSynFromPostPerspective = false;
 };
 
-HyPerConn "L0 to Lx2" = {
+HyPerConn "L0ToLx2" = {
     preLayerName = "L0";
     postLayerName = "Lx2";
     channelCode = 0;
@@ -314,7 +314,7 @@ HyPerConn "L0 to Lx2" = {
     updateGSynFromPostPerspective = false;
 };
 
-HyPerConn "L0 to Lx4" = {
+HyPerConn "L0ToLx4" = {
     preLayerName = "L0";
     postLayerName = "Lx4";
     channelCode = 0;
@@ -359,7 +359,7 @@ HyPerConn "L0 to Lx4" = {
     updateGSynFromPostPerspective = false;
 };
 
-HyPerConn "L0 to Lx1_2" = {
+HyPerConn "L0ToLx1_2" = {
     preLayerName = "L0";
     postLayerName = "Lx1_2";
     channelCode = 0;
@@ -404,7 +404,7 @@ HyPerConn "L0 to Lx1_2" = {
     updateGSynFromPostPerspective = false;
 };
 
-HyPerConn "L0 to Lx1_4" = {
+HyPerConn "L0ToLx1_4" = {
     preLayerName = "L0";
     postLayerName = "Lx1_4";
     channelCode = 0;
@@ -448,67 +448,67 @@ HyPerConn "L0 to Lx1_4" = {
     updateGSynFromPostPerspective = false;
 };
 
-KernelTestProbe "Retina Stats File" = {
+KernelTestProbe "RetinaStatsFile" = {
     targetLayer = "Retina";
     probeOutputFile = "Retina_Stats.txt";
     message = "Retina Stats File      ";
 };
-KernelTestProbe "L0 Stats File" = {
+KernelTestProbe "L0StatsFile" = {
     targetLayer = "L0";
     probeOutputFile = "L0_Stats.txt";
     message = "L0 Stats File          ";
 };
-KernelTestProbe "Lx1 Stats File" = {
+KernelTestProbe "Lx1StatsFile" = {
     targetLayer = "Lx1";
     probeOutputFile = "Lx1_Stats.txt";
     message = "Lx1 Stats File         ";
 };
-KernelTestProbe "Lx2 Stats File" = {
+KernelTestProbe "Lx2StatsFile" = {
     targetLayer = "Lx2";
     probeOutputFile = "Lx2_Stats.txt";
     message = "Lx2 Stats File         ";
 };
-KernelTestProbe "Lx4 Stats File" = {
+KernelTestProbe "Lx4StatsFile" = {
     targetLayer = "Lx4";
     probeOutputFile = "Lx4_Stats.txt";
     message = "Lx4 Stats File         ";
 };
-KernelTestProbe "Lx1_2 Stats File" = {
+KernelTestProbe "Lx1_2StatsFile" = {
     targetLayer = "Lx1_2";
     probeOutputFile = "Lx1_2_Stats.txt";
     message = "Lx1_2 Stats File       ";
 };
-KernelTestProbe "Lx1_4 Stats File" = {
+KernelTestProbe "Lx1_4StatsFile" = {
     targetLayer = "Lx1_4";
     probeOutputFile = "Lx1_4_Stats.txt";
     message = "Lx1_4 Stats File       ";
 };
 
-KernelTestProbe "Retina Stats Screen" = {
+KernelTestProbe "RetinaStatsScreen" = {
     targetLayer = "Retina";
     message = "Retina Stats Screen    ";
 };
-KernelTestProbe "L0 Stats Screen" = {
+KernelTestProbe "L0StatsScreen" = {
     targetLayer = "L0";
     message = "L0 Stats Screen        ";
 };
-KernelTestProbe "Lx1 Stats Screen" = {
+KernelTestProbe "Lx1StatsScreen" = {
     targetLayer = "Lx1";
     message = "Lx1 Stats Screen       ";
 };
-KernelTestProbe "Lx2 Stats Screen" = {
+KernelTestProbe "Lx2StatsScreen" = {
     targetLayer = "Lx2";
     message = "Lx2 Stats Screen       ";
 };
-KernelTestProbe "Lx4 Stats Screen" = {
+KernelTestProbe "Lx4StatsScreen" = {
     targetLayer = "Lx4";
     message = "Lx4 Stats Screen       ";
 };
-KernelTestProbe "Lx1_2 Stats Screen" = {
+KernelTestProbe "Lx1_2StatsScreen" = {
     targetLayer = "Lx1_2";
     message = "Lx1_2 Stats Screen     ";
 };
-KernelTestProbe "Lx1_4 Stats Screen" = {
+KernelTestProbe "Lx1_4StatsScreen" = {
     targetLayer = "Lx1_4";
     message = "Lx1_4 Stats Screen     ";
 };

--- a/tests/KernelTest/input/test_kernel_normalizepost.params
+++ b/tests/KernelTest/input/test_kernel_normalizepost.params
@@ -195,7 +195,7 @@ ANNLayer "Lx1_4" = {
 
 //  connections: 
 
-HyPerConn "Retina to L0" = {
+HyPerConn "RetinaToL0" = {
     preLayerName = "Retina";
     postLayerName = "L0";
     channelCode = 0;
@@ -233,7 +233,7 @@ HyPerConn "Retina to L0" = {
     updateGSynFromPostPerspective = false;
 };
 
-HyPerConn "L0 to Lx1" = {
+HyPerConn "L0ToLx1" = {
     preLayerName = "L0";
     postLayerName = "Lx1";
     channelCode = 0;
@@ -272,7 +272,7 @@ HyPerConn "L0 to Lx1" = {
     updateGSynFromPostPerspective = false;
 };
 
-HyPerConn "L0 to Lx2" = {
+HyPerConn "L0ToLx2" = {
     preLayerName = "L0";
     postLayerName = "Lx2";
     channelCode = 0;
@@ -317,7 +317,7 @@ HyPerConn "L0 to Lx2" = {
     updateGSynFromPostPerspective = false;
 };
 
-HyPerConn "L0 to Lx4" = {
+HyPerConn "L0ToLx4" = {
     preLayerName = "L0";
     postLayerName = "Lx4";
     channelCode = 0;
@@ -362,7 +362,7 @@ HyPerConn "L0 to Lx4" = {
     updateGSynFromPostPerspective = false;
 };
 
-HyPerConn "L0 to Lx1_2" = {
+HyPerConn "L0ToLx1_2" = {
     preLayerName = "L0";
     postLayerName = "Lx1_2";
     channelCode = 0;
@@ -407,7 +407,7 @@ HyPerConn "L0 to Lx1_2" = {
     updateGSynFromPostPerspective = false;
 };
 
-HyPerConn "L0 to Lx1_4" = {
+HyPerConn "L0ToLx1_4" = {
     preLayerName = "L0";
     postLayerName = "Lx1_4";
     channelCode = 0;
@@ -451,67 +451,67 @@ HyPerConn "L0 to Lx1_4" = {
     updateGSynFromPostPerspective = false;
 };
 
-KernelTestProbe "Retina Stats File" = {
+KernelTestProbe "RetinaStatsFile" = {
     targetLayer = "Retina";
     probeOutputFile = "Retina_Stats.txt";
     message = "Retina Stats File      ";
 };
-KernelTestProbe "L0 Stats File" = {
+KernelTestProbe "L0StatsFile" = {
     targetLayer = "L0";
     probeOutputFile = "L0_Stats.txt";
     message = "L0 Stats File          ";
 };
-KernelTestProbe "Lx1 Stats File" = {
+KernelTestProbe "Lx1StatsFile" = {
     targetLayer = "Lx1";
     probeOutputFile = "Lx1_Stats.txt";
     message = "Lx1 Stats File         ";
 };
-KernelTestProbe "Lx2 Stats File" = {
+KernelTestProbe "Lx2StatsFile" = {
     targetLayer = "Lx2";
     probeOutputFile = "Lx2_Stats.txt";
     message = "Lx2 Stats File         ";
 };
-KernelTestProbe "Lx4 Stats File" = {
+KernelTestProbe "Lx4StatsFile" = {
     targetLayer = "Lx4";
     probeOutputFile = "Lx4_Stats.txt";
     message = "Lx4 Stats File         ";
 };
-KernelTestProbe "Lx1_2 Stats File" = {
+KernelTestProbe "Lx1_2StatsFile" = {
     targetLayer = "Lx1_2";
     probeOutputFile = "Lx1_2_Stats.txt";
     message = "Lx1_2 Stats File       ";
 };
-KernelTestProbe "Lx1_4 Stats File" = {
+KernelTestProbe "Lx1_4StatsFile" = {
     targetLayer = "Lx1_4";
     probeOutputFile = "Lx1_4_Stats.txt";
     message = "Lx1_4 Stats File       ";
 };
 
-KernelTestProbe "Retina Stats Screen" = {
+KernelTestProbe "RetinaStatsScreen" = {
     targetLayer = "Retina";
     message = "Retina Stats Screen    ";
 };
-KernelTestProbe "L0 Stats Screen" = {
+KernelTestProbe "L0StatsScreen" = {
     targetLayer = "L0";
     message = "L0 Stats Screen        ";
 };
-KernelTestProbe "Lx1 Stats Screen" = {
+KernelTestProbe "Lx1StatsScreen" = {
     targetLayer = "Lx1";
     message = "Lx1 Stats Screen       ";
 };
-KernelTestProbe "Lx2 Stats Screen" = {
+KernelTestProbe "Lx2StatsScreen" = {
     targetLayer = "Lx2";
     message = "Lx2 Stats Screen       ";
 };
-KernelTestProbe "Lx4 Stats Screen" = {
+KernelTestProbe "Lx4StatsScreen" = {
     targetLayer = "Lx4";
     message = "Lx4 Stats Screen       ";
 };
-KernelTestProbe "Lx1_2 Stats Screen" = {
+KernelTestProbe "Lx1_2StatsScreen" = {
     targetLayer = "Lx1_2";
     message = "Lx1_2 Stats Screen     ";
 };
-KernelTestProbe "Lx1_4 Stats Screen" = {
+KernelTestProbe "Lx1_4StatsScreen" = {
     targetLayer = "Lx1_4";
     message = "Lx1_4 Stats Screen     ";
 };

--- a/tests/KernelTest/input/test_kernel_normalizepost_shrunken.params
+++ b/tests/KernelTest/input/test_kernel_normalizepost_shrunken.params
@@ -199,7 +199,7 @@ ANNLayer "Lx1_4" = {
 
 //  connections: 
 
-HyPerConn "Retina to L0" = {
+HyPerConn "RetinaToL0" = {
     preLayerName = "Retina";
     postLayerName = "L0";
     channelCode = 0;
@@ -238,7 +238,7 @@ HyPerConn "Retina to L0" = {
     updateGSynFromPostPerspective = false;
 };
 
-HyPerConn "L0 to Lx1" = {
+HyPerConn "L0ToLx1" = {
     preLayerName = "L0";
     postLayerName = "Lx1";
     channelCode = 0;
@@ -277,7 +277,7 @@ HyPerConn "L0 to Lx1" = {
     updateGSynFromPostPerspective = false;
 };
 
-HyPerConn "L0 to Lx2" = {
+HyPerConn "L0ToLx2" = {
     preLayerName = "L0";
     postLayerName = "Lx2";
     channelCode = 0;
@@ -316,7 +316,7 @@ HyPerConn "L0 to Lx2" = {
     updateGSynFromPostPerspective = false;
 };
 
-HyPerConn "L0 to Lx4" = {
+HyPerConn "L0ToLx4" = {
     preLayerName = "L0";
     postLayerName = "Lx4";
     channelCode = 0;
@@ -355,7 +355,7 @@ HyPerConn "L0 to Lx4" = {
     updateGSynFromPostPerspective = false;
 };
 
-HyPerConn "L0 to Lx1_2" = {
+HyPerConn "L0ToLx1_2" = {
     preLayerName = "L0";
     postLayerName = "Lx1_2";
     channelCode = 0;
@@ -394,7 +394,7 @@ HyPerConn "L0 to Lx1_2" = {
     updateGSynFromPostPerspective = false;
 };
 
-HyPerConn "L0 to Lx1_4" = {
+HyPerConn "L0ToLx1_4" = {
     preLayerName = "L0";
     postLayerName = "Lx1_4";
     channelCode = 0;
@@ -433,49 +433,49 @@ HyPerConn "L0 to Lx1_4" = {
     updateGSynFromPostPerspective = false;
 };
 
-KernelTestProbe "Retina Stats File" = {
+KernelTestProbe "RetinaStatsFile" = {
     targetLayer = "Retina";
     probeOutputFile = "Retina_Stats.txt";
     message = "Retina Stats File      ";
     triggerLayerName = NULL;
     nnzThreshold = 0;
 };
-KernelTestProbe "L0 Stats File" = {
+KernelTestProbe "L0StatsFile" = {
     targetLayer = "L0";
     probeOutputFile = "L0_Stats.txt";
     message = "L0 Stats File          ";
     triggerLayerName = NULL;
     nnzThreshold = 0;
 };
-KernelTestProbe "Lx1 Stats File" = {
+KernelTestProbe "Lx1StatsFile" = {
     targetLayer = "Lx1";
     probeOutputFile = "Lx1_Stats.txt";
     message = "Lx1 Stats File         ";
     triggerLayerName = NULL;
     nnzThreshold = 0;
 };
-KernelTestProbe "Lx2 Stats File" = {
+KernelTestProbe "Lx2StatsFile" = {
     targetLayer = "Lx2";
     probeOutputFile = "Lx2_Stats.txt";
     message = "Lx2 Stats File         ";
     triggerLayerName = NULL;
     nnzThreshold = 0;
 };
-KernelTestProbe "Lx4 Stats File" = {
+KernelTestProbe "Lx4StatsFile" = {
     targetLayer = "Lx4";
     probeOutputFile = "Lx4_Stats.txt";
     message = "Lx4 Stats File         ";
     triggerLayerName = NULL;
     nnzThreshold = 0;
 };
-KernelTestProbe "Lx1_2 Stats File" = {
+KernelTestProbe "Lx1_2StatsFile" = {
     targetLayer = "Lx1_2";
     probeOutputFile = "Lx1_2_Stats.txt";
     message = "Lx1_2 Stats File       ";
     triggerLayerName = NULL;
     nnzThreshold = 0;
 };
-KernelTestProbe "Lx1_4 Stats File" = {
+KernelTestProbe "Lx1_4StatsFile" = {
     targetLayer = "Lx1_4";
     probeOutputFile = "Lx1_4_Stats.txt";
     message = "Lx1_4 Stats File       ";
@@ -483,43 +483,43 @@ KernelTestProbe "Lx1_4 Stats File" = {
     nnzThreshold = 0;
 };
 
-KernelTestProbe "Retina Stats Screen" = {
+KernelTestProbe "RetinaStatsScreen" = {
     targetLayer = "Retina";
     message = "Retina Stats Screen    ";
     triggerLayerName = NULL;
     nnzThreshold = 0;
 };
-KernelTestProbe "L0 Stats Screen" = {
+KernelTestProbe "L0StatsScreen" = {
     targetLayer = "L0";
     message = "L0 Stats Screen        ";
     triggerLayerName = NULL;
     nnzThreshold = 0;
 };
-KernelTestProbe "Lx1 Stats Screen" = {
+KernelTestProbe "Lx1StatsScreen" = {
     targetLayer = "Lx1";
     message = "Lx1 Stats Screen       ";
     triggerLayerName = NULL;
     nnzThreshold = 0;
 };
-KernelTestProbe "Lx2 Stats Screen" = {
+KernelTestProbe "Lx2StatsScreen" = {
     targetLayer = "Lx2";
     message = "Lx2 Stats Screen       ";
     triggerLayerName = NULL;
     nnzThreshold = 0;
 };
-KernelTestProbe "Lx4 Stats Screen" = {
+KernelTestProbe "Lx4StatsScreen" = {
     targetLayer = "Lx4";
     message = "Lx4 Stats Screen       ";
     triggerLayerName = NULL;
     nnzThreshold = 0;
 };
-KernelTestProbe "Lx1_2 Stats Screen" = {
+KernelTestProbe "Lx1_2StatsScreen" = {
     targetLayer = "Lx1_2";
     message = "Lx1_2 Stats Screen     ";
     triggerLayerName = NULL;
     nnzThreshold = 0;
 };
-KernelTestProbe "Lx1_4 Stats Screen" = {
+KernelTestProbe "Lx1_4StatsScreen" = {
     targetLayer = "Lx1_4";
     message = "Lx1_4 Stats Screen     ";
     triggerLayerName = NULL;

--- a/tests/MPITest/input/MPI_test.params
+++ b/tests/MPITest/input/MPI_test.params
@@ -156,7 +156,7 @@ ANNLayer "Lx1_4" = {
 
 
 
-HyPerConn "L0 to Lx1" = {
+HyPerConn "L0ToLx1" = {
     preLayerName = "L0";
     postLayerName = "Lx1";
     channelCode = 0;
@@ -202,7 +202,7 @@ HyPerConn "L0 to Lx1" = {
 };
 
 
-HyPerConn "L0 to Lx2" = {
+HyPerConn "L0ToLx2" = {
     preLayerName = "L0";
     postLayerName = "Lx2";
     channelCode = 0;
@@ -248,7 +248,7 @@ HyPerConn "L0 to Lx2" = {
 };
 
 
-HyPerConn "L0 to Lx4" = {
+HyPerConn "L0ToLx4" = {
     preLayerName = "L0";
     postLayerName = "Lx4";
     channelCode = 0;
@@ -294,7 +294,7 @@ HyPerConn "L0 to Lx4" = {
 };
 
 
-HyPerConn "L0 to Lx1_2" = {
+HyPerConn "L0ToLx1_2" = {
     preLayerName = "L0";
     postLayerName = "Lx1_2";
     channelCode = 0;
@@ -340,7 +340,7 @@ HyPerConn "L0 to Lx1_2" = {
 };
 
 
-HyPerConn "L0 to Lx1_4" = {
+HyPerConn "L0ToLx1_4" = {
     preLayerName = "L0";
     postLayerName = "Lx1_4";
     channelCode = 0;

--- a/tests/NormalizeSubclassSystemTest/input/NormalizeSubclassSystemTest.params
+++ b/tests/NormalizeSubclassSystemTest/input/NormalizeSubclassSystemTest.params
@@ -58,7 +58,7 @@ Retina "input" = {
    absRefractoryPeriod = 0;
 };
 
-ANNLayer "normalizeL3 output" = {
+ANNLayer "NormalizeL3Output" = {
    nxScale = 1;
    nyScale = 1;
    nf = 4;
@@ -77,7 +77,7 @@ ANNLayer "normalizeL3 output" = {
    VWidth = 0.0;
 };
 
-PtwiseProductLayer "output squared" = {
+PtwiseProductLayer "OutputSquared" = {
    nxScale = 1;
    nyScale = 1;
    nf = 4;
@@ -96,7 +96,7 @@ PtwiseProductLayer "output squared" = {
    VWidth = 0.0;
 };
 
-PtwiseProductLayer "output cubed" = {
+PtwiseProductLayer "OutputCubed" = {
    nxScale = 1;
    nyScale = 1;
    nf = 4;
@@ -115,7 +115,7 @@ PtwiseProductLayer "output cubed" = {
    VWidth = 0.0;
 };
 
-ANNLayer "normalizeL3 check" = {
+ANNLayer "NormalizeL3Check" = {
    nxScale = 0.0625;
    nyScale = 0.0625;
    nf = 1;
@@ -138,9 +138,9 @@ ANNLayer "normalizeL3 check" = {
 // Connections
 //
 
-HyPerConn "normalizeL3 connection" = {
+HyPerConn "NormalizeL3Connection" = {
    preLayerName = "input";
-   postLayerName = "normalizeL3 output";
+   postLayerName = "NormalizeL3Output";
    channelCode = 0;
    numAxonalArbors = 1;
    delay = 0;
@@ -181,37 +181,37 @@ HyPerConn "normalizeL3 connection" = {
    minL3NormTolerated = 0;
 };
 
-IdentConn "normalizeL3 output to output squared on channel 0" = {
-   preLayerName = "normalizeL3 output";
-   postLayerName = "output squared";
+IdentConn "NormalizeL3OutputToOutputSquaredOnChannel0" = {
+   preLayerName = "NormalizeL3Output";
+   postLayerName = "OutputSquared";
    channelCode = 0;
    delay = 0;
 };
 
-IdentConn "normalizeL3 output to output squared on channel 1" = {
-   preLayerName = "normalizeL3 output";
-   postLayerName = "output squared";
+IdentConn "NormalizeL3OutputToOutputSquaredOnChannel1" = {
+   preLayerName = "NormalizeL3Output";
+   postLayerName = "OutputSquared";
    channelCode = 1;
    delay = 1;
 };
 
-IdentConn "normalizeL3 output to output cubed" = {
-   preLayerName = "normalizeL3 output";
-   postLayerName = "output cubed";
+IdentConn "NormalizeL3OutputToOutputCubed" = {
+   preLayerName = "NormalizeL3Output";
+   postLayerName = "OutputCubed";
    channelCode = 0;
    delay = 0;
 };
 
-IdentConn "output squared to output cubed" = {
-   preLayerName = "output squared";
-   postLayerName = "output cubed";
+IdentConn "OutputSquaredToOutputCubed" = {
+   preLayerName = "OutputSquared";
+   postLayerName = "OutputCubed";
    channelCode = 1;
    delay = 1;
 };
 
-HyPerConn "normalizeL3 check connection" = {
-   preLayerName = "output cubed";
-   postLayerName = "normalizeL3 check";
+HyPerConn "NormalizeL3CheckConnection" = {
+   preLayerName = "OutputCubed";
+   postLayerName = "NormalizeL3Check";
    channelCode = 0;
    numAxonalArbors = 1;
    delay = 0;

--- a/tests/NormalizeSubclassSystemTest/src/NormalizeSubclassSystemTest.cpp
+++ b/tests/NormalizeSubclassSystemTest/src/NormalizeSubclassSystemTest.cpp
@@ -22,16 +22,21 @@ int customexit(HyPerCol *hc, int argc, char *argv[]) {
    float tol = 1e-5;
 
    BaseConnection *baseConn;
-   baseConn                   = hc->getConnFromName("normalizeL3 connection");
+   baseConn                   = hc->getConnFromName("NormalizeL3Connection");
    HyPerConn *normalizeL3Conn = dynamic_cast<HyPerConn *>(baseConn);
-   FatalIf(!(normalizeL3Conn), "Test failed.\n");
+   FatalIf(normalizeL3Conn == nullptr, "Connection \"NormalizeL3Connection\" does not exist.\n");
    NormalizeBase *normalizeL3Normalizer = normalizeL3Conn->getNormalizer();
-   FatalIf(!(normalizeL3Normalizer), "Test failed.\n");
+   FatalIf(normalizeL3Normalizer == nullptr, "NormalizeL3Connection has no normalizer.\n");
    float normalizeL3Strength    = normalizeL3Normalizer->getStrength();
    float correctValue           = powf(normalizeL3Strength, 3.0f);
-   HyPerLayer *normalizeL3Check = hc->getLayerFromName("normalizeL3 check");
-   float normalizeL3Value       = normalizeL3Check->getLayerData()[0];
-   FatalIf(!(fabsf(normalizeL3Value - correctValue) < tol), "Test failed.\n");
+   HyPerLayer *normalizeL3Check = hc->getLayerFromName("NormalizeL3Check");
+   FatalIf(normalizeL3Check == nullptr, "Layer \"NormalizeL3Check\" does not exist.\n");
+   float normalizeL3Value = normalizeL3Check->getLayerData()[0];
+   FatalIf(
+         fabsf(normalizeL3Value - correctValue) >= tol,
+         "Result %f differs from %f by more than allowed tolerance.\n",
+         (double)normalizeL3Value,
+         (double)correctValue);
 
    return PV_SUCCESS;
 }

--- a/tests/PlasticTransposeConnTest/input/PlasticTransposeConnTest.params
+++ b/tests/PlasticTransposeConnTest/input/PlasticTransposeConnTest.params
@@ -41,7 +41,7 @@ HyPerCol "column" = {
 // layers
 //
 
-PvpLayer "pre" = {
+PvpLayer "Pre" = {
     // nxScale is set in parameter sweep
     // nyScale is set in parameter sweep
     // imagePath is set in parameter sweep
@@ -60,7 +60,7 @@ PvpLayer "pre" = {
 	displayPeriod = 0;
 };
 
-PvpLayer "post" = {
+PvpLayer "Post" = {
     // nxScale is set in parameter sweep
     // nyScale is set in parameter sweep
     // imagePath is set in parameter sweep
@@ -79,7 +79,7 @@ PvpLayer "post" = {
 	displayPeriod = 0;
 };
 
-ANNLayer "comparison" = {
+ANNLayer "Comparison" = {
     // nxScale is set in parameter sweep
     // nyScale is set in parameter sweep
     nf = 3;
@@ -99,9 +99,9 @@ ANNLayer "comparison" = {
     VWidth = 0.0;
 };
 
-HyPerConn "original map" = {
-    preLayerName = "pre";
-    postLayerName = "post";
+HyPerConn "OriginalMap" = {
+    preLayerName = "Pre";
+    postLayerName = "Post";
     channelCode = -1; // This connection does not modify post.
 
     // nxp is set in parameter sweep
@@ -146,12 +146,12 @@ HyPerConn "original map" = {
     updateGSynFromPostPerspective = false;
 };
 
-TransposeConn "transpose" = {
-    preLayerName = "post";
-    postLayerName = "pre";
+TransposeConn "Transpose" = {
+    preLayerName = "Post";
+    postLayerName = "Pre";
     channelCode = -1;
     delay = 0;
-    originalConnName = "original map";
+    originalConnName = "OriginalMap";
     updateGSynFromPostPerspective = false;
     pvpatchAccumulateType = "convolve";
     convertRateToSpikeCount = false;
@@ -161,12 +161,12 @@ TransposeConn "transpose" = {
     writeCompressedWeights = false;
 };
 
-TransposeConn "transpose of transpose" = {
-    preLayerName = "pre";
-    postLayerName = "comparison";
+TransposeConn "TransposeOfTranspose" = {
+    preLayerName = "Pre";
+    postLayerName = "Comparison";
     channelCode = 0;
     delay = 0;
-    originalConnName = "transpose";
+    originalConnName = "Transpose";
     updateGSynFromPostPerspective = false;
     pvpatchAccumulateType = "convolve";
     convertRateToSpikeCount = false;
@@ -176,12 +176,12 @@ TransposeConn "transpose of transpose" = {
     writeCompressedWeights = false;
 };
 
-CloneConn "clone of original" = {
-    preLayerName = "pre";
-    postLayerName = "comparison";
+CloneConn "CloneOfOriginal" = {
+    preLayerName = "Pre";
+    postLayerName = "Comparison";
     channelCode = 1;
     delay = 0;
-    originalConnName = "original map";
+    originalConnName = "OriginalMap";
     updateGSynFromPostPerspective = false;
     pvpatchAccumulateType = "convolve";
     convertRateToSpikeCount = false;
@@ -189,8 +189,8 @@ CloneConn "clone of original" = {
     writeCompressedCheckpoints = false;
 };
 
-RequireAllZeroActivityProbe "probe" = {
-    targetLayer = "comparison";
+RequireAllZeroActivityProbe "Probe" = {
+    targetLayer = "Comparison";
     triggerLayerName = NULL;
     nnzThreshold = 5.0e-4;
 };
@@ -213,15 +213,15 @@ ParameterSweep "column":lastCheckpointDir = {
     "output/sharedWeightsOn_OneToMany/Last";
 };
 
-ParameterSweep "pre":nxScale = {
+ParameterSweep "Pre":nxScale = {
     1; 1; 2; 2; 1; 1;
 };
 
-ParameterSweep "pre":nyScale = {
+ParameterSweep "Pre":nyScale = {
     1; 1; 2; 2; 1; 1;
 };
 
-ParameterSweep "pre":inputPath= {
+ParameterSweep "Pre":inputPath= {
     "input/8x8image.pvp";
     "input/8x8image.pvp";
     "input/16x16image.pvp";
@@ -230,15 +230,15 @@ ParameterSweep "pre":inputPath= {
     "input/8x8image.pvp";
 };
 
-ParameterSweep "post":nxScale = {
+ParameterSweep "Post":nxScale = {
     1; 1; 1; 1; 2; 2;
 };
 
-ParameterSweep "post":nyScale = {
+ParameterSweep "Post":nyScale = {
     1; 1; 1; 1; 2; 2;
 };
 
-ParameterSweep "post":inputPath= {
+ParameterSweep "Post":inputPath= {
     "input/8x8image.pvp";
     "input/8x8image.pvp";
     "input/8x8image.pvp";
@@ -247,22 +247,22 @@ ParameterSweep "post":inputPath= {
     "input/16x16image.pvp";
 };
 
-ParameterSweep "comparison":nxScale = {
+ParameterSweep "Comparison":nxScale = {
     1; 1; 1; 1; 2; 2;
 };
 
-ParameterSweep "comparison":nyScale = {
+ParameterSweep "Comparison":nyScale = {
     1; 1; 1; 1; 2; 2;
 };
 
-ParameterSweep "original map":nxp = {
+ParameterSweep "OriginalMap":nxp = {
     7; 7; 7; 7; 14; 14;
 };
 
-ParameterSweep "original map":nyp = {
+ParameterSweep "OriginalMap":nyp = {
     7; 7; 7; 7; 14; 14;
 };
 
-ParameterSweep "original map":sharedWeights = {
+ParameterSweep "OriginalMap":sharedWeights = {
     false; true; false; true; false; true;
 };

--- a/tests/TransposeConnTest/input/TransposeConnTest.params
+++ b/tests/TransposeConnTest/input/TransposeConnTest.params
@@ -1,6 +1,6 @@
 // TransposeConnTest.params
 
-debugParsing = false;
+debugParsing = true;
 
 HyPerCol "column" = {
     nx                                  = 32;
@@ -26,7 +26,7 @@ HyPerCol "column" = {
     errorOnNotANumber                   = false;
 };
 
-ANNLayer "Layer A" = {
+ANNLayer "LayerA" = {
     nxScale                             = 1;
     nyScale                             = 1;
     nf                                  = 4;
@@ -50,7 +50,7 @@ ANNLayer "Layer A" = {
     VWidth                              = 0.0;
 };
 
-ANNLayer "Layer B One to One" = {
+ANNLayer "LayerB_OneToOne" = {
     nxScale                             = 1;
     nyScale                             = 1;
     nf                                  = 4;
@@ -74,7 +74,7 @@ ANNLayer "Layer B One to One" = {
     VWidth                              = 0.0;
 };
 
-ANNLayer "Layer B Many to One" = {
+ANNLayer "LayerB_ManyToOne" = {
     nxScale                             = 0.25;
     nyScale                             = 0.25;
     nf                                  = 8;
@@ -98,7 +98,7 @@ ANNLayer "Layer B Many to One" = {
     VWidth                              = 0.0;
 };
 
-ANNLayer "Layer B One to Many" = {
+ANNLayer "LayerB_OneToMany" = {
     nxScale                             = 4;
     nyScale                             = 4;
     nf                                  = 2;
@@ -122,9 +122,9 @@ ANNLayer "Layer B One to Many" = {
     VWidth                              = 0.0;
 };
 
-HyPerConn "Original Map for One to One Test" = {
-    preLayerName                        = "Layer A";
-    postLayerName                       = "Layer B One to One";
+HyPerConn "OriginalMapForOneToOneTest" = {
+    preLayerName                        = "LayerA";
+    postLayerName                       = "LayerB_OneToOne";
     channelCode                         = 0;
     sharedWeights                       = true;
     nxp                                 = 7;
@@ -162,11 +162,11 @@ HyPerConn "Original Map for One to One Test" = {
     
 };
 
-TransposeConn "Transpose for One to One Test of TransposeConn" = {
-    preLayerName                        = "Layer B One to One";
-    postLayerName                       = "Layer A";
+TransposeConn "TransposeForOneToOneTestOfTransposeConn" = {
+    preLayerName                        = "LayerB_OneToOne";
+    postLayerName                       = "LayerA";
     channelCode                         = 0;
-    originalConnName                    = "Original Map for One to One Test";
+    originalConnName                    = "OriginalMapForOneToOneTest";
     delay                               = 0;
     updateGSynFromPostPerspective       = false;
     pvpatchAccumulateType               = "convolve";
@@ -176,11 +176,11 @@ TransposeConn "Transpose for One to One Test of TransposeConn" = {
     selfFlag                            = false;
 };
 
-TransposeConn "Transpose of Transpose for One to One Test of TransposeConn" = {
-    preLayerName                        = "Layer A";
-    postLayerName                       = "Layer B One to One";
+TransposeConn "TransposeOfTransposeForOneToOneTestOfTransposeConn" = {
+    preLayerName                        = "LayerA";
+    postLayerName                       = "LayerB_OneToOne";
     channelCode                         = 1;
-    originalConnName                    = "Transpose for One to One Test of TransposeConn";
+    originalConnName                    = "TransposeForOneToOneTestOfTransposeConn";
     delay                               = 0;
     updateGSynFromPostPerspective       = false;
     pvpatchAccumulateType               = "convolve";
@@ -190,9 +190,9 @@ TransposeConn "Transpose of Transpose for One to One Test of TransposeConn" = {
     selfFlag                            = false;
 };
 
-FeedbackConn "Transpose for One to One Test of FeedbackConn" = {
+FeedbackConn "TransposeForOneToOneTestOfFeedbackConn" = {
     channelCode                         = 0;
-    originalConnName                    = "Original Map for One to One Test";
+    originalConnName                    = "OriginalMapForOneToOneTest";
     delay                               = 0;
     updateGSynFromPostPerspective       = false;
     pvpatchAccumulateType               = "convolve";
@@ -202,9 +202,9 @@ FeedbackConn "Transpose for One to One Test of FeedbackConn" = {
     selfFlag                            = false;
 };
 
-FeedbackConn "Transpose of Transpose for One to One Test of FeedbackConn" = {
+FeedbackConn "TransposeOfTransposeForOneToOneTestOfFeedbackConn" = {
     channelCode                         = 1;
-    originalConnName                    = "Transpose for One to One Test of FeedbackConn";
+    originalConnName                    = "TransposeForOneToOneTestOfFeedbackConn";
     delay                               = 0;
     updateGSynFromPostPerspective       = false;
     pvpatchAccumulateType               = "convolve";
@@ -214,9 +214,9 @@ FeedbackConn "Transpose of Transpose for One to One Test of FeedbackConn" = {
     selfFlag                            = false;
 };
 
-HyPerConn "Original Map for Many to One Test" = {
-    preLayerName                        = "Layer A";
-    postLayerName                       = "Layer B Many to One";
+HyPerConn "OriginalMapForManyToOneTest" = {
+    preLayerName                        = "LayerA";
+    postLayerName                       = "LayerB_ManyToOne";
     channelCode                         = 0;
     sharedWeights                       = true;
     nxp                                 = 7;
@@ -253,11 +253,11 @@ HyPerConn "Original Map for Many to One Test" = {
     minSumTolerated                     = 0.0;    
 };
 
-TransposeConn "Transpose for Many to One Test of TransposeConn" = {
-    preLayerName                        = "Layer B Many to One";
-    postLayerName                       = "Layer A";
+TransposeConn "TransposeForManyToOneTestOfTransposeConn" = {
+    preLayerName                        = "LayerB_ManyToOne";
+    postLayerName                       = "LayerA";
     channelCode                         = 0;
-    originalConnName                    = "Original Map for Many to One Test";
+    originalConnName                    = "OriginalMapForManyToOneTest";
     delay                               = 0;
     updateGSynFromPostPerspective       = false;
     pvpatchAccumulateType               = "convolve";
@@ -267,11 +267,11 @@ TransposeConn "Transpose for Many to One Test of TransposeConn" = {
     selfFlag                            = false;
 };
 
-TransposeConn "Transpose of Transpose for Many to One Test of TransposeConn" = {
-    preLayerName                        = "Layer A";
-    postLayerName                       = "Layer B Many to One";
+TransposeConn "TransposeOfTransposeForManyToOneTestOfTransposeConn" = {
+    preLayerName                        = "LayerA";
+    postLayerName                       = "LayerB_ManyToOne";
     channelCode                         = 1;
-    originalConnName                    = "Transpose for Many to One Test of TransposeConn";
+    originalConnName                    = "TransposeForManyToOneTestOfTransposeConn";
     delay                               = 0;
     updateGSynFromPostPerspective       = false;
     pvpatchAccumulateType               = "convolve";
@@ -281,9 +281,9 @@ TransposeConn "Transpose of Transpose for Many to One Test of TransposeConn" = {
     selfFlag                            = false;
 };
 
-FeedbackConn "Transpose for Many to One Test of FeedbackConn" = {
+FeedbackConn "TransposeForManyToOneTestOfFeedbackConn" = {
     channelCode                         = 0;
-    originalConnName                    = "Original Map for Many to One Test";
+    originalConnName                    = "OriginalMapForManyToOneTest";
     delay                               = 0;
     updateGSynFromPostPerspective       = false;
     pvpatchAccumulateType               = "convolve";
@@ -293,9 +293,9 @@ FeedbackConn "Transpose for Many to One Test of FeedbackConn" = {
     selfFlag                            = false;
 };
 
-FeedbackConn "Transpose of Transpose for Many to One Test of FeedbackConn" = {
+FeedbackConn "TransposeOfTransposeForManyToOneTestOfFeedbackConn" = {
     channelCode                         = 1;
-    originalConnName                    = "Transpose for Many to One Test of FeedbackConn";
+    originalConnName                    = "TransposeForManyToOneTestOfFeedbackConn";
     delay                               = 0;
     updateGSynFromPostPerspective       = false;
     pvpatchAccumulateType               = "convolve";
@@ -305,9 +305,9 @@ FeedbackConn "Transpose of Transpose for Many to One Test of FeedbackConn" = {
     selfFlag                            = false;
 };
 
-HyPerConn "Original Map for One to Many Test" = {
-    preLayerName                        = "Layer A";
-    postLayerName                       = "Layer B One to Many";
+HyPerConn "OriginalMapForOneToManyTest" = {
+    preLayerName                        = "LayerA";
+    postLayerName                       = "LayerB_OneToMany";
     channelCode                         = 0;
     sharedWeights                       = true;
     nxp                                 = 28;
@@ -344,11 +344,11 @@ HyPerConn "Original Map for One to Many Test" = {
     minSumTolerated                     = 0.0;    
 };
 
-TransposeConn "Transpose for One to Many Test of TransposeConn" = {
-    preLayerName                        = "Layer B One to Many";
-    postLayerName                       = "Layer A";
+TransposeConn "TransposeForOneToManyTestOfTransposeConn" = {
+    preLayerName                        = "LayerB_OneToMany";
+    postLayerName                       = "LayerA";
     channelCode                         = 0;
-    originalConnName                    = "Original Map for One to Many Test";
+    originalConnName                    = "OriginalMapForOneToManyTest";
     delay                               = 0;
     updateGSynFromPostPerspective       = false;
     pvpatchAccumulateType               = "convolve";
@@ -358,11 +358,11 @@ TransposeConn "Transpose for One to Many Test of TransposeConn" = {
     selfFlag                            = false;
 };
 
-TransposeConn "Transpose of Transpose for One to Many Test of TransposeConn" = {
-    preLayerName                        = "Layer A";
-    postLayerName                       = "Layer B One to Many";
+TransposeConn "TransposeOfTransposeForOneToManyTestOfTransposeConn" = {
+    preLayerName                        = "LayerA";
+    postLayerName                       = "LayerB_OneToMany";
     channelCode                         = 1;
-    originalConnName                    = "Transpose for One to Many Test of TransposeConn";
+    originalConnName                    = "TransposeForOneToManyTestOfTransposeConn";
     delay                               = 0;
     updateGSynFromPostPerspective       = false;
     pvpatchAccumulateType               = "convolve";
@@ -372,9 +372,9 @@ TransposeConn "Transpose of Transpose for One to Many Test of TransposeConn" = {
     selfFlag                            = false;
 };
 
-FeedbackConn "Transpose for One to Many Test of FeedbackConn" = {
+FeedbackConn "TransposeForOneToManyTestOfFeedbackConn" = {
     channelCode                         = 0;
-    originalConnName                    = "Original Map for One to Many Test";
+    originalConnName                    = "OriginalMapForOneToManyTest";
     delay                               = 0;
     updateGSynFromPostPerspective       = false;
     pvpatchAccumulateType               = "convolve";
@@ -384,9 +384,9 @@ FeedbackConn "Transpose for One to Many Test of FeedbackConn" = {
     selfFlag                            = false;
 };
 
-FeedbackConn "Transpose of Transpose for One to Many Test of FeedbackConn" = {
+FeedbackConn "TransposeOfTransposeForOneToManyTestOfFeedbackConn" = {
     channelCode                         = 1;
-    originalConnName                    = "Transpose for One to Many Test of FeedbackConn";
+    originalConnName                    = "TransposeForOneToManyTestOfFeedbackConn";
     delay                               = 0;
     updateGSynFromPostPerspective       = false;
     pvpatchAccumulateType               = "convolve";

--- a/tests/TransposeConnTest/src/TransposeConnTest.cpp
+++ b/tests/TransposeConnTest/src/TransposeConnTest.cpp
@@ -21,6 +21,11 @@
 
 using namespace PV;
 
+int testTransposeConn(
+      HyPerCol *hc,
+      char const *originalName,
+      char const *transposeName,
+      char const *transposeOfTransposeName);
 int testTransposeOfTransposeWeights(
       HyPerConn *originalMap,
       TransposeConn *transpose,
@@ -74,112 +79,65 @@ int main(int argc, char *argv[]) {
 
    int status = PV_SUCCESS;
 
-   HyPerConn *originalMap              = NULL;
-   TransposeConn *transpose            = NULL;
-   TransposeConn *transposeOfTranspose = NULL;
-
-   BaseConnection *baseConn;
-   baseConn    = hc->getConnFromName("Original Map for One to One Test");
-   originalMap = dynamic_cast<HyPerConn *>(baseConn);
-   FatalIf(!(originalMap->usingSharedWeights()), "Test failed.\n");
-   transpose = dynamic_cast<TransposeConn *>(
-         hc->getConnFromName("Transpose for One to One Test of TransposeConn"));
-   transposeOfTranspose = dynamic_cast<TransposeConn *>(
-         hc->getConnFromName("Transpose of Transpose for One to One Test of TransposeConn"));
-   status = testTransposeOfTransposeWeights(
-         originalMap, transpose, transposeOfTranspose, "One-to-one case, TransposeConn");
-
-   baseConn    = hc->getConnFromName("Original Map for Many to One Test");
-   originalMap = dynamic_cast<HyPerConn *>(baseConn);
-   FatalIf(!(originalMap->usingSharedWeights()), "Test failed.\n");
-   transpose = dynamic_cast<TransposeConn *>(
-         hc->getConnFromName("Transpose for Many to One Test of TransposeConn"));
-   transposeOfTranspose = dynamic_cast<TransposeConn *>(
-         hc->getConnFromName("Transpose of Transpose for Many to One Test of TransposeConn"));
-   status = testTransposeOfTransposeWeights(
-         originalMap, transpose, transposeOfTranspose, "Many-to-one case, TransposeConn");
-
-   baseConn    = hc->getConnFromName("Original Map for One to Many Test");
-   originalMap = dynamic_cast<HyPerConn *>(baseConn);
-   FatalIf(!(originalMap->usingSharedWeights()), "Test failed.\n");
-   transpose = dynamic_cast<TransposeConn *>(
-         hc->getConnFromName("Transpose for One to Many Test of TransposeConn"));
-   transposeOfTranspose = dynamic_cast<TransposeConn *>(
-         hc->getConnFromName("Transpose of Transpose for One to Many Test of TransposeConn"));
-   status = testTransposeOfTransposeWeights(
-         originalMap, transpose, transposeOfTranspose, "One-to-many case, TransposeConn");
-
-   baseConn    = hc->getConnFromName("Original Map for One to One Test");
-   originalMap = dynamic_cast<HyPerConn *>(baseConn);
-   FatalIf(!(originalMap->usingSharedWeights()), "Test failed.\n");
-   transpose = dynamic_cast<TransposeConn *>(
-         hc->getConnFromName("Transpose for One to One Test of FeedbackConn"));
-   transposeOfTranspose = dynamic_cast<TransposeConn *>(
-         hc->getConnFromName("Transpose of Transpose for One to One Test of FeedbackConn"));
-   status = testTransposeOfTransposeWeights(
-         originalMap, transpose, transposeOfTranspose, "One-to-one case, FeedbackConn");
-
-   baseConn    = hc->getConnFromName("Original Map for Many to One Test");
-   originalMap = dynamic_cast<HyPerConn *>(baseConn);
-   FatalIf(!(originalMap->usingSharedWeights()), "Test failed.\n");
-   transpose = dynamic_cast<TransposeConn *>(
-         hc->getConnFromName("Transpose for Many to One Test of FeedbackConn"));
-   transposeOfTranspose = dynamic_cast<TransposeConn *>(
-         hc->getConnFromName("Transpose of Transpose for Many to One Test of FeedbackConn"));
-   status = testTransposeOfTransposeWeights(
-         originalMap, transpose, transposeOfTranspose, "Many-to-one case, FeedbackConn");
-
-   baseConn    = hc->getConnFromName("Original Map for One to Many Test");
-   originalMap = dynamic_cast<HyPerConn *>(baseConn);
-   FatalIf(!(originalMap->usingSharedWeights()), "Test failed.\n");
-   transpose = dynamic_cast<TransposeConn *>(
-         hc->getConnFromName("Transpose for One to Many Test of FeedbackConn"));
-   transposeOfTranspose = dynamic_cast<TransposeConn *>(
-         hc->getConnFromName("Transpose of Transpose for One to Many Test of FeedbackConn"));
-   status = testTransposeOfTransposeWeights(
-         originalMap, transpose, transposeOfTranspose, "One-to-many case, FeedbackConn");
+   status = testTransposeConn(
+         hc,
+         "OriginalMapForOneToOneTest",
+         "TransposeForOneToOneTestOfTransposeConn",
+         "TransposeOfTransposeForOneToOneTestOfTransposeConn");
+   status = testTransposeConn(
+         hc,
+         "OriginalMapForManyToOneTest",
+         "TransposeForManyToOneTestOfTransposeConn",
+         "TransposeOfTransposeForManyToOneTestOfTransposeConn");
+   status = testTransposeConn(
+         hc,
+         "OriginalMapForOneToManyTest",
+         "TransposeForOneToManyTestOfTransposeConn",
+         "TransposeOfTransposeForOneToManyTestOfTransposeConn");
+   status = testTransposeConn(
+         hc,
+         "OriginalMapForOneToOneTest",
+         "TransposeForOneToOneTestOfFeedbackConn",
+         "TransposeOfTransposeForOneToOneTestOfFeedbackConn");
+   status = testTransposeConn(
+         hc,
+         "OriginalMapForManyToOneTest",
+         "TransposeForManyToOneTestOfFeedbackConn",
+         "TransposeOfTransposeForManyToOneTestOfFeedbackConn");
+   status = testTransposeConn(
+         hc,
+         "OriginalMapForOneToManyTest",
+         "TransposeForOneToManyTestOfFeedbackConn",
+         "TransposeOfTransposeForOneToManyTestOfFeedbackConn");
 
    delete hc;
    delete initObj;
    return status;
 }
 
-// int manyToOneForTransposeConn(int argc, char * argv[]) {
-//   HyPerCol * hc = new HyPerCol("column", argc, argv);
-//   // Layers
-//   const char * layerAname = "Layer A";
-//   const char * layerB1to1name = "Layer B One to one";
-//   const char * layerB_ManyTo1Name = "Layer B Many to one";
-//   const char * layerB1toManyName = "Layer B One to many";
-//   const char * originalConnName = "Many to one original map";
-//   const char * transposeConnName = "Many to one transpose";
-//   const char * transposeOfTransposeConnName = "Many to one double transpose";
-//
-//   ANNLayer * layerA = new ANNLayer(layerAname, hc);
-//   FatalIf(!(layerA), "Test failed.\n");
-//   ANNLayer * layerB_ManyTo1 = new ANNLayer(layerB_ManyTo1Name, hc);
-//   FatalIf(!(layerB_ManyTo1), "Test failed.\n");
-//   new ANNLayer(layerB1to1name, hc); // This layer and the next are unused in this test, but get
-//   created anyway
-//   new ANNLayer(layerB1toManyName, hc); // to cause the params to be read, so we don't get
-//   unused-parameter warnings.
-//
-//   // Connections
-//   HyPerConn * originalMapManyto1 = new HyPerConn(originalConnName, hc);
-//   FatalIf(!(originalMapManyto1), "Test failed.\n");
-//   TransposeConn * transposeManyto1 = new TransposeConn(transposeConnName, hc);
-//   FatalIf(!(transposeManyto1), "Test failed.\n");
-//   TransposeConn * transposeOfTransposeManyto1 = new TransposeConn(transposeOfTransposeConnName,
-//   hc);
-//   FatalIf(!(transposeOfTransposeManyto1), "Test failed.\n");
-//
-//   hc->run(); // Weight values are initialized when run calls allocateDataStructures
-//
-//   int status = testTransposeOfTransposeWeights(originalMapManyto1, transposeManyto1,
-//   transposeOfTransposeManyto1, "Many-to-one case, TransposeConn");
-//   delete hc;
-//   return status;
-//}
+int testTransposeConn(
+      HyPerCol *hc,
+      char const *originalName,
+      char const *transposeName,
+      char const *transposeOfTransposeName) {
+   HyPerConn *originalMap = dynamic_cast<HyPerConn *>(hc->getConnFromName(originalName));
+   FatalIf(!originalMap, "Connection \"%s\" does not exist.\n", originalName);
+   FatalIf(
+         !originalMap->usingSharedWeights(),
+         "%s does not use shared weights, but this test requires shared weights to be on.\n",
+         originalMap->getDescription_c());
+
+   TransposeConn *transpose = dynamic_cast<TransposeConn *>(hc->getConnFromName(transposeName));
+   FatalIf(!transpose, "Connection \"%s\" does not exist.\n", transposeName);
+
+   TransposeConn *transposeOfTranspose =
+         dynamic_cast<TransposeConn *>(hc->getConnFromName(transposeOfTransposeName));
+   FatalIf(!transposeOfTranspose, "Connection \"%s\" does not exist.\n", transposeOfTransposeName);
+
+   int status = testTransposeOfTransposeWeights(
+         originalMap, transpose, transposeOfTranspose, "One-to-one case, TransposeConn");
+   return status;
+}
 
 int testTransposeOfTransposeWeights(
       HyPerConn *originalMap,
@@ -194,7 +152,7 @@ int testTransposeOfTransposeWeights(
       dumpWeights(originalMap);
       dumpWeights(transpose);
       dumpWeights(transposeOfTranspose);
-      ErrorLog().printf("%s: TestTransposeConn failed.\n", message);
+      Fatal().printf("%s: TestTransposeConn failed.\n", message);
    }
    return status;
 }

--- a/tests/TransposeHyPerConnTest/input/TransposeHyPerConnTest.params
+++ b/tests/TransposeHyPerConnTest/input/TransposeHyPerConnTest.params
@@ -25,7 +25,7 @@ HyPerCol "column" = {
     errorOnNotANumber                   = false;
 };
 
-ANNLayer "Layer A" = {
+ANNLayer "LayerA" = {
     nxScale                             = 1;
     nyScale                             = 1;
     nf                                  = 4;
@@ -49,7 +49,7 @@ ANNLayer "Layer A" = {
     VWidth                              = 0.0;
 };
 
-ANNLayer "Layer B One to One" = {
+ANNLayer "LayerB_OneToOne" = {
     nxScale                             = 1;
     nyScale                             = 1;
     nf                                  = 4;
@@ -73,7 +73,7 @@ ANNLayer "Layer B One to One" = {
     VWidth                              = 0.0;
 };
 
-ANNLayer "Layer B Many to One" = {
+ANNLayer "LayerB_ManyToOne" = {
     nxScale                             = 0.25;
     nyScale                             = 0.25;
     nf                                  = 8;
@@ -97,7 +97,7 @@ ANNLayer "Layer B Many to One" = {
     VWidth                              = 0.0;
 };
 
-ANNLayer "Layer B One to Many" = {
+ANNLayer "LayerB_OneToMany" = {
     nxScale                             = 4;
     nyScale                             = 4;
     nf                                  = 2;
@@ -121,9 +121,9 @@ ANNLayer "Layer B One to Many" = {
     VWidth                              = 0.0;
 };
 
-HyPerConn "Original Map for One to One Test" = {
-    preLayerName                        = "Layer A";
-    postLayerName                       = "Layer B One to One";
+HyPerConn "OriginalMapForOneToOneTest" = {
+    preLayerName                        = "LayerA";
+    postLayerName                       = "LayerB_OneToOne";
     channelCode                         = 0;
     sharedWeights                       = false;
     nxp                                 = 7;
@@ -160,11 +160,11 @@ HyPerConn "Original Map for One to One Test" = {
     minSumTolerated                     = 0.0;  
 };
 
-TransposeConn "Transpose for One to One Test of TransposeConn" = {
-    preLayerName                        = "Layer B One to One";
-    postLayerName                       = "Layer A";
+TransposeConn "TransposeForOneToOneTestOfTransposeConn" = {
+    preLayerName                        = "LayerB_OneToOne";
+    postLayerName                       = "LayerA";
     channelCode                         = 0;
-    originalConnName                    = "Original Map for One to One Test";
+    originalConnName                    = "OriginalMapForOneToOneTest";
     delay                               = 0;
     updateGSynFromPostPerspective       = false;
     pvpatchAccumulateType               = "convolve";
@@ -174,11 +174,11 @@ TransposeConn "Transpose for One to One Test of TransposeConn" = {
     selfFlag                            = false;
 };
 
-TransposeConn "Transpose of Transpose for One to One Test of TransposeConn" = {
-    preLayerName                        = "Layer A";
-    postLayerName                       = "Layer B One to One";
+TransposeConn "TransposeOfTransposeForOneToOneTestOfTransposeConn" = {
+    preLayerName                        = "LayerA";
+    postLayerName                       = "LayerB_OneToOne";
     channelCode                         = 1;
-    originalConnName                    = "Transpose for One to One Test of TransposeConn";
+    originalConnName                    = "TransposeForOneToOneTestOfTransposeConn";
     delay                               = 0;
     updateGSynFromPostPerspective       = false;
     pvpatchAccumulateType               = "convolve";
@@ -188,9 +188,9 @@ TransposeConn "Transpose of Transpose for One to One Test of TransposeConn" = {
     selfFlag                            = false;
 };
 
-FeedbackConn "Transpose for One to One Test of FeedbackConn" = {
+FeedbackConn "TransposeForOneToOneTestOfFeedbackConn" = {
     channelCode                         = 0;
-    originalConnName                    = "Original Map for One to One Test";
+    originalConnName                    = "OriginalMapForOneToOneTest";
     delay                               = 0;
     updateGSynFromPostPerspective       = false;
     pvpatchAccumulateType               = "convolve";
@@ -200,9 +200,9 @@ FeedbackConn "Transpose for One to One Test of FeedbackConn" = {
     selfFlag                            = false;
 };
 
-FeedbackConn "Transpose of Transpose for One to One Test of FeedbackConn" = {
+FeedbackConn "TransposeOfTransposeForOneToOneTestOfFeedbackConn" = {
     channelCode                         = 1;
-    originalConnName                    = "Transpose for One to One Test of FeedbackConn";
+    originalConnName                    = "TransposeForOneToOneTestOfFeedbackConn";
     delay                               = 0;
     updateGSynFromPostPerspective       = false;
     pvpatchAccumulateType               = "convolve";
@@ -212,9 +212,9 @@ FeedbackConn "Transpose of Transpose for One to One Test of FeedbackConn" = {
     selfFlag                            = false;
 };
 
-HyPerConn "Original Map for Many to One Test" = {
-    preLayerName                        = "Layer A";
-    postLayerName                       = "Layer B Many to One";
+HyPerConn "OriginalMapForManyToOneTest" = {
+    preLayerName                        = "LayerA";
+    postLayerName                       = "LayerB_ManyToOne";
     channelCode                         = 0;
     sharedWeights                       = false;
     nxp                                 = 7;
@@ -251,11 +251,11 @@ HyPerConn "Original Map for Many to One Test" = {
     minSumTolerated                     = 0.0;  
 };
 
-TransposeConn "Transpose for Many to One Test of TransposeConn" = {
-    preLayerName                        = "Layer B Many to One";
-    postLayerName                       = "Layer A";
+TransposeConn "TransposeForManyToOneTestOfTransposeConn" = {
+    preLayerName                        = "LayerB_ManyToOne";
+    postLayerName                       = "LayerA";
     channelCode                         = 0;
-    originalConnName                    = "Original Map for Many to One Test";
+    originalConnName                    = "OriginalMapForManyToOneTest";
     delay                               = 0;
     updateGSynFromPostPerspective       = false;
     pvpatchAccumulateType               = "convolve";
@@ -265,11 +265,11 @@ TransposeConn "Transpose for Many to One Test of TransposeConn" = {
     selfFlag                            = false;
 };
 
-TransposeConn "Transpose of Transpose for Many to One Test of TransposeConn" = {
-    preLayerName                        = "Layer A";
-    postLayerName                       = "Layer B Many to One";
+TransposeConn "TransposeOfTransposeForManyToOneTestOfTransposeConn" = {
+    preLayerName                        = "LayerA";
+    postLayerName                       = "LayerB_ManyToOne";
     channelCode                         = 1;
-    originalConnName                    = "Transpose for Many to One Test of TransposeConn";
+    originalConnName                    = "TransposeForManyToOneTestOfTransposeConn";
     delay                               = 0;
     updateGSynFromPostPerspective       = false;
     pvpatchAccumulateType               = "convolve";
@@ -279,9 +279,9 @@ TransposeConn "Transpose of Transpose for Many to One Test of TransposeConn" = {
     selfFlag                            = false;
 };
 
-FeedbackConn "Transpose for Many to One Test of FeedbackConn" = {
+FeedbackConn "TransposeForManyToOneTestOfFeedbackConn" = {
     channelCode                         = 0;
-    originalConnName                    = "Original Map for Many to One Test";
+    originalConnName                    = "OriginalMapForManyToOneTest";
     delay                               = 0;
     updateGSynFromPostPerspective       = false;
     pvpatchAccumulateType               = "convolve";
@@ -291,9 +291,9 @@ FeedbackConn "Transpose for Many to One Test of FeedbackConn" = {
     selfFlag                            = false;
 };
 
-FeedbackConn "Transpose of Transpose for Many to One Test of FeedbackConn" = {
+FeedbackConn "TransposeOfTransposeForManyToOneTestOfFeedbackConn" = {
     channelCode                         = 1;
-    originalConnName                    = "Transpose for Many to One Test of FeedbackConn";
+    originalConnName                    = "TransposeForManyToOneTestOfFeedbackConn";
     delay                               = 0;
     updateGSynFromPostPerspective       = false;
     pvpatchAccumulateType               = "convolve";
@@ -303,9 +303,9 @@ FeedbackConn "Transpose of Transpose for Many to One Test of FeedbackConn" = {
     selfFlag                            = false;
 };
 
-HyPerConn "Original Map for One to Many Test" = {
-    preLayerName                        = "Layer A";
-    postLayerName                       = "Layer B One to Many";
+HyPerConn "OriginalMapForOneToManyTest" = {
+    preLayerName                        = "LayerA";
+    postLayerName                       = "LayerB_OneToMany";
     channelCode                         = 0;
     sharedWeights                       = false;
     nxp                                 = 28;
@@ -342,11 +342,11 @@ HyPerConn "Original Map for One to Many Test" = {
     minSumTolerated                     = 0.0;  
 };
 
-TransposeConn "Transpose for One to Many Test of TransposeConn" = {
-    preLayerName                        = "Layer B One to Many";
-    postLayerName                       = "Layer A";
+TransposeConn "TransposeForOneToManyTestOfTransposeConn" = {
+    preLayerName                        = "LayerB_OneToMany";
+    postLayerName                       = "LayerA";
     channelCode                         = 0;
-    originalConnName                    = "Original Map for One to Many Test";
+    originalConnName                    = "OriginalMapForOneToManyTest";
     delay                               = 0;
     updateGSynFromPostPerspective       = false;
     pvpatchAccumulateType               = "convolve";
@@ -356,11 +356,11 @@ TransposeConn "Transpose for One to Many Test of TransposeConn" = {
     selfFlag                            = false;
 };
 
-TransposeConn "Transpose of Transpose for One to Many Test of TransposeConn" = {
-    preLayerName                        = "Layer A";
-    postLayerName                       = "Layer B One to Many";
+TransposeConn "TransposeOfTransposeForOneToManyTestOfTransposeConn" = {
+    preLayerName                        = "LayerA";
+    postLayerName                       = "LayerB_OneToMany";
     channelCode                         = 1;
-    originalConnName                    = "Transpose for One to Many Test of TransposeConn";
+    originalConnName                    = "TransposeForOneToManyTestOfTransposeConn";
     delay                               = 0;
     updateGSynFromPostPerspective       = false;
     pvpatchAccumulateType               = "convolve";
@@ -370,9 +370,9 @@ TransposeConn "Transpose of Transpose for One to Many Test of TransposeConn" = {
     selfFlag                            = false;
 };
 
-FeedbackConn "Transpose for One to Many Test of FeedbackConn" = {
+FeedbackConn "TransposeForOneToManyTestOfFeedbackConn" = {
     channelCode                         = 0;
-    originalConnName                    = "Original Map for One to Many Test";
+    originalConnName                    = "OriginalMapForOneToManyTest";
     delay                               = 0;
     updateGSynFromPostPerspective       = false;
     pvpatchAccumulateType               = "convolve";
@@ -382,9 +382,9 @@ FeedbackConn "Transpose for One to Many Test of FeedbackConn" = {
     selfFlag                            = false;
 };
 
-FeedbackConn "Transpose of Transpose for One to Many Test of FeedbackConn" = {
+FeedbackConn "TransposeOfTransposeForOneToManyTestOfFeedbackConn" = {
     channelCode                         = 1;
-    originalConnName                    = "Transpose for One to Many Test of FeedbackConn";
+    originalConnName                    = "TransposeForOneToManyTestOfFeedbackConn";
     delay                               = 0;
     updateGSynFromPostPerspective       = false;
     pvpatchAccumulateType               = "convolve";

--- a/tests/TransposeHyPerConnTest/src/TransposeHyPerConnTest.cpp
+++ b/tests/TransposeHyPerConnTest/src/TransposeHyPerConnTest.cpp
@@ -21,6 +21,11 @@
 
 using namespace PV;
 
+int testTransposeConn(
+      HyPerCol *hc,
+      char const *originalName,
+      char const *transposeName,
+      char const *transposeOfTransposeName);
 int testTransposeOfTransposeWeights(
       HyPerConn *originalMap,
       TransposeConn *transpose,
@@ -74,73 +79,63 @@ int main(int argc, char *argv[]) {
 
    int status = PV_SUCCESS;
 
-   HyPerConn *originalMap              = NULL;
-   TransposeConn *transpose            = NULL;
-   TransposeConn *transposeOfTranspose = NULL;
-
-   BaseConnection *baseConn;
-   baseConn    = hc->getConnFromName("Original Map for One to One Test");
-   originalMap = dynamic_cast<HyPerConn *>(baseConn);
-   // FatalIf(!(originalMap->usingSharedWeights()), "Test failed.\n");
-   transpose = dynamic_cast<TransposeConn *>(
-         hc->getConnFromName("Transpose for One to One Test of TransposeConn"));
-   transposeOfTranspose = dynamic_cast<TransposeConn *>(
-         hc->getConnFromName("Transpose of Transpose for One to One Test of TransposeConn"));
-   status = testTransposeOfTransposeWeights(
-         originalMap, transpose, transposeOfTranspose, "One-to-one case, TransposeConn");
-
-   baseConn    = hc->getConnFromName("Original Map for Many to One Test");
-   originalMap = dynamic_cast<HyPerConn *>(baseConn);
-   // FatalIf(!(originalMap->usingSharedWeights()), "Test failed.\n");
-   transpose = dynamic_cast<TransposeConn *>(
-         hc->getConnFromName("Transpose for Many to One Test of TransposeConn"));
-   transposeOfTranspose = dynamic_cast<TransposeConn *>(
-         hc->getConnFromName("Transpose of Transpose for Many to One Test of TransposeConn"));
-   status = testTransposeOfTransposeWeights(
-         originalMap, transpose, transposeOfTranspose, "Many-to-one case, TransposeConn");
-
-   baseConn    = hc->getConnFromName("Original Map for One to Many Test");
-   originalMap = dynamic_cast<HyPerConn *>(baseConn);
-   // FatalIf(!(originalMap->usingSharedWeights()), "Test failed.\n");
-   transpose = dynamic_cast<TransposeConn *>(
-         hc->getConnFromName("Transpose for One to Many Test of TransposeConn"));
-   transposeOfTranspose = dynamic_cast<TransposeConn *>(
-         hc->getConnFromName("Transpose of Transpose for One to Many Test of TransposeConn"));
-   status = testTransposeOfTransposeWeights(
-         originalMap, transpose, transposeOfTranspose, "One-to-many case, TransposeConn");
-
-   baseConn    = hc->getConnFromName("Original Map for One to One Test");
-   originalMap = dynamic_cast<HyPerConn *>(baseConn);
-   // FatalIf(!(originalMap->usingSharedWeights()), "Test failed.\n");
-   transpose = dynamic_cast<TransposeConn *>(
-         hc->getConnFromName("Transpose for One to One Test of FeedbackConn"));
-   transposeOfTranspose = dynamic_cast<TransposeConn *>(
-         hc->getConnFromName("Transpose of Transpose for One to One Test of FeedbackConn"));
-   status = testTransposeOfTransposeWeights(
-         originalMap, transpose, transposeOfTranspose, "One-to-one case, FeedbackConn");
-
-   baseConn    = hc->getConnFromName("Original Map for Many to One Test");
-   originalMap = dynamic_cast<HyPerConn *>(baseConn);
-   // FatalIf(!(originalMap->usingSharedWeights()), "Test failed.\n");
-   transpose = dynamic_cast<TransposeConn *>(
-         hc->getConnFromName("Transpose for Many to One Test of FeedbackConn"));
-   transposeOfTranspose = dynamic_cast<TransposeConn *>(
-         hc->getConnFromName("Transpose of Transpose for Many to One Test of FeedbackConn"));
-   status = testTransposeOfTransposeWeights(
-         originalMap, transpose, transposeOfTranspose, "Many-to-one case, FeedbackConn");
-
-   baseConn    = hc->getConnFromName("Original Map for One to Many Test");
-   originalMap = dynamic_cast<HyPerConn *>(baseConn);
-   // FatalIf(!(originalMap->usingSharedWeights()), "Test failed.\n");
-   transpose = dynamic_cast<TransposeConn *>(
-         hc->getConnFromName("Transpose for One to Many Test of FeedbackConn"));
-   transposeOfTranspose = dynamic_cast<TransposeConn *>(
-         hc->getConnFromName("Transpose of Transpose for One to Many Test of FeedbackConn"));
-   status = testTransposeOfTransposeWeights(
-         originalMap, transpose, transposeOfTranspose, "One-to-many case, FeedbackConn");
+   status = testTransposeConn(
+         hc,
+         "OriginalMapForOneToOneTest",
+         "TransposeForOneToOneTestOfTransposeConn",
+         "TransposeOfTransposeForOneToOneTestOfTransposeConn");
+   status = testTransposeConn(
+         hc,
+         "OriginalMapForManyToOneTest",
+         "TransposeForManyToOneTestOfTransposeConn",
+         "TransposeOfTransposeForManyToOneTestOfTransposeConn");
+   status = testTransposeConn(
+         hc,
+         "OriginalMapForOneToManyTest",
+         "TransposeForOneToManyTestOfTransposeConn",
+         "TransposeOfTransposeForOneToManyTestOfTransposeConn");
+   status = testTransposeConn(
+         hc,
+         "OriginalMapForOneToOneTest",
+         "TransposeForOneToOneTestOfFeedbackConn",
+         "TransposeOfTransposeForOneToOneTestOfFeedbackConn");
+   status = testTransposeConn(
+         hc,
+         "OriginalMapForManyToOneTest",
+         "TransposeForManyToOneTestOfFeedbackConn",
+         "TransposeOfTransposeForManyToOneTestOfFeedbackConn");
+   status = testTransposeConn(
+         hc,
+         "OriginalMapForOneToManyTest",
+         "TransposeForOneToManyTestOfFeedbackConn",
+         "TransposeOfTransposeForOneToManyTestOfFeedbackConn");
 
    delete hc;
    delete initObj;
+   return status;
+}
+
+int testTransposeConn(
+      HyPerCol *hc,
+      char const *originalName,
+      char const *transposeName,
+      char const *transposeOfTransposeName) {
+   HyPerConn *originalMap = dynamic_cast<HyPerConn *>(hc->getConnFromName(originalName));
+   FatalIf(!originalMap, "Connection \"%s\" does not exist.\n", originalName);
+   FatalIf(
+         originalMap->usingSharedWeights(),
+         "%s uses shared weights, but this test requires shared weights to be off.\n",
+         originalMap->getDescription_c());
+
+   TransposeConn *transpose = dynamic_cast<TransposeConn *>(hc->getConnFromName(transposeName));
+   FatalIf(!transpose, "Connection \"%s\" does not exist.\n", transposeName);
+
+   TransposeConn *transposeOfTranspose =
+         dynamic_cast<TransposeConn *>(hc->getConnFromName(transposeOfTransposeName));
+   FatalIf(!transposeOfTranspose, "Connection \"%s\" does not exist.\n", transposeOfTransposeName);
+
+   int status = testTransposeOfTransposeWeights(
+         originalMap, transpose, transposeOfTranspose, "One-to-one case, TransposeConn");
    return status;
 }
 
@@ -157,7 +152,7 @@ int testTransposeOfTransposeWeights(
       dumpWeights(originalMap);
       dumpWeights(transpose);
       dumpWeights(transposeOfTranspose);
-      ErrorLog().printf("%s: TestTransposeConn failed.\n", message);
+      Fatal().printf("%s: TestTransposeConn failed.\n", message);
    }
    return status;
 }

--- a/tests/test_border_activity/input/test_border_activity.params
+++ b/tests/test_border_activity/input/test_border_activity.params
@@ -14,7 +14,7 @@ HyPerCol "column" = {
    lastCheckpointDir = "output/test_border_activity/Last";
 };
 
-PvpLayer "test_border_activity image" = {
+PvpLayer "test_border_activity_image" = {
    nxScale = 1;
    nyScale = 1;
    nf = 1;
@@ -34,7 +34,7 @@ PvpLayer "test_border_activity image" = {
    displayPeriod = 0;
 };
 
-Retina "test_border_activity retina" = {
+Retina "test_border_activity_retina" = {
    nxScale = 1;
    nyScale = 1;
    nf = 1;
@@ -55,7 +55,7 @@ Retina "test_border_activity retina" = {
    burstDuration = 20;
 };
 
-ANNLayer "test_border_activity layer" = {
+ANNLayer "test_border_activity_layer" = {
    nxScale = 1;
    nyScale = 1;
    nf = 1;
@@ -76,9 +76,9 @@ ANNLayer "test_border_activity layer" = {
    VWidth = 0.0;
 };
 
-HyPerConn "test_border_activity connection 1" = {
-   preLayerName = "test_border_activity image";
-   postLayerName = "test_border_activity retina";
+HyPerConn "test_border_activity_connection1" = {
+   preLayerName = "test_border_activity_image";
+   postLayerName = "test_border_activity_retina";
    nxp = 1;
    nyp = 1;
    nfp = 1;
@@ -100,9 +100,9 @@ HyPerConn "test_border_activity connection 1" = {
    writeCompressedCheckpoints = false;
 };
 
-HyPerConn "test_border_activity connection 2" = {
-   preLayerName = "test_border_activity retina";
-   postLayerName = "test_border_activity layer";
+HyPerConn "test_border_activity_connection2" = {
+   preLayerName = "test_border_activity_retina";
+   postLayerName = "test_border_activity_layer";
    nxp = 7;
    nyp = 7;
    nfp = 1;

--- a/tests/test_border_activity/src/test_border_activity.cpp
+++ b/tests/test_border_activity/src/test_border_activity.cpp
@@ -52,9 +52,9 @@ int main(int argc, char *argv[]) {
 
    HyPerCol *hc = new HyPerCol("column", initObj);
 
-   const char *imageLayerName  = "test_border_activity image";
-   const char *retinaLayerName = "test_border_activity retina";
-   const char *l1LayerName     = "test_border_activity layer";
+   const char *imageLayerName  = "test_border_activity_image";
+   const char *retinaLayerName = "test_border_activity_retina";
+   const char *l1LayerName     = "test_border_activity_layer";
 
    PvpLayer *image = new PvpLayer(imageLayerName, hc);
    assert(image);
@@ -63,9 +63,9 @@ int main(int argc, char *argv[]) {
    ANNLayer *l1 = new ANNLayer(l1LayerName, hc);
    assert(l1);
 
-   HyPerConn *conn1 = new HyPerConn("test_border_activity connection 1", hc);
+   HyPerConn *conn1 = new HyPerConn("test_border_activity_connection1", hc);
    FatalIf(!(conn1), "Test failed.\n");
-   HyPerConn *conn2 = new HyPerConn("test_border_activity connection 2", hc);
+   HyPerConn *conn2 = new HyPerConn("test_border_activity_connection2", hc);
    FatalIf(!(conn2), "Test failed.\n");
 
 #ifdef DEBUG_OUTPUT

--- a/tests/test_cocirc/input/test_cocirc.params
+++ b/tests/test_cocirc/input/test_cocirc.params
@@ -1,5 +1,5 @@
 
-HyPerCol "test_cocirc column" = {
+HyPerCol "test_cocirc_column" = {
    nx = 16;
    ny = 16;
    checkpointWrite = false;
@@ -7,23 +7,23 @@ HyPerCol "test_cocirc column" = {
    lastCheckpointDir = "output/Last";
 };
 
-HyPerLayer "test_cocirc pre" = {
+HyPerLayer "test_cocirc_pre" = {
    nxScale = 1;
    nyScale = 1;
    nf = 4;
    marginWidth = 2;
 };
 
-HyPerLayer "test_cocirc post" = {
+HyPerLayer "test_cocirc_post" = {
    nxScale = 1;
    nyScale = 1;
    nf = 4;
    marginWidth = 2;  
 };
 
-HyPerConn "test_cocirc hyperconn" = {
-   preLayerName = "test_cocirc pre";
-   postLayerName = "test_cocirc post";
+HyPerConn "test_cocirc_hyperconn" = {
+   preLayerName = "test_cocirc_pre";
+   postLayerName = "test_cocirc_post";
    nxp = 5;
    nyp = 5;
    channelCode = 0;
@@ -53,9 +53,9 @@ HyPerConn "test_cocirc hyperconn" = {
    cocircWeights = 1.0;
 };
 
-HyPerConn "test_cocirc cocircconn" = {
-   preLayerName = "test_cocirc pre";
-   postLayerName = "test_cocirc post";
+HyPerConn "test_cocirc_cocircconn" = {
+   preLayerName = "test_cocirc_pre";
+   postLayerName = "test_cocirc_post";
    nxp = 5;
    nyp = 5;
    channelCode = 0;
@@ -85,23 +85,23 @@ HyPerConn "test_cocirc cocircconn" = {
    cocircWeights = 1.0;
 };
 
-HyPerLayer "test_cocirc pre 2" = {
+HyPerLayer "test_cocirc_pre2" = {
    nxScale = 2;
    nyScale = 2;
    nf = 4;
    marginWidth = 4;
 };
 
-HyPerLayer "test_cocirc post 2" = {
+HyPerLayer "test_cocirc_post2" = {
    nxScale = 2;
    nyScale = 2;
    nf = 4;
    marginWidth = 4;  
 };
 
-HyPerConn "test_cocirc hyperconn 1 to 2" = {
-   preLayerName = "test_cocirc pre";
-   postLayerName = "test_cocirc post 2";
+HyPerConn "test_cocirc_hyperconn1to2" = {
+   preLayerName = "test_cocirc_pre";
+   postLayerName = "test_cocirc_post2";
    nxp = 10;  // must be scale factor times odd number
    nyp = 10;
    channelCode = 0;
@@ -128,9 +128,9 @@ HyPerConn "test_cocirc hyperconn 1 to 2" = {
    cocircWeights = 1.0;
 };
 
-HyPerConn "test_cocirc cocircconn 1 to 2" = {
-   preLayerName = "test_cocirc pre";
-   postLayerName = "test_cocirc post 2";
+HyPerConn "test_cocirc_cocircconn1to2" = {
+   preLayerName = "test_cocirc_pre";
+   postLayerName = "test_cocirc_post2";
    nxp = 10;  // must be scale factor times odd number
    nyp = 10;
    channelCode = 0;
@@ -157,9 +157,9 @@ HyPerConn "test_cocirc cocircconn 1 to 2" = {
    cocircWeights = 1.0;
 };
 
-HyPerConn "test_cocirc hyperconn 2 to 1" = {
-   preLayerName = "test_cocirc pre 2";
-   postLayerName = "test_cocirc post";
+HyPerConn "test_cocirc_hyperconn2to1" = {
+   preLayerName = "test_cocirc_pre2";
+   postLayerName = "test_cocirc_post";
    nxp = 5;  // must be odd number
    nyp = 5;
    channelCode = 0;
@@ -186,9 +186,9 @@ HyPerConn "test_cocirc hyperconn 2 to 1" = {
    cocircWeights = 1.0;
 };
 
-HyPerConn "test_cocirc cocircconn 2 to 1" = {
-   preLayerName = "test_cocirc pre 2";
-   postLayerName = "test_cocirc post";
+HyPerConn "test_cocirc_cocircconn2to1" = {
+   preLayerName = "test_cocirc_pre2";
+   postLayerName = "test_cocirc_post";
    nxp = 5;  // must be odd number
    nyp = 5;
    channelCode = 0;

--- a/tests/test_cocirc/src/test_cocirc.cpp
+++ b/tests/test_cocirc/src/test_cocirc.cpp
@@ -21,31 +21,31 @@ int check_cocirc_vs_hyper(HyPerConn *cHyPer, HyPerConn *cKernel, int kPre, int a
 
 int main(int argc, char *argv[]) {
    PV_Init *initObj = new PV_Init(&argc, &argv, false /*allowUnrecognizedArguments*/);
-   PV::HyPerCol *hc = new PV::HyPerCol("test_cocirc column", initObj);
+   PV::HyPerCol *hc = new PV::HyPerCol("test_cocirc_column", initObj);
 
-   const char *preLayerName  = "test_cocirc pre";
-   const char *postLayerName = "test_cocirc post";
+   const char *preLayerName  = "test_cocirc_pre";
+   const char *postLayerName = "test_cocirc_post";
 
    PV::Example *pre = new PV::Example(preLayerName, hc);
    FatalIf(!(pre), "Test failed.\n");
    PV::Example *post = new PV::Example(postLayerName, hc);
    FatalIf(!(post), "Test failed.\n");
-   PV::HyPerConn *cHyPer = new HyPerConn("test_cocirc hyperconn", hc);
+   PV::HyPerConn *cHyPer = new HyPerConn("test_cocirc_hyperconn", hc);
    FatalIf(!(cHyPer), "Test failed.\n");
-   PV::HyPerConn *cCocirc = new HyPerConn("test_cocirc cocircconn", hc);
+   PV::HyPerConn *cCocirc = new HyPerConn("test_cocirc_cocircconn", hc);
    FatalIf(!(cCocirc), "Test failed.\n");
 
-   PV::Example *pre2 = new PV::Example("test_cocirc pre 2", hc);
+   PV::Example *pre2 = new PV::Example("test_cocirc_pre2", hc);
    FatalIf(!(pre2), "Test failed.\n");
-   PV::Example *post2 = new PV::Example("test_cocirc post 2", hc);
+   PV::Example *post2 = new PV::Example("test_cocirc_post2", hc);
    FatalIf(!(post2), "Test failed.\n");
-   PV::HyPerConn *cHyPer1to2 = new HyPerConn("test_cocirc hyperconn 1 to 2", hc);
+   PV::HyPerConn *cHyPer1to2 = new HyPerConn("test_cocirc_hyperconn1to2", hc);
    FatalIf(!(cHyPer1to2), "Test failed.\n");
-   PV::HyPerConn *cCocirc1to2 = new HyPerConn("test_cocirc cocircconn 1 to 2", hc);
+   PV::HyPerConn *cCocirc1to2 = new HyPerConn("test_cocirc_cocircconn1to2", hc);
    FatalIf(!(cCocirc1to2), "Test failed.\n");
-   PV::HyPerConn *cHyPer2to1 = new HyPerConn("test_cocirc hyperconn 2 to 1", hc);
+   PV::HyPerConn *cHyPer2to1 = new HyPerConn("test_cocirc_hyperconn2to1", hc);
    FatalIf(!(cHyPer2to1), "Test failed.\n");
-   PV::HyPerConn *cCocirc2to1 = new HyPerConn("test_cocirc cocircconn 2 to 1", hc);
+   PV::HyPerConn *cCocirc2to1 = new HyPerConn("test_cocirc_cocircconn2to1", hc);
    FatalIf(!(cCocirc2to1), "Test failed.\n");
 
    ensureDirExists(hc->getCommunicator()->getLocalMPIBlock(), hc->getOutputPath());

--- a/tests/test_constant_input/input/test_constant_input.params
+++ b/tests/test_constant_input/input/test_constant_input.params
@@ -1,6 +1,6 @@
 debugParsing = false;
 
-HyPerCol "test_constant_input column" = {
+HyPerCol "test_constant_input_column" = {
     nx = 16;
     ny = 16;
     startTime = 0.0;
@@ -20,7 +20,7 @@ HyPerCol "test_constant_input column" = {
     // lastCheckpointDir = "output/Last";
 };
 
-TestImage "test_constant_input image" = {
+TestImage "test_constant_input_image" = {
     nxScale = 1;
     nyScale = 1;
     nf = 1;
@@ -33,7 +33,7 @@ TestImage "test_constant_input image" = {
     constantVal = 1.0;
 };
 
-Retina "test_constant_input retina" = {
+Retina "test_constant_input_retina" = {
     nxScale = 1;
     nyScale = 1;
     nf = 1;
@@ -51,9 +51,9 @@ Retina "test_constant_input retina" = {
     endStim = infinity;
 };
 
-HyPerConn "test_constant_input connection" = {
-    preLayerName = "test_constant_input image";
-    postLayerName = "test_constant_input retina";
+HyPerConn "test_constant_input_connection" = {
+    preLayerName = "test_constant_input_image";
+    postLayerName = "test_constant_input_retina";
     channelCode = 0;
     sharedWeights = true;
     nxp = 3;

--- a/tests/test_constant_input/src/test_constant_input.cpp
+++ b/tests/test_constant_input/src/test_constant_input.cpp
@@ -41,19 +41,19 @@ int main(int argc, char *argv[]) {
 
    // create the managing hypercolumn
    //
-   HyPerCol *hc = new HyPerCol("test_constant_input column", initObj);
+   HyPerCol *hc = new HyPerCol("test_constant_input_column", initObj);
 
    // create the image
    //
-   TestImage *image = new TestImage("test_constant_input image", hc);
+   TestImage *image = new TestImage("test_constant_input_image", hc);
 
    // create the layers
    //
-   HyPerLayer *retina = new Retina("test_constant_input retina", hc);
+   HyPerLayer *retina = new Retina("test_constant_input_retina", hc);
 
    // create the connections
    //
-   HyPerConn *conn             = new HyPerConn("test_constant_input connection", hc);
+   HyPerConn *conn             = new HyPerConn("test_constant_input_connection", hc);
    const int nxp               = conn->xPatchSize();
    const int nyp               = conn->yPatchSize();
    const PVLayerLoc *imageLoc  = image->getLayerLoc();

--- a/tests/test_gauss2d/input/test_gauss2d.params
+++ b/tests/test_gauss2d/input/test_gauss2d.params
@@ -3,7 +3,7 @@
 
 debugParsing = false;
 
-HyPerCol "test_gauss2d column" = {
+HyPerCol "test_gauss2d_column" = {
    nx = 16;
    ny = 16;
    startTime = 0.0;
@@ -20,7 +20,7 @@ HyPerCol "test_gauss2d column" = {
    errorOnNotANumber = false;
 };
 
-HyPerLayer "test_gauss2d pre" = {
+HyPerLayer "test_gauss2d_pre" = {
    restart = false;
    nxScale = 1;
    nyScale = 1;
@@ -35,7 +35,7 @@ HyPerLayer "test_gauss2d pre" = {
    sparseLayer = false;
 };
 
-HyPerLayer "test_gauss2d post" = {
+HyPerLayer "test_gauss2d_post" = {
    restart = false;
    nxScale = 1;
    nyScale = 1;
@@ -50,9 +50,9 @@ HyPerLayer "test_gauss2d post" = {
    sparseLayer = false;
 };
 
-HyPerConn "test_gauss2d hyperconn" = {
-   preLayerName = "test_gauss2d pre";
-   postLayerName = "test_gauss2d post";
+HyPerConn "test_gauss2d_hyperconn" = {
+   preLayerName = "test_gauss2d_pre";
+   postLayerName = "test_gauss2d_post";
    nxp = 5;
    nyp = 5;
    nfp = -1;
@@ -81,9 +81,9 @@ HyPerConn "test_gauss2d hyperconn" = {
    shrinkPatches = false;
 };
 
-HyPerConn "test_gauss2d kernelconn" = {
-   preLayerName = "test_gauss2d pre";
-   postLayerName = "test_gauss2d post";
+HyPerConn "test_gauss2d_kernelconn" = {
+   preLayerName = "test_gauss2d_pre";
+   postLayerName = "test_gauss2d_post";
    nxp = 5;
    nyp = 5;
    nfp = -1;
@@ -112,7 +112,7 @@ HyPerConn "test_gauss2d kernelconn" = {
    shrinkPatches = false;
 };
 
-HyPerLayer "test_gauss2d pre 2" = {
+HyPerLayer "test_gauss2d_pre2" = {
    restart = false;
    nxScale = 2;
    nyScale = 2;
@@ -127,7 +127,7 @@ HyPerLayer "test_gauss2d pre 2" = {
    sparseLayer = false;
 };
 
-HyPerLayer "test_gauss2d post 2" = {
+HyPerLayer "test_gauss2d_post2" = {
    restart = false;
    nxScale = 2;
    nyScale = 2;
@@ -142,9 +142,9 @@ HyPerLayer "test_gauss2d post 2" = {
    sparseLayer = false;
 };
 
-HyPerConn "test_gauss2d hyperconn 1 to 2" = {
-   preLayerName = "test_gauss2d pre";
-   postLayerName = "test_gauss2d post 2";
+HyPerConn "test_gauss2d_hyperconn1to2" = {
+   preLayerName = "test_gauss2d_pre";
+   postLayerName = "test_gauss2d_post2";
    nxp = 10;  // must be scale factor times odd number
    nyp = 10;
    nfp = -1;
@@ -174,9 +174,9 @@ HyPerConn "test_gauss2d hyperconn 1 to 2" = {
    shrinkPatches = false;
 };
 
-HyPerConn "test_gauss2d kernelconn 1 to 2" = {
-   preLayerName = "test_gauss2d pre";
-   postLayerName = "test_gauss2d post 2";
+HyPerConn "test_gauss2d_kernelconn1to2" = {
+   preLayerName = "test_gauss2d_pre";
+   postLayerName = "test_gauss2d_post2";
    nxp = 10;  // must be scale factor times odd number
    nyp = 10;
    nfp = -1;
@@ -206,9 +206,9 @@ HyPerConn "test_gauss2d kernelconn 1 to 2" = {
    shrinkPatches = false;
 };
 
-HyPerConn "test_gauss2d hyperconn 2 to 1" = {
-   preLayerName = "test_gauss2d pre 2";
-   postLayerName = "test_gauss2d post";
+HyPerConn "test_gauss2d_hyperconn2to1" = {
+   preLayerName = "test_gauss2d_pre2";
+   postLayerName = "test_gauss2d_post";
    nxp = 5; // must be odd
    nyp = 5;
    nfp = -1;
@@ -238,9 +238,9 @@ HyPerConn "test_gauss2d hyperconn 2 to 1" = {
    shrinkPatches = false;
 };
 
-HyPerConn "test_gauss2d kernelconn 2 to 1" = {
-   preLayerName = "test_gauss2d pre 2";
-   postLayerName = "test_gauss2d post";
+HyPerConn "test_gauss2d_kernelconn2to1" = {
+   preLayerName = "test_gauss2d_pre2";
+   postLayerName = "test_gauss2d_post";
    nxp = 5;
    nyp = 5;
    nfp = -1;

--- a/tests/test_gauss2d/src/test_gauss2d.cpp
+++ b/tests/test_gauss2d/src/test_gauss2d.cpp
@@ -32,36 +32,36 @@ int main(int argc, char *argv[]) {
    }
 
    initObj->setParams("input/test_gauss2d.params");
-   const char *pre_layer_name   = "test_gauss2d pre";
-   const char *post_layer_name  = "test_gauss2d post";
-   const char *pre2_layer_name  = "test_gauss2d pre 2";
-   const char *post2_layer_name = "test_gauss2d post 2";
+   const char *pre_layer_name   = "test_gauss2d_pre";
+   const char *post_layer_name  = "test_gauss2d_post";
+   const char *pre2_layer_name  = "test_gauss2d_pre2";
+   const char *post2_layer_name = "test_gauss2d_post2";
 
-   PV::HyPerCol *hc = new PV::HyPerCol("test_gauss2d column", initObj);
+   PV::HyPerCol *hc = new PV::HyPerCol("test_gauss2d_column", initObj);
    PV::Example *pre = new PV::Example(pre_layer_name, hc);
    FatalIf(!(pre), "Test failed.\n");
    PV::Example *post = new PV::Example(post_layer_name, hc);
    FatalIf(!(post), "Test failed.\n");
 
-   PV::HyPerConn *cHyPer = new HyPerConn("test_gauss2d hyperconn", hc);
+   PV::HyPerConn *cHyPer = new HyPerConn("test_gauss2d_hyperconn", hc);
 
-   PV::HyPerConn *cKernel = new HyPerConn("test_gauss2d kernelconn", hc);
+   PV::HyPerConn *cKernel = new HyPerConn("test_gauss2d_kernelconn", hc);
 
    PV::Example *pre2 = new PV::Example(pre2_layer_name, hc);
    FatalIf(!(pre2), "Test failed.\n");
    PV::Example *post2 = new PV::Example(post2_layer_name, hc);
    FatalIf(!(post2), "Test failed.\n");
 
-   PV::HyPerConn *cHyPer1to2 = new HyPerConn("test_gauss2d hyperconn 1 to 2", hc);
+   PV::HyPerConn *cHyPer1to2 = new HyPerConn("test_gauss2d_hyperconn1to2", hc);
    FatalIf(!(cHyPer1to2), "Test failed.\n");
 
-   PV::HyPerConn *cKernel1to2 = new HyPerConn("test_gauss2d kernelconn 1 to 2", hc);
+   PV::HyPerConn *cKernel1to2 = new HyPerConn("test_gauss2d_kernelconn1to2", hc);
    FatalIf(!(cKernel1to2), "Test failed.\n");
 
-   PV::HyPerConn *cHyPer2to1 = new HyPerConn("test_gauss2d hyperconn 2 to 1", hc);
+   PV::HyPerConn *cHyPer2to1 = new HyPerConn("test_gauss2d_hyperconn2to1", hc);
    FatalIf(!(cHyPer2to1), "Test failed.\n");
 
-   PV::HyPerConn *cKernel2to1 = new HyPerConn("test_gauss2d kernelconn 2 to 1", hc);
+   PV::HyPerConn *cKernel2to1 = new HyPerConn("test_gauss2d_kernelconn2to1", hc);
    FatalIf(!(cKernel2to1), "Test failed.\n");
 
    int status = 0;

--- a/tests/test_mirror_BCs/input/test_mirror_BCs.params
+++ b/tests/test_mirror_BCs/input/test_mirror_BCs.params
@@ -4,7 +4,7 @@
 
 debugParsing = false;
 
-HyPerCol "test_mirror_BCs column" = {
+HyPerCol "test_mirror_BCs_column" = {
    startTime = 0.0;
    dt = 1.0;
    stopTime = 1.0;
@@ -15,7 +15,7 @@ HyPerCol "test_mirror_BCs column" = {
    lastCheckpointDir = "output/Last";
 };
 
-HyPerLayer "test_mirror_BCs layer" = {
+HyPerLayer "test_mirror_BCs_layer" = {
    restart = false;
    nxScale = 1;
    nyScale = 1;

--- a/tests/test_mirror_BCs/src/test_mirror_BCs.cpp
+++ b/tests/test_mirror_BCs/src/test_mirror_BCs.cpp
@@ -18,8 +18,8 @@ int main(int argc, char *argv[]) {
    PVLayerLoc sLoc, bLoc;
    PVLayerCube *sCube, *bCube;
 
-   PV::HyPerCol *hc = new PV::HyPerCol("test_mirror_BCs column", initObj);
-   PV::Example *l   = new PV::Example("test_mirror_BCs layer", hc);
+   PV::HyPerCol *hc = new PV::HyPerCol("test_mirror_BCs_column", initObj);
+   PV::Example *l   = new PV::Example("test_mirror_BCs_layer", hc);
 
    int nf             = l->clayer->loc.nf;
    PVHalo const *halo = &l->clayer->loc.halo;

--- a/tools/ChangeParamsGroupName.sh
+++ b/tools/ChangeParamsGroupName.sh
@@ -1,0 +1,84 @@
+#! /usr/bin/env bash
+# Usage: ChangeParamsGroupName oldname newname filename
+#
+# Checks if the string "newname" (including double quotes) appears in the file
+# and if not, changes appearances of the string "oldname" to "newname" (where
+# the quotes are part of the string being searched for, but not part of the
+# argument to the command).
+#
+# The script runs sed, editing filename in place with the suffix '.bak',
+# and then deletes the .bak file.
+#
+# The motivation is to quickly change the name of a layer or connection in
+# all its occurrences in a params file.
+
+progname="$(dirname $0)"
+usage="Usage: $progname oldname newname filename
+oldname can only contain letters, numbers, underscores or spaces.
+newname can only contain letters, numbers, or underscores and must start with
+        a letter or a number.
+Neither oldname nor newname can be the empty string.
+Only a single filename can be processed."
+
+if test $# -eq 0
+then
+    echo "$usage"
+    exit 0
+fi
+
+if test $# -ne 3
+then
+    >&2 echo "$usage" 
+    exit 1
+fi
+
+oldname="$1"
+newname="$2"
+filename="$3"
+
+cleanold="${oldname//[^0-9A-Za-z_ ]/}"
+cleannew="${newname//[^0-9A-Za-z_]/}"
+if test "$oldname" != "$cleanold"
+then
+   >&2 echo "$progname: oldname argument has an invalid character."
+   exit 1
+fi
+
+if test "$newname" != "$cleannew"
+then
+   >&2 echo "$progname: newname argument has an invalid character."
+   exit 1
+fi
+
+if test "$(echo -n "$oldname" | wc -c)" -eq 0
+then
+    >&2 echo "$progname: oldname argument cannot be empty"
+    exit 1
+fi
+
+if test "$(echo -n "$newname" | wc -c)" -eq 0
+then
+    >&2 echo "$progname: newname argument cannot be empty"
+    exit 1
+fi
+
+if ! test -f "$filename"
+then
+    >&2 echo "$progname: filename must exist as a regular file (or a symlink to a regular file)."
+    exit 1
+fi
+
+if test -n "$(echo "$filename" | fgrep \""$newname"\")"
+then
+    >&2 echo "$progname: newname argument already exists in the file."
+    exit 1
+fi
+
+if test -z "$(fgrep \""$oldname"\" "$filename")"
+then
+    >&2 echo "$progname: oldname argument does not exist in the file."
+    exit 1
+fi
+
+sed -e '1,$s/"'"$oldname"'"/"'"$newname"'"/g' -i.bak "$filename"
+rm "$filename.bak"


### PR DESCRIPTION
This pull request changes the parsing so that layer, connections, probes, etc. cannot have spaces in their names. The rationale is twofold.

First, PetaVision creates filenames based on the names of the objects, and spaces in filenames can cause problems. Second, the python/draw tool cannot handle spaces in the object names and silently skips over objects whose names contain spaces.

The rules for a params file parameter groupname are now that the name can only contain letters, numbers and underscores, and must start with a letter or number.