### PR TITLE
Miscellaneous bugfixes

### DIFF
--- a/doxygen/src/main.md
+++ b/doxygen/src/main.md
@@ -13,7 +13,7 @@ Installation Instructions:
 
 * [AWS Installation](https://github.com/PetaVision/OpenPV/wiki/AWS-Installation)
 
-* [OS X Installation](https://github.com/PetaVision/OpenPV/wiki/OS-X-Installation)
+* [MacOS Installation](https://github.com/PetaVision/OpenPV/wiki/MacOS-Installation)
 
 * [Ubuntu Installation](https://github.com/PetaVision/OpenPV/wiki/Ubuntu-Installation)
 

--- a/src/checkpointing/CheckpointableFileStream.cpp
+++ b/src/checkpointing/CheckpointableFileStream.cpp
@@ -98,9 +98,9 @@ int CheckpointableFileStream::registerData(Checkpointer *checkpointer) {
       return status;
    }
    checkpointer->registerCheckpointData<long>(
-         mObjName, string("FileStreamRead"), &mFileReadPos, (std::size_t)1, false);
+         mObjName, string("FileStreamRead"), &mFileReadPos, (std::size_t)1, false, false);
    checkpointer->registerCheckpointData<long>(
-         mObjName, string("FileStreamWrite"), &mFileWritePos, (std::size_t)1, false);
+         mObjName, string("FileStreamWrite"), &mFileWritePos, (std::size_t)1, false, false);
    return PV_SUCCESS;
 }
 

--- a/src/checkpointing/Checkpointer.cpp
+++ b/src/checkpointing/Checkpointer.cpp
@@ -439,6 +439,10 @@ void Checkpointer::ioParam_initializeFromCheckpointDir(enum ParamsIOFlag ioFlag,
          &mInitializeFromCheckpointDir,
          "",
          true);
+   if (ioFlag == PARAMS_IO_READ and mInitializeFromCheckpointDir != nullptr
+       and mInitializeFromCheckpointDir[0] != '\0') {
+      verifyDirectory(mInitializeFromCheckpointDir, "InitializeFromCheckpointDir.\n");
+   }
 }
 
 // defaultInitializeFromCheckpointFlag was made obsolete Dec 18, 2016.
