### PR TITLE
Removed redundant messages in non-root processes.

### DIFF
--- a/src/columns/HyPerCol.hpp
+++ b/src/columns/HyPerCol.hpp
@@ -236,7 +236,8 @@ class HyPerCol : public Subject, Observer {
    void addObject(BaseObject *obj);
    int checkDirExists(const char *dirname, struct stat *pathstat);
    inline void notify(std::vector<std::shared_ptr<BaseMessage const>> messages) {
-      Subject::notify(mObjectHierarchy, messages, getCommunicator()->commRank() == 0 /*printFlag*/);
+      Subject::notify(
+            mObjectHierarchy, messages, getCommunicator()->globalCommRank() == 0 /*printFlag*/);
    }
    inline void notify(std::shared_ptr<BaseMessage const> message) {
       notify(std::vector<std::shared_ptr<BaseMessage const>>{message});

--- a/src/columns/PV_Init.cpp
+++ b/src/columns/PV_Init.cpp
@@ -222,12 +222,15 @@ int PV_Init::setMPIConfiguration(int rows, int columns, int batchWidth) {
 }
 
 void PV_Init::printInitMessage() {
-   time_t currentTime = time(nullptr);
-   InfoLog() << "PetaVision initialized at "
-             << ctime(&currentTime); // string returned by ctime contains a trailing \n.
-   InfoLog() << "Configuration is:\n";
-   printState();
-   InfoLog().printf("----------------\n");
+   Communicator *communicator = getCommunicator();
+   if (communicator == nullptr or communicator->globalCommRank() == 0) {
+      time_t currentTime = time(nullptr);
+      InfoLog() << "PetaVision initialized at "
+                << ctime(&currentTime); // string returned by ctime contains a trailing \n.
+      InfoLog() << "Configuration is:\n";
+      printState();
+      InfoLog().printf("----------------\n");
+   }
 }
 
 int PV_Init::resetState() {

--- a/src/columns/RandomSeed.cpp
+++ b/src/columns/RandomSeed.cpp
@@ -30,7 +30,6 @@ void RandomSeed::initialize(unsigned int initialSeed) {
    mInitialized = true;
    mInitialSeed = initialSeed;
    mNextSeed    = initialSeed;
-   InfoLog() << "RandomSeed initialized to " << mNextSeed << ".\n";
 }
 
 unsigned int RandomSeed::allocate(unsigned int numRequested) {

--- a/src/connections/HyPerConn.cpp
+++ b/src/connections/HyPerConn.cpp
@@ -601,7 +601,9 @@ void HyPerConn::ioParam_sharedWeights(enum ParamsIOFlag ioFlag) {
          ioFlag, name, "sharedWeights", &sharedWeights, true /*default*/, true /*warn if absent*/);
    if (sharedWeights == false and receiveGpu == true) {
       if (parent->getCommunicator()->globalCommRank() == 0) {
-         ErrorLog().printf("%s: sharedWeights must be true in order to receive on the GPU.\n", getDescription_c());
+         ErrorLog().printf(
+               "%s: sharedWeights must be true in order to receive on the GPU.\n",
+               getDescription_c());
       }
       MPI_Barrier(parent->getCommunicator()->globalCommunicator());
       MPI_Finalize();
@@ -856,7 +858,7 @@ void HyPerConn::ioParam_nyp(enum ParamsIOFlag ioFlag) {
 void HyPerConn::ioParam_nfp(enum ParamsIOFlag ioFlag) {
    parent->parameters()->ioParamValue(ioFlag, name, "nfp", &nfp, -1, false);
    if (ioFlag == PARAMS_IO_READ && nfp == -1 && !parent->parameters()->present(name, "nfp")
-       && parent->columnId() == 0) {
+       && parent->getCommunicator()->globalCommRank() == 0) {
       InfoLog().printf(
             "%s: nfp will be set in the communicateInitInfo() stage.\n", getDescription_c());
    }

--- a/src/connections/TransposeConn.cpp
+++ b/src/connections/TransposeConn.cpp
@@ -343,7 +343,10 @@ int TransposeConn::allocatePostDeviceWeights() { return PV_SUCCESS; }
 
 // Set this post to orig
 int TransposeConn::allocatePostConn() {
-   InfoLog() << "Connection " << name << " setting " << originalConn->getName() << " as postConn\n";
+   if (parent->getCommunicator()->globalCommRank() == 0) {
+      InfoLog() << "Connection " << name << " setting " << originalConn->getName()
+                << " as postConn\n";
+   }
    postConn = originalConn;
 
    // Can't do this with shrink patches flag

--- a/src/io/PVParams.cpp
+++ b/src/io/PVParams.cpp
@@ -2252,12 +2252,14 @@ int PVParams::checkDuplicates(const char *paramName, double val) {
       if (!strcmp(paramName, parm->name())) {
          double oldval = parm->value();
          if (val == oldval) {
-            WarnLog().printf(
-                  "parameter name \"%s\" duplicates a previous parameter name and value (%s = "
-                  "%f)\n",
-                  paramName,
-                  parm->name(),
-                  val);
+            if (worldRank == 0) {
+               WarnLog().printf(
+                     "parameter name \"%s\" duplicates a previous parameter name and value "
+                     "(%s = %f)\n",
+                     paramName,
+                     parm->name(),
+                     val);
+            }
          }
          else {
             ErrorLog().printf(

--- a/tests/BatchCheckpointSystemTest/input/CheckpointParameters1.params
+++ b/tests/BatchCheckpointSystemTest/input/CheckpointParameters1.params
@@ -50,7 +50,6 @@ HyPerLayer "OutputNoDelay" = {
     writeStep                           = 1;
     initialWriteTime                    = 0;
     sparseLayer                         = true;
-    writeSparseValues                   = true;
     updateGpu                           = false;
     dataType                            = NULL;
 };
@@ -66,7 +65,6 @@ HyPerLayer "OutputWithDelay" = {
     writeStep                           = 1;
     initialWriteTime                    = 0;
     sparseLayer                         = true;
-    writeSparseValues                   = true;
     updateGpu                           = false;
     dataType                            = NULL;
 };
@@ -82,7 +80,6 @@ HyPerLayer "OutputArbor" = {
     writeStep                           = 1;
     initialWriteTime                    = 0;
     sparseLayer                         = true;
-    writeSparseValues                   = true;
     updateGpu                           = false;
     dataType                            = NULL;
 };
@@ -98,7 +95,6 @@ HyPerLayer "OutputFromFullHyPerConn" = {
     writeStep                           = 1;
     initialWriteTime                    = 0;
     sparseLayer                         = true;
-    writeSparseValues                   = true;
     updateGpu                           = false;
     dataType                            = NULL;
 };

--- a/tests/BatchCheckpointSystemTest/input/CheckpointParameters2.params
+++ b/tests/BatchCheckpointSystemTest/input/CheckpointParameters2.params
@@ -52,7 +52,6 @@ HyPerLayer "OutputNoDelay" = {
     writeStep                           = 1;
     initialWriteTime                    = 0;
     sparseLayer                         = true;
-    writeSparseValues                   = true;
     updateGpu                           = false;
     dataType                            = NULL;
     VThresh                             = -3.40282e+38;
@@ -74,7 +73,6 @@ HyPerLayer "OutputWithDelay" = {
     writeStep                           = 1;
     initialWriteTime                    = 0;
     sparseLayer                         = true;
-    writeSparseValues                   = true;
     updateGpu                           = false;
     dataType                            = NULL;
 };
@@ -91,7 +89,6 @@ HyPerLayer "OutputArbor" = {
     writeStep                           = 1;
     initialWriteTime                    = 0;
     sparseLayer                         = true;
-    writeSparseValues                   = true;
     updateGpu                           = false;
     dataType                            = NULL;
 };
@@ -108,7 +105,6 @@ HyPerLayer "OutputFromFullHyPerConn" = {
     writeStep                           = 1;
     initialWriteTime                    = 0;
     sparseLayer                         = true;
-    writeSparseValues                   = true;
     updateGpu                           = false;
     dataType                            = NULL;
 };

--- a/tests/BatchMPICheckpointSystemTest/input/CheckpointParameters1.params
+++ b/tests/BatchMPICheckpointSystemTest/input/CheckpointParameters1.params
@@ -50,7 +50,6 @@ HyPerLayer "OutputNoDelay" = {
     writeStep                           = 1;
     initialWriteTime                    = 0;
     sparseLayer                         = true;
-    writeSparseValues                   = true;
     updateGpu                           = false;
     dataType                            = NULL;
 };
@@ -66,7 +65,6 @@ HyPerLayer "OutputWithDelay" = {
     writeStep                           = 1;
     initialWriteTime                    = 0;
     sparseLayer                         = true;
-    writeSparseValues                   = true;
     updateGpu                           = false;
     dataType                            = NULL;
 };
@@ -82,7 +80,6 @@ HyPerLayer "OutputArbor" = {
     writeStep                           = 1;
     initialWriteTime                    = 0;
     sparseLayer                         = true;
-    writeSparseValues                   = true;
     updateGpu                           = false;
     dataType                            = NULL;
 };
@@ -98,7 +95,6 @@ HyPerLayer "OutputFromFullHyPerConn" = {
     writeStep                           = 1;
     initialWriteTime                    = 0;
     sparseLayer                         = true;
-    writeSparseValues                   = true;
     updateGpu                           = false;
     dataType                            = NULL;
 };

--- a/tests/BatchMPICheckpointSystemTest/input/CheckpointParameters2.params
+++ b/tests/BatchMPICheckpointSystemTest/input/CheckpointParameters2.params
@@ -52,7 +52,6 @@ HyPerLayer "OutputNoDelay" = {
     writeStep                           = 1;
     initialWriteTime                    = 0;
     sparseLayer                         = true;
-    writeSparseValues                   = true;
     updateGpu                           = false;
     dataType                            = NULL;
 };
@@ -69,7 +68,6 @@ HyPerLayer "OutputWithDelay" = {
     writeStep                           = 1;
     initialWriteTime                    = 0;
     sparseLayer                         = true;
-    writeSparseValues                   = true;
     updateGpu                           = false;
     dataType                            = NULL;
 };
@@ -86,7 +84,6 @@ HyPerLayer "OutputArbor" = {
     writeStep                           = 1;
     initialWriteTime                    = 0;
     sparseLayer                         = true;
-    writeSparseValues                   = true;
     updateGpu                           = false;
     dataType                            = NULL;
 };
@@ -103,7 +100,6 @@ HyPerLayer "OutputFromFullHyPerConn" = {
     writeStep                           = 1;
     initialWriteTime                    = 0;
     sparseLayer                         = true;
-    writeSparseValues                   = true;
     updateGpu                           = false;
     dataType                            = NULL;
 };

--- a/tests/CheckpointSystemTest/input/CheckpointParameters1.params
+++ b/tests/CheckpointSystemTest/input/CheckpointParameters1.params
@@ -49,7 +49,6 @@ HyPerLayer "OutputNoDelay" = {
     writeStep                           = 1;
     initialWriteTime                    = 0;
     sparseLayer                         = true;
-    writeSparseValues                   = true;
     updateGpu                           = false;
     dataType                            = NULL;
 };
@@ -65,7 +64,6 @@ HyPerLayer "OutputWithDelay" = {
     writeStep                           = 1;
     initialWriteTime                    = 0;
     sparseLayer                         = true;
-    writeSparseValues                   = true;
     updateGpu                           = false;
     dataType                            = NULL;
 };
@@ -81,7 +79,6 @@ HyPerLayer "OutputArbor" = {
     writeStep                           = 1;
     initialWriteTime                    = 0;
     sparseLayer                         = true;
-    writeSparseValues                   = true;
     updateGpu                           = false;
     dataType                            = NULL;
 };
@@ -97,7 +94,6 @@ HyPerLayer "OutputFromFullHyPerConn" = {
     writeStep                           = 1;
     initialWriteTime                    = 0;
     sparseLayer                         = true;
-    writeSparseValues                   = true;
     updateGpu                           = false;
     dataType                            = NULL;
 };

--- a/tests/CheckpointSystemTest/input/CheckpointParameters2.params
+++ b/tests/CheckpointSystemTest/input/CheckpointParameters2.params
@@ -49,7 +49,6 @@ HyPerLayer "OutputNoDelay" = {
     writeStep                           = 1;
     initialWriteTime                    = 0;
     sparseLayer                         = true;
-    writeSparseValues                   = true;
     updateGpu                           = false;
     dataType                            = NULL;
 };
@@ -65,7 +64,6 @@ HyPerLayer "OutputWithDelay" = {
     writeStep                           = 1;
     initialWriteTime                    = 0;
     sparseLayer                         = true;
-    writeSparseValues                   = true;
     updateGpu                           = false;
     dataType                            = NULL;
 };
@@ -81,7 +79,6 @@ HyPerLayer "OutputArbor" = {
     writeStep                           = 1;
     initialWriteTime                    = 0;
     sparseLayer                         = true;
-    writeSparseValues                   = true;
     updateGpu                           = false;
     dataType                            = NULL;
 };
@@ -97,7 +94,6 @@ HyPerLayer "OutputFromFullHyPerConn" = {
     writeStep                           = 1;
     initialWriteTime                    = 0;
     sparseLayer                         = true;
-    writeSparseValues                   = true;
     updateGpu                           = false;
     dataType                            = NULL;
 };

--- a/tests/GPULCATest/input/GPULCATest.params
+++ b/tests/GPULCATest/input/GPULCATest.params
@@ -95,7 +95,6 @@ HyPerLCALayer "V1CPU" = {
     writeStep                           = 1;
     initialWriteTime                    = 0;
     sparseLayer                         = true;
-    writeSparseValues                   = true;
     updateGpu                           = false;
     dataType                            = NULL;
     VThresh                             = 0.025;

--- a/tests/LCATest/input/LCATest.params
+++ b/tests/LCATest/input/LCATest.params
@@ -96,7 +96,6 @@ HyPerLCALayer "V1" = {
     writeStep                           = 1;
     initialWriteTime                    = 0;
     sparseLayer                         = true;
-    writeSparseValues                   = true;
     updateGpu                           = false;
     dataType                            = NULL;
     VThresh                             = 0.025;

--- a/tests/LIFTest/input/LIFTest.params
+++ b/tests/LIFTest/input/LIFTest.params
@@ -90,7 +90,6 @@ Retina "Retina" = {
     writeStep                       = -1;
     sparseLayer                     = true;
     updateGpu                       = false;
-    writeSparseValues               = false;
     phase                           = 0;
     triggerLayerName                = NULL;
     spikingFlag                     = true;
@@ -137,7 +136,6 @@ LIFGap "LIFTest" = {
     valueBC                         = 0.0;
     sparseLayer                     = true;
     updateGpu                       = false;
-    writeSparseValues               = false;
     phase                           = 0;
     triggerLayerName                = NULL;
     
@@ -213,7 +211,6 @@ LIFGap "LIFGapTest" = {
     valueBC                         = 0.0;
     sparseLayer                     = true;
     updateGpu                       = false;
-    writeSparseValues               = false;
     phase                           = 0;
     triggerLayerName                = NULL;
     

--- a/tests/LIFTest/input/LIFTest_GPU.params
+++ b/tests/LIFTest/input/LIFTest_GPU.params
@@ -85,7 +85,6 @@ Retina "Retina" = {
     valueBC                         = 0.0;
     writeStep                       = -1;
     sparseLayer                     = true;
-    writeSparseValues               = false;
     phase                           = 0;
     triggerLayerName                = NULL;
     spikingFlag                     = true;
@@ -130,7 +129,6 @@ LIFGap "LIFTest" = {
     mirrorBCflag                    = false;
     valueBC                         = 0.0;
     sparseLayer                     = true;
-    writeSparseValues               = false;
     phase                           = 0;
     triggerLayerName                = NULL;
     
@@ -204,7 +202,6 @@ LIFGap "LIFGapTest" = {
     mirrorBCflag                    = false;
     valueBC                         = 0.0;
     sparseLayer                     = true;
-    writeSparseValues               = false;
     phase                           = 0;
     triggerLayerName                = NULL;
     

--- a/tests/MomentumLCATest/input/MomentumLCATest.params
+++ b/tests/MomentumLCATest/input/MomentumLCATest.params
@@ -105,7 +105,6 @@ MomentumLCALayer "V1" = {
     writeStep                           = 1;
     initialWriteTime                    = 0; // 1.44e+06;
     sparseLayer                         = true;
-    writeSparseValues                   = true;
     updateGpu                           = false;
     VThresh                             = 0.025;
     AMin                                = 0;

--- a/tests/RandStateSystemTest/input/RandStateSystemTest1.params
+++ b/tests/RandStateSystemTest/input/RandStateSystemTest1.params
@@ -109,7 +109,6 @@ Retina "RetinaOff" = {
     spikingFlag                 = true;  // false (no quotes) is translated to 0
     
     sparseLayer                 = true;
-    writeSparseValues           = false; // spiking retinas have binary activities
     writeStep                   = -1;
 
     foregroundRate              = 200;   // Hz // Max poisson spiking rate when input is 255

--- a/tests/RandStateSystemTest/input/RandStateSystemTest2.params
+++ b/tests/RandStateSystemTest/input/RandStateSystemTest2.params
@@ -109,7 +109,6 @@ Retina "RetinaOff" = {
     spikingFlag                 = true;  // false (no quotes) is translated to 0
     
     sparseLayer                 = true;
-    writeSparseValues           = false; // spiking retinas have binary activities
     writeStep                   = -1;
 
     foregroundRate              = 200;   // Hz // Max poisson spiking rate when input is 255

--- a/tests/ResetStateOnTriggerTest/input/ResetStateOnTriggerGPU.params
+++ b/tests/ResetStateOnTriggerTest/input/ResetStateOnTriggerGPU.params
@@ -109,7 +109,6 @@ HyPerLCALayer "V1" = {
     writeStep                           = 1;
     initialWriteTime                    = 0; // 1.44e+06;
     sparseLayer                         = true;
-    writeSparseValues                   = true;
     updateGpu                           = false;
     VThresh                             = 0.025;
     AMin                                = 0;

--- a/tests/SegmentTest/input/centerpoint.params
+++ b/tests/SegmentTest/input/centerpoint.params
@@ -27,7 +27,6 @@ PvpLayer "Input" = {
     writeFrameToTimestamp = true;
     writeStep = -1;
     sparseLayer = false;
-    writeSparseValues = true;
     displayPeriod = 0;
     mirrorBCflag = true;
     useInputBCflag = false;

--- a/tests/SegmentTest/input/segmentResize.params
+++ b/tests/SegmentTest/input/segmentResize.params
@@ -26,7 +26,6 @@ PvpLayer "Input" = {
     writeFrameToTimestamp = true;
     writeStep = -1;
     sparseLayer = false;
-    writeSparseValues = true;
     displayPeriod = 0;
     mirrorBCflag = true;
     useInputBCflag = false;

--- a/tests/SegmentTest/input/testInOutSegmentify.params
+++ b/tests/SegmentTest/input/testInOutSegmentify.params
@@ -27,7 +27,6 @@ PvpLayer "Input" = {
     writeFrameToTimestamp = true;
     writeStep = -1;
     sparseLayer = false;
-    writeSparseValues = true;
     displayPeriod = 0;
     mirrorBCflag = true;
     useInputBCflag = false;

--- a/tests/TotalEnergyTest/input/TotalEnergyTest.params
+++ b/tests/TotalEnergyTest/input/TotalEnergyTest.params
@@ -103,7 +103,6 @@ HyPerLCALayer "V1" = {
     writeStep                           = 1;
     initialWriteTime                    = 0; // 1.44e+06;
     sparseLayer                         = true;
-    writeSparseValues                   = true;
     VThresh                             = 0.025;
     AMin                                = 0;
     AMax                                = infinity;

--- a/tests/WriteSparseFileTest/input/WriteSparseFileTest.params
+++ b/tests/WriteSparseFileTest/input/WriteSparseFileTest.params
@@ -74,7 +74,6 @@ ANNLayer "output" = {
     writeStep = 1.0;
     initialWriteTime = 1.0;
     sparseLayer = true;
-    writeSparseValues = true;
 
     InitVType = "ZeroV";
 
@@ -117,7 +116,6 @@ ANNLayer "comparison" = {
     writeStep = 1.0;
     initialWriteTime = 1.0;
     sparseLayer = true;
-    writeSparseValues = true;
 
     InitVType = "ZeroV";
 


### PR DESCRIPTION
This pull request addresses duplication of messages when run under MPI. In many cases, each MPI process writes the same message to its log file even though the duplication carries no additional information. With this pull request, such messages (at least the most common ones) are written only by the root process. Additionally, timer information produced when the HyPerCol is deleted at the end of a run is only sent to the root process, since the MPI_Barrier calls should keep the timers more or less in sync.