### PR TITLE
Modifies lua scripts to handle null string params

### DIFF
--- a/parameterWrapper/PVModule.lua
+++ b/parameterWrapper/PVModule.lua
@@ -13,7 +13,7 @@ end
 --Prints a single parameter value to string for parameters in a group
 local function valToString(paramStringTable, val)
    --NULL value
-   if(val == nil) then
+   if(type(val) == "function") then
       appendString(paramStringTable, "NULL")
    --Param sweep option
    elseif(type(val) == "table") then

--- a/src/columns/HyPerCol.cpp
+++ b/src/columns/HyPerCol.cpp
@@ -924,6 +924,8 @@ int HyPerCol::outputParams(char const *path) {
       mLuaPrintParamsStream->printf(
             "package.path = package.path .. \";\" .. \"" PV_DIR "/../parameterWrapper/?.lua\"\n");
       mLuaPrintParamsStream->printf("local pv = require \"PVModule\"\n\n");
+      mLuaPrintParamsStream->printf(
+            "NULL = function() end; -- to allow string parameters to be set to NULL\n\n");
       mLuaPrintParamsStream->printf("-- Base table variable to store\n");
       mLuaPrintParamsStream->printf("local pvParameters = {\n");
    }

--- a/src/io/PVParams.cpp
+++ b/src/io/PVParams.cpp
@@ -1546,7 +1546,7 @@ void PVParams::writeParamString(const char *paramName, const char *svalue) {
       }
       else {
          mPrintParamsStream->printf("    %-35s = NULL;\n", paramName);
-         mPrintLuaStream->printf("    %-35s = nil;\n", paramName);
+         mPrintLuaStream->printf("    %-35s = NULL;\n", paramName);
       }
    }
 }


### PR DESCRIPTION
This pull request addresses an issue where params files generated from lua scripts were not able to set a string parameter to NULL.

Now, the generated .lua file defines a (trivial) function called NULL, and entries in the Lua table can be set to NULL instead of nil.