### PR TITLE
Additional flushes sent to output stream

### DIFF
--- a/src/checkpointing/Checkpointer.cpp
+++ b/src/checkpointing/Checkpointer.cpp
@@ -787,10 +787,6 @@ void Checkpointer::checkpointNow() {
       return;
    }
    checkpointToDirectory(checkpointDirectory);
-   if (mMPIBlock->getRank() == 0) {
-      InfoLog().printf("checkpointWrite complete. simTime = %f\n", mTimeInfo.mSimTime);
-      InfoLog().flush();
-   }
 
    if (mDeleteOlderCheckpoints) {
       rotateOldCheckpoints(checkpointDirectory);
@@ -826,6 +822,10 @@ void Checkpointer::checkpointToDirectory(std::string const &directory) {
    mCheckpointTimer->start();
    writeTimers(checkpointDirectory);
    mCheckpointTimer->stop();
+   if (mMPIBlock->getRank() == 0) {
+      InfoLog().printf("checkpointWrite complete. simTime = %f\n", mTimeInfo.mSimTime);
+      InfoLog().flush();
+   }
 }
 
 void Checkpointer::finalCheckpoint(double simTime) {

--- a/src/columns/HyPerCol.cpp
+++ b/src/columns/HyPerCol.cpp
@@ -486,6 +486,7 @@ int HyPerCol::run(double start_time, double stop_time, double dt) {
    mDeltaTime = dt;
 
    allocateColumn();
+   getOutputStream().flush();
 
    bool dryRunFlag = mPVInitObj->getBooleanArgument("DryRun");
    if (dryRunFlag) {
@@ -671,6 +672,7 @@ int HyPerCol::advanceTime(double sim_time) {
          time(&current_time);
          progressStream << "   time==" << sim_time << "  "
                         << ctime(&current_time); // ctime outputs an newline
+         progressStream.flush();
       }
    }
 


### PR DESCRIPTION
Following the discussion in
<https://github.com/PetaVision/OpenPV/issues/242>, commands to flush
the output stream have been added in the following cases:
    on return from HyPerCol::allocateColumn()
    when the 'time===' progress message is printed
    on writing a SIGUSR1-generated checkpoint.