### PR TITLE
Additional params files for InputLayerNormalizeOffsetTest

### DIFF
--- a/tests/InputLayerNormalizeOffsetTest/CMakeLists.txt
+++ b/tests/InputLayerNormalizeOffsetTest/CMakeLists.txt
@@ -2,4 +2,4 @@ set(SRC_CPP
   src/InputLayerNormalizeOffsetTest.cpp
 )
 
-pv_add_test(SRCFILES ${SRC_CPP} ${SRC_HPP} ${SRC_C} ${SRC_H})
+pv_add_test(PARAMS translate resizePad resizeCrop SRCFILES ${SRC_CPP} ${SRC_HPP} ${SRC_C} ${SRC_H})

--- a/tests/InputLayerNormalizeOffsetTest/input/resizeCrop.params
+++ b/tests/InputLayerNormalizeOffsetTest/input/resizeCrop.params
@@ -1,0 +1,89 @@
+//
+// resize_crop.params for InputLayerNormalizeOffsetTest
+//
+// created by peteschultz: Aug 31, 2017
+//
+
+// A params file to test normalizeLuminanceFlag with resizing
+// There are two PvpLayers, "Input", and "ValidRegion".
+// "Input" reads an 8-by-8-by-1 activity pvp file of the values 1 to 64.
+// "ValidRegion" reads an 8-by-8-by-1 activity pvp file of all ones.
+//
+// The layers are 12-by-8 and autoResizeFlag true and adjustAspectRatio set to "crop".
+// The offsetX variable is set to one, so that there are pixels in the InputLayers that
+// are not in the input region. That is, the ValidRegion layer activity is not all ones.
+//
+// The Input layer has normalizeLuminance on, and ValidRegion has normalizeLuminance off.
+// They both have the same offsets, and neither resizes.
+// The pad value for Input is -1, and the pad value for ValidRegion is zero.
+//
+// In the part of the layer where ValidRegion is zero, normalizeLuminance should not change
+// the pad value of -1.
+//
+// In the part of the layer where ValidRegion is zero, the values should be normalized
+// to have mean value zero and standard deviation one.
+//
+// The InputRegionLayerTest.cpp code allocates the HyPerCol and then checks 
+// the contents of the InputLayer, using the contents of the ValidRegion layer.
+
+debugParsing = false;
+
+HyPerCol "column" = {
+    startTime                           = 0;
+    dt                                  = 1;
+    stopTime                            = 10;
+    progressInterval                    = 10;
+    writeProgressToErr                  = false;
+    outputPath                          = "output/";
+    verifyWrites                        = false;
+    checkpointWrite                     = false;
+    lastCheckpointDir                   = "output/Last";
+    initializeFromCheckpointDir         = "";
+    printParamsFilename                 = "pv.params";
+    randomSeed                          = 1234567890;
+    nx                                  = 12;
+    ny                                  = 8;
+    nbatch                              = 1;
+    errorOnNotANumber                   = true;
+};
+
+PvpLayer "Input" = {
+    nxScale                             = 1;
+    nyScale                             = 1;
+    nf                                  = 1;
+    phase                               = 0;
+    mirrorBCflag                        = false;
+    valueBC                             = 0;
+    initializeFromCheckpointFlag        = false;
+    writeStep                           = 1;
+    initialWriteTime                    = 0;
+    sparseLayer                         = false;
+    updateGpu                           = false;
+    displayPeriod                       = 0;
+    inputPath                           = "input/inputimage.pvp";
+    offsetAnchor                        = "tl";
+    offsetX                             = 1; // So that ValidRegion is not completely ones
+    offsetY                             = 0;
+    maxShiftX                           = 0;
+    maxShiftY                           = 0;
+    jitterChangeInterval                = 1;
+    autoResizeFlag                      = true;
+    aspectRatioAdjustment               = "crop";
+    interpolationMethod                 = "nearestneighbor";
+    inverseFlag                         = false;
+    normalizeLuminanceFlag              = true;
+    normalizeStdDev                     = true;
+    useInputBCflag                      = false;
+    padValue                            = -1;
+    batchMethod                         = "byFile";
+    randomSeed                          = 123456789;
+    start_frame_index                   = [0.000000];
+};
+
+PvpLayer "ValidRegion" = {
+    #include "Input";
+    @inputPath                          = "input/ones.pvp";
+    @inverseFlag                        = false;
+    @normalizeLuminanceFlag             = false;
+    @padValue                           = 0;
+};