@@ -506,7 +510,6 @@ void Checkpointer::readNamedCheckpointEntry(
    if (mSuppressNonplasticCheckpoints and constantEntireRun) {
       return;
    }
-   verifyDirectory(mInitializeFromCheckpointDir, "InitializeFromCheckpointDir.\n");
    std::string checkpointDirectory = generateBlockPath(mInitializeFromCheckpointDir);
    for (auto &c : mCheckpointRegistry) {
       if (c->getName() == checkpointEntryName) {
@@ -910,7 +913,7 @@ void Checkpointer::verifyDirectory(char const *directory, std::string const &des
          status = PV_FAILURE;
       }
       struct stat directoryStat;
-      int statResult = stat(directory, &directoryStat);
+      int statResult = stat(expandLeadingTilde(directory).c_str(), &directoryStat);
       if (statResult != 0) {
          ErrorLog() << "Checkpointer \"" << mName << "\": checking status of " << description
                     << " \"" << directory << "\" returned error \"" << strerror(errno) << "\".\n";

--- a/src/checkpointing/Checkpointer.cpp
+++ b/src/checkpointing/Checkpointer.cpp
@@ -194,7 +194,8 @@ void Checkpointer::ioParam_checkpointWriteTriggerMode(enum ParamsIOFlag ioFlag, 
                   std::string("nextCheckpointStep"),
                   &mNextCheckpointStep,
                   (std::size_t)1,
-                  true /*broadcast*/);
+                  true /*broadcast*/,
+                  false /*not constant entire run*/);
          }
          else if (
                !strcmp(mCheckpointWriteTriggerModeString, "time")
@@ -206,7 +207,8 @@ void Checkpointer::ioParam_checkpointWriteTriggerMode(enum ParamsIOFlag ioFlag, 
                   std::string("nextCheckpointTime"),
                   &mNextCheckpointSimtime,
                   (std::size_t)1,
-                  true /*broadcast*/);
+                  true /*broadcast*/,
+                  false /*not constant entire run*/);
          }
          else if (
                !strcmp(mCheckpointWriteTriggerModeString, "clock")
@@ -488,16 +490,22 @@ void Checkpointer::registerTimer(Timer const *timer) { mTimers.push_back(timer);
 
 void Checkpointer::readNamedCheckpointEntry(
       std::string const &objName,
-      std::string const &dataName) {
+      std::string const &dataName,
+      bool constantEntireRun) {
    std::string checkpointEntryName(objName);
    if (!(objName.empty() || dataName.empty())) {
       checkpointEntryName.append("_");
    }
    checkpointEntryName.append(dataName);
-   readNamedCheckpointEntry(checkpointEntryName);
+   readNamedCheckpointEntry(checkpointEntryName, constantEntireRun);
 }
 
-void Checkpointer::readNamedCheckpointEntry(std::string const &checkpointEntryName) {
+void Checkpointer::readNamedCheckpointEntry(
+      std::string const &checkpointEntryName,
+      bool constantEntireRun) {
+   if (mSuppressNonplasticCheckpoints and constantEntireRun) {
+      return;
+   }
    verifyDirectory(mInitializeFromCheckpointDir, "InitializeFromCheckpointDir.\n");
    std::string checkpointDirectory = generateBlockPath(mInitializeFromCheckpointDir);
    for (auto &c : mCheckpointRegistry) {

--- a/src/checkpointing/Checkpointer.hpp
+++ b/src/checkpointing/Checkpointer.hpp
@@ -182,17 +182,22 @@ class Checkpointer : public Subject {
          std::string const &dataName,
          T *dataPointer,
          size_t numValues,
-         bool broadcast);
+         bool broadcast,
+         bool constantEntireRun);
 
    bool registerCheckpointEntry(
          std::shared_ptr<CheckpointEntry> checkpointEntry,
-         bool constantEntireRun = false);
+         bool constantEntireRun);
 
    void registerTimer(Timer const *timer);
    virtual void addObserver(Observer *observer, BaseMessage const &message) override;
 
-   void readNamedCheckpointEntry(std::string const &objName, std::string const &dataName);
-   void readNamedCheckpointEntry(std::string const &checkpointEntryName);
+   void readNamedCheckpointEntry(
+         std::string const &objName,
+         std::string const &dataName,
+         bool constantEntireRun);
+   void
+   readNamedCheckpointEntry(std::string const &checkpointEntryName, bool constantEntireRun = false);
    void readStateFromCheckpoint();
    void checkpointRead(double *simTimePointer, long int *currentStepPointer);
    void checkpointWrite(double simTime);

--- a/src/checkpointing/Checkpointer.tpp
+++ b/src/checkpointing/Checkpointer.tpp
@@ -18,10 +18,12 @@ bool Checkpointer::registerCheckpointData(
       std::string const &dataName,
       T *dataPointer,
       std::size_t numValues,
-      bool broadcast) {
+      bool broadcast,
+      bool constantEntireRun) {
    return registerCheckpointEntry(
          std::make_shared<CheckpointEntryData<T>>(
-               objName, dataName, getMPIBlock(), dataPointer, numValues, broadcast));
+               objName, dataName, getMPIBlock(), dataPointer, numValues, broadcast),
+         constantEntireRun);
 }
 
 namespace TextOutput {

--- a/src/columns/HyPerCol.cpp
+++ b/src/columns/HyPerCol.cpp
@@ -200,7 +200,12 @@ int HyPerCol::initialize(const char *name, PV_Init *initObj) {
    mRunTimer = new Timer(mName, "column", "run    ");
    mCheckpointer->registerTimer(mRunTimer);
    mCheckpointer->registerCheckpointData(
-         mName, "nextProgressTime", &mNextProgressTime, (std::size_t)1, true /*broadcast*/);
+         mName,
+         "nextProgressTime",
+         &mNextProgressTime,
+         (std::size_t)1,
+         true /*broadcast*/,
+         false /*not constant*/);
 
    mCheckpointReadFlag = !mCheckpointer->getCheckpointReadDirectory().empty();
    return PV_SUCCESS;

--- a/src/columns/Publisher.cpp
+++ b/src/columns/Publisher.cpp
@@ -45,7 +45,8 @@ void Publisher::checkpointDataStore(
       char const *bufferName) {
    bool registerSucceeded = checkpointer->registerCheckpointEntry(
          std::make_shared<CheckpointEntryDataStore>(
-               objectName, bufferName, checkpointer->getMPIBlock(), store, &mLayerCube->loc));
+               objectName, bufferName, checkpointer->getMPIBlock(), store, &mLayerCube->loc),
+         false /*not constant*/);
 }
 
 int Publisher::updateAllActiveIndices() {

--- a/src/components/AdaptiveTimeScaleController.cpp
+++ b/src/components/AdaptiveTimeScaleController.cpp
@@ -46,7 +46,7 @@ AdaptiveTimeScaleController::~AdaptiveTimeScaleController() { free(mName); }
 int AdaptiveTimeScaleController::registerData(Checkpointer *checkpointer) {
    auto ptr = std::make_shared<CheckpointEntryTimeScaleInfo>(
          mName, "timescaleinfo", checkpointer->getMPIBlock(), &mTimeScaleInfo);
-   checkpointer->registerCheckpointEntry(ptr);
+   checkpointer->registerCheckpointEntry(ptr, false /*not constant*/);
    return PV_SUCCESS;
 }
 

--- a/src/components/BatchIndexer.cpp
+++ b/src/components/BatchIndexer.cpp
@@ -115,10 +115,16 @@ int BatchIndexer::registerData(Checkpointer *checkpointer) {
          std::string("FrameNumbers"),
          mIndices.data(),
          mIndices.size(),
-         false /*do not broadcast*/);
+         false /*do not broadcast*/,
+         false /*not constant*/);
    if (mBatchMethod == RANDOM) {
       checkpointer->registerCheckpointData<unsigned int>(
-            mObjName, std::string("RandomSeed"), &mRandomSeed, 1, false /*do not broadcast*/);
+            mObjName,
+            std::string("RandomSeed"),
+            &mRandomSeed,
+            1,
+            false /*do not broadcast*/,
+            false /*not constant*/);
    }
    return PV_SUCCESS;
 }
