### PR TITLE
Output from AbstractNormProbe-derived classes

### DIFF
--- a/doxygen/cfg/doxy.cfg
+++ b/doxygen/cfg/doxy.cfg
@@ -754,14 +754,20 @@ WARN_LOGFILE           =
 # Note: If this tag is empty the current directory is searched.
 
 INPUT                  = ../src/arch \
+                         ../src/checkpointing \
                          ../src/columns \
+                         ../src/components \
                          ../src/connections \
                          ../src/cudakernels \
                          ../src/include \
+                         ../src/initv \
                          ../src/io \
                          ../src/kernels \
                          ../src/layers \
                          ../src/normalizers \
+                         ../src/observerpattern \
+                         ../src/probes \
+                         ../src/structures \
                          ../src/utils \
                          ../src/weightinit \
                          ./src

--- a/doxygen/cfg/doxy_xml.cfg
+++ b/doxygen/cfg/doxy_xml.cfg
@@ -568,7 +568,7 @@ WARN_LOGFILE           =
 # directories like "/usr/src/myproject". Separate the files or directories
 # with spaces.
 
-INPUT                  = src/arch src/build/ src/connections src/include src/io src/layers src/normalizers src/utils src/weightinit src/columns src/cudakernels 
+INPUT                  = src/arch src/checkpointing src/columns src/connections src/cudakernels src/include src/initv src/io src/kernels src/layers src/normalizers src/observerpattern src/probes src/structures src/utils src/weightinit
 
 # This tag can be used to specify the character encoding of the source files
 # that doxygen parses. Internally doxygen uses the UTF-8 encoding, which is

--- a/src/io/PVParams.hpp
+++ b/src/io/PVParams.hpp
@@ -429,22 +429,23 @@ void PVParams::handleUnnecessaryParameter(
       T correct_value) {
    int status = PV_SUCCESS;
    if (present(group_name, param_name)) {
-      if (worldRank == 0) {
-         const char *class_name = groupKeywordFromName(group_name);
+      const char *class_name = groupKeywordFromName(group_name);
+
+      // marks param as read so that presentAndNotBeenRead doesn't trip up
+      T params_value = (T)value(group_name, param_name);
+      if (params_value == correct_value) {
          WarnLog().printf(
                "%s \"%s\" does not use parameter %s, but it is present in the parameters file.\n",
                class_name,
                group_name,
                param_name);
       }
-      T params_value = (T)value(
-            group_name,
-            param_name); // marks param as read so that presentAndNotBeenRead doesn't trip up
-      if (params_value != correct_value) {
+      else {
          status = PV_FAILURE;
          if (worldRank == 0) {
-            ErrorLog() << "   Value " << params_value << " is inconsistent with correct value "
-                       << correct_value << std::endl;
+            ErrorLog() << class_name << " \"" << group_name << "\" must use a value of "
+                       << correct_value << " for " << param_name << ", but " << params_value
+                       << " was specified." << std::endl;
          }
       }
    }

--- a/src/probes/AbstractNormProbe.cpp
+++ b/src/probes/AbstractNormProbe.cpp
@@ -128,6 +128,17 @@ int AbstractNormProbe::setNormDescriptionToString(char const *s) {
    return normDescription ? PV_SUCCESS : PV_FAILURE;
 }
 
+void AbstractNormProbe::initOutputStreams(const char *filename, Checkpointer *checkpointer) {
+   LayerProbe::initOutputStreams(filename, checkpointer);
+   int const nBatch = getNumValues();
+   for (auto &s : mOutputStreams) {
+      if (getMessage() != nullptr and getMessage()[0] != '\0') {
+         s->printf("%s\n", getMessage());
+      }
+      s->printf("time, batch, numNeurons, \"%s\"\n", getNormDescription());
+   }
+}
+
 int AbstractNormProbe::calcValues(double timeValue) {
    double *valuesBuffer = this->getValuesBuffer();
    for (int b = 0; b < this->getNumValues(); b++) {
@@ -151,7 +162,7 @@ int AbstractNormProbe::outputState(double timevalue) {
       int nk     = getTargetLayer()->getNumGlobalNeurons();
       for (int b = 0; b < nBatch; b++) {
          output(b).printf(
-               "%st = %6.3f b = %d numNeurons = %8d %s = %f",
+               "%6.3f, %d, %8d, %f",
                getMessage(),
                timevalue,
                b,

--- a/src/probes/AbstractNormProbe.hpp
+++ b/src/probes/AbstractNormProbe.hpp
@@ -113,6 +113,8 @@ class AbstractNormProbe : public LayerProbe {
     */
    virtual int communicateInitInfo(CommunicateInitInfoMessage const *message) override;
 
+   virtual void initOutputStreams(const char *filename, Checkpointer *checkpointer) override;
+
    /**
     * Returns true if masking is used and the layer has multiple features but
     * the masking layer has a single feature.  In this case it is expected that


### PR DESCRIPTION
This pull request addresses issue <https://github.com/PetaVision/OpenPV/issues/224>. The output files generated by AbstractNormProbe-derived classes have a .csv format.