--- a/tests/InputLayerNormalizeOffsetTest/input/resizePad.params
+++ b/tests/InputLayerNormalizeOffsetTest/input/resizePad.params
@@ -1,0 +1,87 @@
+//
+// resize_pad.params for InputLayerNormalizeOffsetTest
+//
+// created by peteschultz: Aug 31, 2017
+//
+
+// A params file to test normalizeLuminanceFlag with resizing.
+// There are two PvpLayers, "Input", and "ValidRegion".
+// "Input" reads an 8-by-8-by-1 activity pvp file of the values 1 to 64.
+// "ValidRegion" reads an 8-by-8-by-1 activity pvp file of all ones.
+
+// The layers are 12-by-8 and autoResizeFlag true and adjustAspectRatio set to "crop".
+//
+// The Input layer has normalizeLuminance on, and ValidRegion has normalizeLuminance off.
+// They both have the same offsets, and neither resizes.
+// The pad value for Input is -1, and the pad value for ValidRegion is zero.
+//
+// In the part of the layer where ValidRegion is zero, normalizeLuminance should not change
+// the pad value of -1.
+//
+// In the part of the layer where ValidRegion is zero, the values should be normalized
+// to have mean value zero and standard deviation one.
+//
+// The InputRegionLayerTest.cpp code allocates the HyPerCol and then checks 
+// the contents of the InputLayer, using the contents of the ValidRegion layer.
+
+debugParsing = false;
+
+HyPerCol "column" = {
+    startTime                           = 0;
+    dt                                  = 1;
+    stopTime                            = 10;
+    progressInterval                    = 10;
+    writeProgressToErr                  = false;
+    outputPath                          = "output/";
+    verifyWrites                        = false;
+    checkpointWrite                     = false;
+    lastCheckpointDir                   = "output/Last";
+    initializeFromCheckpointDir         = "";
+    printParamsFilename                 = "pv.params";
+    randomSeed                          = 1234567890;
+    nx                                  = 12;
+    ny                                  = 8;
+    nbatch                              = 1;
+    errorOnNotANumber                   = true;
+};
+
+PvpLayer "Input" = {
+    nxScale                             = 1;
+    nyScale                             = 1;
+    nf                                  = 1;
+    phase                               = 0;
+    mirrorBCflag                        = false;
+    valueBC                             = 0;
+    initializeFromCheckpointFlag        = false;
+    writeStep                           = 1;
+    initialWriteTime                    = 0;
+    sparseLayer                         = false;
+    updateGpu                           = false;
+    displayPeriod                       = 0;
+    inputPath                           = "input/inputimage.pvp";
+    offsetAnchor                        = "cc";
+    offsetX                             = 0;
+    offsetY                             = 0;
+    maxShiftX                           = 0;
+    maxShiftY                           = 0;
+    jitterChangeInterval                = 1;
+    autoResizeFlag                      = true;
+    aspectRatioAdjustment               = "pad";
+    interpolationMethod                 = "nearestneighbor";
+    inverseFlag                         = false;
+    normalizeLuminanceFlag              = true;
+    normalizeStdDev                     = true;
+    useInputBCflag                      = false;
+    padValue                            = -1;
+    batchMethod                         = "byFile";
+    randomSeed                          = 123456789;
+    start_frame_index                   = [0.000000];
+};
+
+PvpLayer "ValidRegion" = {
+    #include "Input";
+    @inputPath                          = "input/ones.pvp";
+    @inverseFlag                        = false;
+    @normalizeLuminanceFlag             = false;
+    @padValue                           = 0;
+};

--- a/tests/InputLayerNormalizeOffsetTest/input/translate.params
+++ b/tests/InputLayerNormalizeOffsetTest/input/translate.params
@@ -1,5 +1,5 @@
 //
-// InputLayerNormalizeOffsetTest.params
+// translate.params for InputLayerNormalizeOffsetTest
 //
 // created by peteschultz: Aug 31, 2017
 //

--- a/tests/InputLayerNormalizeOffsetTest/src/InputLayerNormalizeOffsetTest.cpp
+++ b/tests/InputLayerNormalizeOffsetTest/src/InputLayerNormalizeOffsetTest.cpp
@@ -28,13 +28,6 @@ void verifyActivity(
 int main(int argc, char *argv[]) {
    PV::PV_Init *pv_init =
          new PV::PV_Init(&argc, &argv, false /* do not allow unrecognized arguments */);
-   std::string const correctParams = std::string("input/InputLayerNormalizeOffsetTest.params");
-   std::string const &paramsFile   = pv_init->getStringArgument(std::string("ParamsFile"));
-   if (!paramsFile.empty() and paramsFile != correctParams) {
-      WarnLog() << "This test requires params file InputLayerNormalizeOffsetTest.params\n";
-      WarnLog() << "The ParamsFile configuration setting will be ignored.\n";
-   }
-   pv_init->setParams(correctParams.c_str());
 
    PV::HyPerCol *hc = new PV::HyPerCol(pv_init);
    hc->allocateColumn();


### PR DESCRIPTION
This pull request adds additional params files to InputLayerNormalizeOffsetTest, to test additional cases:

The original params file has been renamed `translate.params`, and it applies an offset without resizing.

The new file `resize_pad.params` changes the layer size to 12x8, while loading the same 8x8 images, and sets autoResizeFlag to true and adjustAspectRatio to pad. It sets offsetX and offsetY to zero.

The new file `resize_crop.params` is the same, except that it sets adjustAspectRatio to crop, and sets offsetX to 1 so that the InputRegion layer will not be all ones.