@@ -130,7 +136,7 @@ int BatchIndexer::processCheckpointRead() {
 
 int BatchIndexer::readStateFromCheckpoint(Checkpointer *checkpointer) {
    if (mInitializeFromCheckpointFlag) {
-      checkpointer->readNamedCheckpointEntry(mObjName, "FrameNumbers");
+      checkpointer->readNamedCheckpointEntry(mObjName, "FrameNumbers", false /*not constant*/);
       checkIndices();
    }
    return PV_SUCCESS;

--- a/src/connections/HyPerConn.cpp
+++ b/src/connections/HyPerConn.cpp
@@ -657,6 +657,12 @@ void HyPerConn::ioParam_weightUpdatePeriod(enum ParamsIOFlag ioFlag) {
          parent->parameters()->ioParamValueRequired(
                ioFlag, name, "weightUpdatePeriod", &weightUpdatePeriod);
       }
+      else
+         FatalIf(
+               parent->parameters()->present(name, "weightUpdatePeriod"),
+               "%s sets both triggerLayerName and weightUpdatePeriod; "
+               "only one of these can be set.\n",
+               getDescription_c());
    }
 }
 

--- a/src/connections/ImprintConn.cpp
+++ b/src/connections/ImprintConn.cpp
@@ -274,7 +274,12 @@ int ImprintConn::registerData(Checkpointer *checkpointer) {
    int status         = HyPerConn::registerData(checkpointer);
    std::size_t numBuf = (std::size_t)(getNumDataPatches() * numberOfAxonalArborLists());
    checkpointer->registerCheckpointData(
-         std::string(name), "ImprintState", lastActiveTime, numBuf, true /*broadcast*/);
+         std::string(name),
+         "ImprintState",
+         lastActiveTime,
+         numBuf,
+         true /*broadcast*/,
+         false /*not constant*/);
    return PV_SUCCESS;
 }
 

--- a/src/connections/MomentumConn.cpp
+++ b/src/connections/MomentumConn.cpp
@@ -190,7 +190,8 @@ int MomentumConn::readStateFromCheckpoint(Checkpointer *checkpointer) {
    if (initializeFromCheckpointFlag) {
       status = HyPerConn::readStateFromCheckpoint(checkpointer);
       if (plasticityFlag) {
-         checkpointer->readNamedCheckpointEntry(std::string(name), std::string("prev_dW"));
+         checkpointer->readNamedCheckpointEntry(
+               std::string(name), std::string("prev_dW"), false /*not constant*/);
       }
    }
    return status;

--- a/src/layers/HyPerLayer.cpp
+++ b/src/layers/HyPerLayer.cpp
@@ -518,7 +518,8 @@ void HyPerLayer::checkpointPvpActivityFloat(
                checkpointer->getMPIBlock(),
                pvpBuffer,
                getLayerLoc(),
-               extended));
+               extended),
+         false /*not constant*/);
    FatalIf(
          !registerSucceeded,
          "%s failed to register %s for checkpointing.\n",
@@ -538,7 +539,8 @@ void HyPerLayer::checkpointRandState(
                checkpointer->getMPIBlock(),
                randState->getRNG(0),
                getLayerLoc(),
-               extendedFlag));
+               extendedFlag),
+         false /*not constant*/);
    FatalIf(
          !registerSucceeded,
          "%s failed to register %s for checkpointing.\n",
@@ -1590,13 +1592,15 @@ int HyPerLayer::registerData(Checkpointer *checkpointer) {
          std::string("lastUpdateTime"),
          &mLastUpdateTime,
          (std::size_t)1,
-         true /*broadcast*/);
+         true /*broadcast*/,
+         false /*not constant*/);
    checkpointer->registerCheckpointData(
          std::string(getName()),
          std::string("nextWrite"),
          &writeTime,
          (std::size_t)1,
-         true /*broadcast*/);
+         true /*broadcast*/,
+         false /*not constant*/);
 
    if (writeStep >= 0.0) {
       openOutputStateFile(checkpointer);
@@ -1606,7 +1610,8 @@ int HyPerLayer::registerData(Checkpointer *checkpointer) {
                std::string("numframes_sparse"),
                &writeActivitySparseCalls,
                (std::size_t)1,
-               true /*broadcast*/);
+               true /*broadcast*/,
+               false /*not constant*/);
       }
       else {
          checkpointer->registerCheckpointData(
@@ -1614,7 +1619,8 @@ int HyPerLayer::registerData(Checkpointer *checkpointer) {
                std::string("numframes"),
                &writeActivityCalls,
                (std::size_t)1,
-               true /*broadcast*/);
+               true /*broadcast*/,
+               false /*not constant*/);
       }
    }
 
