### PR TITLE
MPI processes create CUDA devices serially

### DIFF
--- a/src/columns/HyPerCol.cpp
+++ b/src/columns/HyPerCol.cpp
@@ -1237,7 +1237,13 @@ void HyPerCol::initializeCUDA(std::string const &in_device) {
                 << device << "\n";
    }
 
-   mCudaDevice = new PVCuda::CudaDevice(device);
+   int globalSize = mCommunicator->globalCommSize();
+   for (int r = 0; r < globalSize; r++) {
+      if (r == globalRank()) {
+         mCudaDevice = new PVCuda::CudaDevice(device);
+      }
+      MPI_Barrier(mCommunicator->globalCommunicator());
+   }
 
    // Only print rank for comm rank 0
    if (globalRank() == 0) {


### PR DESCRIPTION
This pull requests addresses an issue where several MPI processes creating CUDA devices simultaneously could cause CUDA functions to fail. When run under MPI, the CudaDevice constructor is called in a loop synchronized by MPI_Barrier, and each process creates the device only when the loop counter is equal to its global rank.