### PR TITLE
Clarifies error in handleUnnecessaryParameter

### DIFF
--- a/src/io/PVParams.hpp
+++ b/src/io/PVParams.hpp
@@ -429,22 +429,23 @@ void PVParams::handleUnnecessaryParameter(
       T correct_value) {
    int status = PV_SUCCESS;
    if (present(group_name, param_name)) {
-      if (worldRank == 0) {
-         const char *class_name = groupKeywordFromName(group_name);
+      const char *class_name = groupKeywordFromName(group_name);
+
+      // marks param as read so that presentAndNotBeenRead doesn't trip up
+      T params_value = (T)value(group_name, param_name);
+      if (params_value == correct_value) {
          WarnLog().printf(
                "%s \"%s\" does not use parameter %s, but it is present in the parameters file.\n",
                class_name,
                group_name,
                param_name);
       }
-      T params_value = (T)value(
-            group_name,
-            param_name); // marks param as read so that presentAndNotBeenRead doesn't trip up
-      if (params_value != correct_value) {
+      else {
          status = PV_FAILURE;
          if (worldRank == 0) {
-            ErrorLog() << "   Value " << params_value << " is inconsistent with correct value "
-                       << correct_value << std::endl;
+            ErrorLog() << class_name << " \"" << group_name << "\" must use a value of "
+                       << correct_value << " for " << param_name << ", but " << params_value
+                       << " was specified." << std::endl;
          }
       }
    }


### PR DESCRIPTION
This pull request improves the error message produced by the PVParams::handleUnnecessaryParameter method. This error message is produced if a derived class sets a parameter defined in a base class to a specific value, but the params file sets the parameter to a different value.