### PR TITLE
writeTimeScales is obsolete

### DIFF
--- a/src/components/AdaptiveTimeScaleController.cpp
+++ b/src/components/AdaptiveTimeScaleController.cpp
@@ -21,7 +21,6 @@ AdaptiveTimeScaleController::AdaptiveTimeScaleController(
       double baseMin,
       double tauFactor,
       double growthFactor,
-      bool writeTimeScales,
       bool writeTimeScaleFieldnames,
       Communicator *communicator) {
    mName                     = strdup(name);
@@ -30,7 +29,6 @@ AdaptiveTimeScaleController::AdaptiveTimeScaleController(
    mBaseMin                  = baseMin;
    mTauFactor                = tauFactor;
    mGrowthFactor             = growthFactor;
-   mWriteTimeScales          = writeTimeScales;
    mWriteTimeScaleFieldnames = writeTimeScaleFieldnames;
    mCommunicator             = communicator;
 

--- a/src/components/AdaptiveTimeScaleController.hpp
+++ b/src/components/AdaptiveTimeScaleController.hpp
@@ -32,7 +32,6 @@ class AdaptiveTimeScaleController : public CheckpointerDataInterface {
          double baseMin,
          double tauFactor,
          double growthFactor,
-         bool writeTimeScales,
          bool writeTimeScaleFieldnames,
          Communicator *comm);
    virtual ~AdaptiveTimeScaleController();
@@ -52,7 +51,6 @@ class AdaptiveTimeScaleController : public CheckpointerDataInterface {
    double mBaseMin;
    double mTauFactor;
    double mGrowthFactor;
-   bool mWriteTimeScales;
    bool mWriteTimeScaleFieldnames;
    Communicator *mCommunicator;
 

--- a/src/components/KneeTimeScaleController.cpp
+++ b/src/components/KneeTimeScaleController.cpp
@@ -9,7 +9,6 @@ KneeTimeScaleController::KneeTimeScaleController(
       double baseMin,
       double tauFactor,
       double growthFactor,
-      bool writeTimeScales,
       bool writeTimeScaleFieldnames,
       Communicator *comm,
       double kneeThresh,
@@ -21,7 +20,6 @@ KneeTimeScaleController::KneeTimeScaleController(
               baseMin,
               tauFactor,
               growthFactor,
-              writeTimeScales,
               writeTimeScaleFieldnames,
               comm) {
    mKneeThresh = kneeThresh;

--- a/src/components/KneeTimeScaleController.hpp
+++ b/src/components/KneeTimeScaleController.hpp
@@ -14,7 +14,6 @@ class KneeTimeScaleController : public AdaptiveTimeScaleController {
          double baseMin,
          double tauFactor,
          double growthFactor,
-         bool writeTimeScales,
          bool writeTimeScaleFieldnames,
          Communicator *comm,
          double kneeThresh,

--- a/src/components/LogTimeScaleController.cpp
+++ b/src/components/LogTimeScaleController.cpp
@@ -10,7 +10,6 @@ LogTimeScaleController::LogTimeScaleController(
       double baseMin,
       double tauFactor,
       double growthFactor,
-      bool writeTimeScales,
       bool writeTimeScaleFieldnames,
       Communicator *comm,
       double logThresh,
@@ -22,7 +21,6 @@ LogTimeScaleController::LogTimeScaleController(
               baseMin,
               tauFactor,
               growthFactor,
-              writeTimeScales,
               writeTimeScaleFieldnames,
               comm) {
    mLogThresh = logThresh;

--- a/src/components/LogTimeScaleController.hpp
+++ b/src/components/LogTimeScaleController.hpp
@@ -15,7 +15,6 @@ class LogTimeScaleController : public AdaptiveTimeScaleController {
          double baseMin,
          double tauFactor,
          double growthFactor,
-         bool writeTimeScales,
          bool writeTimeScaleFieldnames,
          Communicator *comm,
          double logThresh,

--- a/src/probes/AdaptiveTimeScaleProbe.hpp
+++ b/src/probes/AdaptiveTimeScaleProbe.hpp
@@ -62,17 +62,16 @@ class AdaptiveTimeScaleProbe : public ColProbe {
     */
    virtual void ioParam_growthFactor(enum ParamsIOFlag ioFlag);
 
+   // writeTimeScales was marked obsolete Jul 27, 2017.
    /**
-    * @brief writeTimeScales: Specifies if the timescales should be written
-    * @details The timescales get written to
-    * outputPath/[name_of_probe]_timescales.txt.
+    * @brief writeTimeScales is obsolete, as it is redundant with textOutputFlag.
     */
    virtual void ioParam_writeTimeScales(enum ParamsIOFlag ioFlag);
 
    /**
     * @brief writeTimeScaleFieldnames: A flag to determine if fieldnames are
     * written to the
-    * HyPerCol_timescales file, if false, file is written as comma separated list
+    * HyPerCol_timescales file. If false, file is written as comma separated list
     */
    virtual void ioParam_writeTimeScaleFieldnames(enum ParamsIOFlag ioFlag);
    /** @} */
@@ -105,7 +104,6 @@ class AdaptiveTimeScaleProbe : public ColProbe {
    double mBaseMin                = 1.0;
    double tauFactor               = 1.0;
    double mGrowthFactor           = 1.0;
-   bool mWriteTimeScales          = true;
    bool mWriteTimeScaleFieldnames = true;
 
    BaseProbe *mTargetProbe                                   = nullptr;

--- a/src/probes/KneeTimeScaleProbe.cpp
+++ b/src/probes/KneeTimeScaleProbe.cpp
@@ -28,7 +28,6 @@ void KneeTimeScaleProbe::allocateTimeScaleController() {
          mBaseMin,
          tauFactor,
          mGrowthFactor,
-         mWriteTimeScales,
          mWriteTimeScaleFieldnames,
          parent->getCommunicator(),
          mKneeThresh,

--- a/src/probes/LogTimeScaleProbe.cpp
+++ b/src/probes/LogTimeScaleProbe.cpp
@@ -28,7 +28,6 @@ void LogTimeScaleProbe::allocateTimeScaleController() {
          mBaseMin,
          tauFactor,
          mGrowthFactor,
-         mWriteTimeScales,
          mWriteTimeScaleFieldnames,
          parent->getCommunicator(),
          mLogThresh,

--- a/tests/GPULCATest/input/GPULCATest.params
+++ b/tests/GPULCATest/input/GPULCATest.params
@@ -224,7 +224,6 @@ AdaptiveTimeScaleProbe "AdaptiveTimeScalesCPU" = {
     baseMin                             = 0.5;
     tauFactor                           = 0.1;
     growthFactor                        = 0.01;
-    writeTimeScales                     = true;
     writeTimeScaleFieldnames            = true;
 };
 

--- a/tests/LCATest/input/LCATest.params
+++ b/tests/LCATest/input/LCATest.params
@@ -293,7 +293,6 @@ AdaptiveTimeScaleProbe "AdaptiveTimeScales" = {
     baseMin                             = 0.5;
     tauFactor                           = 0.1;
     growthFactor                        = 0.01;
-    writeTimeScales                     = true;
     writeTimeScaleFieldnames            = true;
 };
 

--- a/tests/MomentumLCATest/input/MomentumLCATest.params
+++ b/tests/MomentumLCATest/input/MomentumLCATest.params
@@ -44,7 +44,6 @@ AdaptiveTimeScaleProbe "AdaptiveTimeScales" = {
    baseMin = 0.125;
    tauFactor = 0.05;
    growthFactor = 0;
-   writeTimeScales = true;
 };
 
 //

--- a/tests/TotalEnergyTest/input/TotalEnergyTest.params
+++ b/tests/TotalEnergyTest/input/TotalEnergyTest.params
@@ -42,7 +42,6 @@ AdaptiveTimeScaleProbe "AdaptiveTimeScales" = {
    baseMin = 0.125;
    tauFactor = 0.05;
    growthFactor = 0;
-   writeTimeScales = true;
 };
 
 //

--- a/tests/TransposeConnTest/input/TransposeConnTest.params
+++ b/tests/TransposeConnTest/input/TransposeConnTest.params
@@ -22,7 +22,6 @@ HyPerCol "column" = {
     // deleteOlderCheckpoints;
     // suppressNonplasticCheckpoints;
     lastCheckpointDir                   = "output/Last";
-    writeTimeScales                     = true;
     errorOnNotANumber                   = false;
 };
 

--- a/tutorials/LCACifar/input/LCA_Cifar.lua
+++ b/tutorials/LCACifar/input/LCA_Cifar.lua
@@ -73,7 +73,6 @@ local pvParameters = {
       baseMin                             = 0.05;  -- Initial value for timescale growth
       tauFactor                           = 0.03;  -- Percent of tau used as growth target
       growthFactor                        = 0.025; -- Exponential growth factor. The smaller value between this and the above is chosen. 
-      writeTimeScales                     = true;
       writeTimeScalesFieldnames           = false;
    };
 

--- a/tutorials/Total_Energy/input/AlmostHardThreshold.params
+++ b/tutorials/Total_Energy/input/AlmostHardThreshold.params
@@ -39,7 +39,7 @@ AdaptiveTimeScaleProbe "AdaptiveTimeScales" = {
     baseMin                             = 0.125;
     tauFactor                           = 0.05;
     growthFactor                        = 0;
-    writeTimeScales                     = true;
+    textOutputFlag                      = true;
 };
 
 ImageLayer "input" = {

--- a/tutorials/Total_Energy/input/AlmostSoftThreshold.params
+++ b/tutorials/Total_Energy/input/AlmostSoftThreshold.params
@@ -39,7 +39,7 @@ AdaptiveTimeScaleProbe "AdaptiveTimeScales" = {
     baseMin                             = 0.125;
     tauFactor                           = 0.05;
     growthFactor                        = 0;
-    writeTimeScales                     = true;
+    textOutputFlag                      = true;
 };
 
 ImageLayer "input" = {

--- a/tutorials/Total_Energy/input/FirmThreshold.params
+++ b/tutorials/Total_Energy/input/FirmThreshold.params
@@ -39,7 +39,7 @@ AdaptiveTimeScaleProbe "AdaptiveTimeScales" = {
     BaseMin                             = 0.125;
     tauFactor                           = 0.05;
     growthFactor                        = 0;
-    writeTimeScales                     = true;
+    textOutputFlag                      = true;
 };
 
 ImageLayer "input" = {

--- a/tutorials/Total_Energy/input/HardThreshold.params
+++ b/tutorials/Total_Energy/input/HardThreshold.params
@@ -38,7 +38,7 @@ AdaptiveTimeScaleProbe "AdaptiveTimeScales" = {
     baseMin                             = 0.125;
     tauFactor                           = 0.05;
     growthFactor                        = 0;
-    writeTimeScales                     = true;
+    textOutputFlag                      = true;
 };
 
 ImageLayer "input" = {

--- a/tutorials/Total_Energy/input/ISTA.params
+++ b/tutorials/Total_Energy/input/ISTA.params
@@ -37,7 +37,7 @@ AdaptiveTimeScaleProbe "AdaptiveTimeScales" = {
     BaseMin                             = 0.125;
     tauFactor                           = 0.05;
     growthFactor                        = 0;
-    writeTimeScales                     = true;
+    textOutputFlag                      = true;
 };
 
 ImageLayer "input" = {

--- a/tutorials/Total_Energy/input/SoftThreshMasked.params
+++ b/tutorials/Total_Energy/input/SoftThreshMasked.params
@@ -37,7 +37,7 @@ AdaptiveTimeScaleProbe "AdaptiveTimeScales" = {
     baseMin                              = 0.125;
     tauFactor                            = 0.05;
     growthFactor                         = 0;
-    writeTimeScales                      = true;
+    textOutputFlag                       = true;
 };
 
 ImageLayer "input" = {

--- a/tutorials/Total_Energy/input/SoftThreshold.params
+++ b/tutorials/Total_Energy/input/SoftThreshold.params
@@ -38,7 +38,7 @@ AdaptiveTimeScaleProbe "AdaptiveTimeScales" = {
     baseMin                              = 0.125;
     tauFactor                            = 0.05;
     growthFactor                         = 0;
-    writeTimeScales                      = true;
+    textOutputFlag                       = true;
 };
 
 ImageLayer "input" = {

--- a/tutorials/Total_Energy/input/UsingANNNormalizedError.params
+++ b/tutorials/Total_Energy/input/UsingANNNormalizedError.params
@@ -38,7 +38,7 @@ AdaptiveTimeScaleProbe "AdaptiveTimeScales" = {
     baseMin                              = 0.125;
     tauFactor                            = 0.05;
     growthFactor                         = 0;
-    writeTimeScales                      = true;
+    textOutputFlag                       = true;
 };
 
 ImageLayer "input" = {

--- a/tutorials/Total_Energy/input/UsingQuotientColProbe.params
+++ b/tutorials/Total_Energy/input/UsingQuotientColProbe.params
@@ -39,7 +39,7 @@ AdaptiveTimeScaleProbe "AdaptiveTimeScales" = {
    baseMin                              = 0.125;
    tauFactor                            = 0.05;
    growthFactor                         = 0;
-   writeTimeScales                      = true;
+   textOutputFlag                       = true;
 };
 
 ImageLayer "input" = {


### PR DESCRIPTION
This flag in AdaptiveTimeScaleProbe is redundant with the base class
parameter textOutputFlag. A warning is issued if writeTimeScales
is set and equal to textOutputFlag; the program exits with error
if writeTimeScales is set and the value conflicts with textOutputFlag.

writeTimeScaleFieldnames is read if textOutputFlag is true, and
skipped otherwise.