@@ -2136,19 +2142,19 @@ int HyPerLayer::readStateFromCheckpoint(Checkpointer *checkpointer) {
 }
 
 int HyPerLayer::readActivityFromCheckpoint(Checkpointer *checkpointer) {
-   checkpointer->readNamedCheckpointEntry(std::string(name), std::string("A"));
+   checkpointer->readNamedCheckpointEntry(std::string(name), std::string("A"), false);
    return PV_SUCCESS;
 }
 
 int HyPerLayer::readVFromCheckpoint(Checkpointer *checkpointer) {
    if (getV() != nullptr) {
-      checkpointer->readNamedCheckpointEntry(std::string(name), std::string("V"));
+      checkpointer->readNamedCheckpointEntry(std::string(name), std::string("V"), false);
    }
    return PV_SUCCESS;
 }
 
 int HyPerLayer::readDelaysFromCheckpoint(Checkpointer *checkpointer) {
-   checkpointer->readNamedCheckpointEntry(std::string(name), std::string("Delays"));
+   checkpointer->readNamedCheckpointEntry(std::string(name), std::string("Delays"), false);
    return PV_SUCCESS;
 }
 

--- a/src/layers/LIF.cpp
+++ b/src/layers/LIF.cpp
@@ -362,27 +362,27 @@ int LIF::readStateFromCheckpoint(Checkpointer *checkpointer) {
 }
 
 int LIF::readVthFromCheckpoint(Checkpointer *checkpointer) {
-   checkpointer->readNamedCheckpointEntry(std::string(name), "Vth");
+   checkpointer->readNamedCheckpointEntry(std::string(name), "Vth", false /*not constant*/);
    return PV_SUCCESS;
 }
 
 int LIF::readG_EFromCheckpoint(Checkpointer *checkpointer) {
-   checkpointer->readNamedCheckpointEntry(std::string(name), "G_E");
+   checkpointer->readNamedCheckpointEntry(std::string(name), "G_E", false /*not constant*/);
    return PV_SUCCESS;
 }
 
 int LIF::readG_IFromCheckpoint(Checkpointer *checkpointer) {
-   checkpointer->readNamedCheckpointEntry(std::string(name), "G_I");
+   checkpointer->readNamedCheckpointEntry(std::string(name), "G_I", false /*not constant*/);
    return PV_SUCCESS;
 }
 
 int LIF::readG_IBFromCheckpoint(Checkpointer *checkpointer) {
-   checkpointer->readNamedCheckpointEntry(std::string(name), "G_IB");
+   checkpointer->readNamedCheckpointEntry(std::string(name), "G_IB", false /*not constant*/);
    return PV_SUCCESS;
 }
 
 int LIF::readRandStateFromCheckpoint(Checkpointer *checkpointer) {
-   checkpointer->readNamedCheckpointEntry(std::string(name), "rand_state");
+   checkpointer->readNamedCheckpointEntry(std::string(name), "rand_state", false /*not constant*/);
    return PV_SUCCESS;
 }
 

--- a/src/layers/LIFGap.cpp
+++ b/src/layers/LIFGap.cpp
@@ -203,7 +203,8 @@ int LIFGap::readStateFromCheckpoint(Checkpointer *checkpointer) {
 }
 
 int LIFGap::readGapStrengthFromCheckpoint(Checkpointer *checkpointer) {
-   checkpointer->readNamedCheckpointEntry(std::string(name), std::string("gapStrength"));
+   checkpointer->readNamedCheckpointEntry(
+         std::string(name), std::string("gapStrength"), false /*not constant*/);
    return PV_SUCCESS;
 }
 

--- a/src/layers/Retina.cpp
+++ b/src/layers/Retina.cpp
@@ -242,7 +242,8 @@ int Retina::readStateFromCheckpoint(Checkpointer *checkpointer) {
 }
 
 int Retina::readRandStateFromCheckpoint(Checkpointer *checkpointer) {
-   checkpointer->readNamedCheckpointEntry(std::string(name), std::string("rand_state.pvp"));
+   checkpointer->readNamedCheckpointEntry(
+         std::string(name), std::string("rand_state.pvp"), false /*not constant*/);
    return PV_SUCCESS;
 }
 

--- a/tests/CheckpointerClassTest/src/main.cpp
+++ b/tests/CheckpointerClassTest/src/main.cpp
@@ -57,8 +57,9 @@ int main(int argc, char *argv[]) {
    auto integerCheckpointEntry = std::make_shared<PV::CheckpointEntryData<int>>(
          std::string("integer"), mpiBlock, &integerCheckpoint, (size_t)1, true /*broadcasting*/);
 
-   checkpointer->registerCheckpointEntry(floatingpointCheckpointEntry);
-   checkpointer->registerCheckpointEntry(integerCheckpointEntry);
+   checkpointer->registerCheckpointEntry(
+         floatingpointCheckpointEntry, false /*treat as non-constant*/);
+   checkpointer->registerCheckpointEntry(integerCheckpointEntry, false /*treat as non-constant*/);
 
    checkpointer->checkpointWrite(0.0);
    checkpointer->checkpointWrite(1.0);
@@ -86,8 +87,9 @@ int main(int argc, char *argv[]) {
    checkpointReadDir.append("/Checkpoint04");
    arguments.setStringArgument("CheckpointReadDirectory", checkpointReadDir);
    checkpointer = new PV::Checkpointer("checkpointer", mpiBlock, &arguments);
-   checkpointer->registerCheckpointEntry(floatingpointCheckpointEntry);
-   checkpointer->registerCheckpointEntry(integerCheckpointEntry);
+   checkpointer->registerCheckpointEntry(
+         floatingpointCheckpointEntry, false /*treat as non-constant*/);
+   checkpointer->registerCheckpointEntry(integerCheckpointEntry, false /*treat as non-constant*/);
 
    // Read the values in from checkpoint.
    checkpointer->checkpointRead(&readTime, &readStep);

--- a/tests/CheckpointerMPIBlockTest/src/CheckpointerMPIBlockTest.cpp
+++ b/tests/CheckpointerMPIBlockTest/src/CheckpointerMPIBlockTest.cpp
@@ -154,7 +154,8 @@ int run(int argc, char *argv[]) {
          &loc,
          false /*not extended*/);
 
-   bool registerSucceeded = checkpointer->registerCheckpointEntry(checkpointEntry);
+   bool registerSucceeded =
+         checkpointer->registerCheckpointEntry(checkpointEntry, false /*treat as non-constant*/);
    FatalIf(!registerSucceeded, "Checkpointer failed to register TestBuffer for checkpointing.\n");
 
    checkpointer->checkpointWrite(0.0);
@@ -173,7 +174,8 @@ int run(int argc, char *argv[]) {
    auto checkpointReader =
          new PV::Checkpointer(std::string("checkpointer"), globalMPIBlock, &arguments);
 
-   registerSucceeded = checkpointReader->registerCheckpointEntry(checkpointEntry);
+   registerSucceeded = checkpointReader->registerCheckpointEntry(
+         checkpointEntry, false /*treat as non-constant*/);
    FatalIf(!registerSucceeded, "Checkpointer failed to register TestBuffer for checkpointing.\n");
 
    // Read the values in from checkpoint.


### PR DESCRIPTION
This pull request fixes the following bugs:

* If a connection has both triggerLayerName and weightUpdatePeriod set, the program exits with an error. Previously, weightUpdatePeriod would go unread, leading to a warning, but the warning is easy to miss.
* Nonplastic connections no longer cause an error when reading from a checkpoint with suppressNonplasticCheckpoints flag set.
* A leading `~/` in the initializeFromCheckpointDir parameter now expands to the home directory properly.

Additionally, the link to the Mac installation page in the doxygen main.md file has been updated to reflect changes on the wiki.