### PR TITLE
Removes the startTime parameter

### DIFF
--- a/cmake/ExampleProject/input/ExampleProject.params
+++ b/cmake/ExampleProject/input/ExampleProject.params
@@ -2,7 +2,6 @@
 
 
 HyPerCol "column" = {
-    startTime                           = 0;
     dt                                  = 1;
     stopTime                            = 10;
     progressInterval                    = 10;

--- a/parameterWrapper/examples/example_params.lua
+++ b/parameterWrapper/examples/example_params.lua
@@ -34,7 +34,6 @@ local basicParams = {
       ny = nySize;
       dt = 1.0;
       randomSeed = 1234567890;
-      startTime = 0.0;
       stopTime = 10.0; 
       errorOnNotANumber = true;
       progressInterval = 10.0;

--- a/parameterWrapper/examples/specializedBinoc.lua
+++ b/parameterWrapper/examples/specializedBinoc.lua
@@ -52,7 +52,6 @@ local pvParams = {
       ny = nySize;
       dt = 1.0;
       randomSeed = 1234567890;
-      startTime = 0.0;
       stopTime = 100000000.0; 
       progressInterval = 5000.0;
       writeProgressToErr = true;

--- a/src/arch/cuda/CudaDevice.hpp
+++ b/src/arch/cuda/CudaDevice.hpp
@@ -129,7 +129,7 @@ class CudaDevice {
    struct cudaDeviceProp device_props;
    cudaStream_t stream;
    long deviceMem;
-   size_t numConvKernels;
+   size_t numConvKernels = (size_t)0;
 
    void *handle;
 };

--- a/src/bindings/input/BasicSystemTest.params
+++ b/src/bindings/input/BasicSystemTest.params
@@ -17,7 +17,6 @@ HyPerCol "column" = {
    dt = 1.0;  //time step in ms.
    dtAdaptFlag = false;  // If true, layers can provide HyPerCol info on acceptable timesteps and dt can be adjusted accordingly 
    randomSeed = 1234567890;  // Must be at least 8 digits long.  // if not set here,  clock time is used to generate seed
-   startTime = 0.0;
    stopTime = 10.0;  
    errorOnNotANumber = true;
    progressInterval = 10.0; //Program will output its progress at each progressStep

--- a/src/columns/HyPerCol.hpp
+++ b/src/columns/HyPerCol.hpp
@@ -51,11 +51,6 @@ class HyPerCol : public Subject, Observer {
     */
 
    /**
-    * @brief mStartTime: The set starting time for the run
-    */
-   virtual void ioParam_startTime(enum ParamsIOFlag ioFlag);
-
-   /**
     * @brief mStopTime: The set stopping time for the run
     */
    virtual void ioParam_stopTime(enum ParamsIOFlag ioFlag);
@@ -165,8 +160,8 @@ class HyPerCol : public Subject, Observer {
     * This method is called by the run() method.
     */
    void allocateColumn();
-   int run() { return run(mStartTime, mStopTime, mDeltaTime); }
-   int run(double mStartTime, double mStopTime, double dt);
+   int run() { return run(mStopTime, mDeltaTime); }
+   int run(double stopTime, double dt);
    NormalizeBase *getNormalizerFromName(const char *normalizerName);
 
    // Getters and setters
@@ -180,7 +175,6 @@ class HyPerCol : public Subject, Observer {
    const char *getPrintParamsFilename() const { return mPrintParamsFilename; }
    double getDeltaTime() const { return mDeltaTime; }
    double simulationTime() const { return mSimTime; }
-   double getStartTime() const { return mStartTime; }
    double getStopTime() const { return mStopTime; }
    int globalRank() { return mCommunicator->globalCommRank(); }
    int columnId() { return mCommunicator->commRank(); }
@@ -285,7 +279,6 @@ class HyPerCol : public Subject, Observer {
    char *mPrintParamsFilename; // filename for outputting the mParams, including
    // defaults and
    // excluding unread mParams
-   double mStartTime;
    double mSimTime;
    double mStopTime; // time to stop time
    double mDeltaTime; // time step interval

--- a/src/connections/CopyConn.cpp
+++ b/src/connections/CopyConn.cpp
@@ -94,7 +94,7 @@ void CopyConn::ioParam_weightUpdatePeriod(enum ParamsIOFlag ioFlag) {
 
 void CopyConn::ioParam_initialWeightUpdateTime(enum ParamsIOFlag ioFlag) {
    if (ioFlag == PARAMS_IO_READ) {
-      initialWeightUpdateTime = parent->getStartTime();
+      initialWeightUpdateTime = 0.0;
       parent->parameters()->handleUnnecessaryParameter(name, "initialWeightUpdateTime");
       weightUpdateTime = initialWeightUpdateTime;
    }

--- a/src/connections/HyPerConn.cpp
+++ b/src/connections/HyPerConn.cpp
@@ -772,22 +772,20 @@ void HyPerConn::ioParam_writeStep(enum ParamsIOFlag ioFlag) {
 void HyPerConn::ioParam_initialWriteTime(enum ParamsIOFlag ioFlag) {
    pvAssert(!parent->parameters()->presentAndNotBeenRead(name, "writeStep"));
    if (writeStep >= 0) {
-      double start_time = parent->getStartTime();
       parent->parameters()->ioParamValue(
-            ioFlag, name, "initialWriteTime", &initialWriteTime, start_time);
+            ioFlag, name, "initialWriteTime", &initialWriteTime, initialWriteTime);
       if (ioFlag == PARAMS_IO_READ) {
-         if (writeStep > 0 && initialWriteTime < start_time) {
+         if (writeStep > 0 && initialWriteTime < 0.0) {
             if (parent->columnId() == 0) {
                WarnLog(adjustInitialWriteTime);
                adjustInitialWriteTime.printf(
-                     "%s: initialWriteTime %f earlier than starting time %f.  Adjusting "
+                     "%s: initialWriteTime %f is negative.  Adjusting "
                      "initialWriteTime:\n",
                      getDescription_c(),
-                     initialWriteTime,
-                     start_time);
+                     initialWriteTime);
                adjustInitialWriteTime.flush();
             }
-            while (initialWriteTime < start_time) {
+            while (initialWriteTime < 0.0) {
                initialWriteTime += writeStep;
             }
             if (parent->columnId() == 0) {

--- a/src/connections/HyPerConn.hpp
+++ b/src/connections/HyPerConn.hpp
@@ -456,7 +456,7 @@ class HyPerConn : public BaseConnection {
    float wMax;
    float wMin;
    double wPostTime; // time of last conversion to wPostPatches
-   double initialWriteTime;
+   double initialWriteTime = 0.0;
    double writeTime; // time of next output, initialized in params file parameter initialWriteTime
    double writeStep; // output time interval
    bool writeCompressedWeights; // if true, outputState writes weights with 8-bit precision; if

--- a/src/connections/TransposeConn.cpp
+++ b/src/connections/TransposeConn.cpp
@@ -145,7 +145,7 @@ void TransposeConn::ioParam_weightUpdatePeriod(enum ParamsIOFlag ioFlag) {
 
 void TransposeConn::ioParam_initialWeightUpdateTime(enum ParamsIOFlag ioFlag) {
    if (ioFlag == PARAMS_IO_READ) {
-      initialWeightUpdateTime = parent->getStartTime();
+      initialWeightUpdateTime = 0.0;
       // Every timestep needUpdate checks originalConn's lastUpdateTime against transpose's
       // lastUpdateTime, so weightUpdatePeriod and initialWeightUpdateTime aren't needed
       parent->parameters()->handleUnnecessaryParameter(

--- a/src/connections/TransposePoolingConn.cpp
+++ b/src/connections/TransposePoolingConn.cpp
@@ -193,7 +193,7 @@ void TransposePoolingConn::ioParam_weightUpdatePeriod(enum ParamsIOFlag ioFlag) 
 
 void TransposePoolingConn::ioParam_initialWeightUpdateTime(enum ParamsIOFlag ioFlag) {
    if (ioFlag == PARAMS_IO_READ) {
-      initialWeightUpdateTime = parent->getStartTime();
+      initialWeightUpdateTime = 0.0;
       // Every timestep needUpdate checks mOriginalConn's lastUpdateTime against transpose's
       // lastUpdateTime, so weightUpdatePeriod and initialWeightUpdateTime aren't needed
       parent->parameters()->handleUnnecessaryParameter(

--- a/src/layers/ConstantLayer.cpp
+++ b/src/layers/ConstantLayer.cpp
@@ -44,15 +44,10 @@ int ConstantLayer::communicateInitInfo(std::shared_ptr<CommunicateInitInfoMessag
 }
 
 // bool ConstantLayer::checkIfUpdateNeeded() {
-bool ConstantLayer::needUpdate(double time, double dt) {
+bool ConstantLayer::needUpdate(double timestamp, double dt) {
    // Only update on initialization
-   assert(time >= parent->getStartTime());
-   if (time == parent->getStartTime()) {
-      return true;
-   }
-   else {
-      return false;
-   }
+   assert(timestamp >= 0.0);
+   return (timestamp == 0.0);
 }
 
 } /* namespace PV */

--- a/src/layers/ConstantLayer.hpp
+++ b/src/layers/ConstantLayer.hpp
@@ -16,7 +16,7 @@ class ConstantLayer : public PV::HyPerLayer {
   public:
    ConstantLayer(const char *name, HyPerCol *hc);
    virtual ~ConstantLayer();
-   virtual bool needUpdate(double time, double dt) override;
+   virtual bool needUpdate(double timestamp, double dt) override;
 
   protected:
    ConstantLayer();

--- a/src/layers/HyPerLayer.cpp
+++ b/src/layers/HyPerLayer.cpp
@@ -848,22 +848,19 @@ void HyPerLayer::ioParam_writeStep(enum ParamsIOFlag ioFlag) {
 void HyPerLayer::ioParam_initialWriteTime(enum ParamsIOFlag ioFlag) {
    assert(!parent->parameters()->presentAndNotBeenRead(name, "writeStep"));
    if (writeStep >= 0.0) {
-      double start_time = parent->getStartTime();
-      parent->parameters()->ioParamValue(
-            ioFlag, name, "initialWriteTime", &initialWriteTime, start_time);
-      if (ioFlag == PARAMS_IO_READ && writeStep > 0.0 && initialWriteTime < start_time) {
+      parent->parameters()->ioParamValue(ioFlag, name, "initialWriteTime", &initialWriteTime, 0.0);
+      if (ioFlag == PARAMS_IO_READ && writeStep > 0.0 && initialWriteTime < 0.0) {
          double storeInitialWriteTime = initialWriteTime;
-         while (initialWriteTime < start_time) {
+         while (initialWriteTime < 0.0) {
             initialWriteTime += writeStep;
          }
          if (parent->columnId() == 0) {
             WarnLog(warningMessage);
             warningMessage.printf(
-                  "%s: initialWriteTime %f is earlier than start time %f.  Adjusting "
+                  "%s: initialWriteTime %f is negative.  Adjusting "
                   "initialWriteTime:\n",
                   getDescription_c(),
-                  initialWriteTime,
-                  start_time);
+                  initialWriteTime);
             warningMessage.printf("    initialWriteTime adjusted to %f\n", initialWriteTime);
          }
       }

--- a/src/layers/ImageFromMemoryBuffer.cpp
+++ b/src/layers/ImageFromMemoryBuffer.cpp
@@ -168,9 +168,7 @@ int ImageFromMemoryBuffer::updateState(double time, double dt) {
    return PV_SUCCESS;
 }
 
-double ImageFromMemoryBuffer::getDeltaUpdateTime() {
-   return parent->getStopTime() - parent->getStartTime();
-}
+double ImageFromMemoryBuffer::getDeltaUpdateTime() { return parent->getStopTime(); }
 
 ImageFromMemoryBuffer::~ImageFromMemoryBuffer() {}
 

--- a/src/layers/ImageFromMemoryBuffer.hpp
+++ b/src/layers/ImageFromMemoryBuffer.hpp
@@ -86,8 +86,7 @@ class ImageFromMemoryBuffer : public ImageLayer {
    virtual bool needUpdate(double time, double dt) override { return hasNewImageFlag; }
 
    /**
-    * For ImageFromMemoryBuffer, the updateTime is the parent->getStopTime() -
-    * parent->getStartTime().
+    * For ImageFromMemoryBuffer, the updateTime is the parent->getStopTime().
     * Implemented to allow triggering off of an ImageFromMemoryBuffer layer.
     */
    virtual double getDeltaUpdateTime() override;

--- a/src/normalizers/NormalizeBase.cpp
+++ b/src/normalizers/NormalizeBase.cpp
@@ -96,7 +96,7 @@ int NormalizeBase::normalizeWeightsWrapper() {
    int status      = PV_SUCCESS;
    double simTime  = parent->simulationTime();
    bool needUpdate = false;
-   if (normalizeOnInitialize && simTime == parent->getStartTime()) {
+   if (normalizeOnInitialize && simTime == 0.0) {
       needUpdate = true;
    }
    else if (!normalizeOnWeightUpdate) {

--- a/src/probes/PointLIFProbe.cpp
+++ b/src/probes/PointLIFProbe.cpp
@@ -36,7 +36,7 @@ int PointLIFProbe::initialize_base() {
 
 int PointLIFProbe::initialize(const char *name, HyPerCol *hc) {
    int status = PointProbe::initialize(name, hc);
-   writeTime  = parent->getStartTime();
+   writeTime  = 0.0;
    return status;
 }
 

--- a/src/probes/QuotientColProbe.cpp
+++ b/src/probes/QuotientColProbe.cpp
@@ -132,7 +132,7 @@ int QuotientColProbe::communicateInitInfo(
 int QuotientColProbe::calcValues(double timeValue) {
    int numValues        = this->getNumValues();
    double *valuesBuffer = getValuesBuffer();
-   if (parent->simulationTime() == parent->getStartTime()) {
+   if (parent->simulationTime() == 0.0) {
       for (int b = 0; b < numValues; b++) {
          valuesBuffer[b] = 1.0;
       }

--- a/tests/ANNLayerVerticesTest/input/ANNLayerVerticesTest.params
+++ b/tests/ANNLayerVerticesTest/input/ANNLayerVerticesTest.params
@@ -16,7 +16,6 @@ HyPerCol "column" = {
    ny = 32;
    dt = 1.0;  //time step in ms.
    randomSeed = 1234567890;  // Must be at least 8 digits long.  // if not set here,  clock time is used to generate seed
-   startTime = 0.0;
    stopTime = 10.0;  
    errorOnNotANumber = true;
    progressInterval = 10.0; //Program will output its progress at each progressInterval

--- a/tests/AdjustAxonalArborsTest/input/AdjustAxonalArborsTest.params
+++ b/tests/AdjustAxonalArborsTest/input/AdjustAxonalArborsTest.params
@@ -34,7 +34,6 @@ HyPerCol "column" = {
    ny = 2;
    dt = 1.0;  //time step in ms.	     
    randomSeed = 1290140979;  // Must be at least 8 digits long.  // if not set here,  clock time is used to generate seed
-   startTime = 0.0;
    stopTime = 10.0;  
    progressInterval = 10.0; //Program will output its progress at each progressInterval
    writeProgressToErr = false;  

--- a/tests/ArborSystemTest/input/test_arbors.params
+++ b/tests/ArborSystemTest/input/test_arbors.params
@@ -14,7 +14,6 @@ HyPerCol "column" = {
    ny = 32;
    dt = 1.0;
    randomSeed = 17406293508;  // if not set here,  clock time is used to generate seed
-   startTime = 0.0;
    stopTime = 10;  // num images plus (num layers + 1) * delay
    writeProgressToErr = false;
    verifyWrites = false;

--- a/tests/AvgPoolTest/input/avgpooltest.params
+++ b/tests/AvgPoolTest/input/avgpooltest.params
@@ -5,7 +5,6 @@ HyPerCol "column" = {
     ny = 8;  //218;
     dt = 1.0;
     randomSeed = 1234567890;  // Must be at least 8 digits long.  // if not set here,  clock time is used to generate seed
-    startTime = 0.0;
     stopTime = 10.0;       // Depends on number of VINE video frames
     progressInterval = 1.0;
     outputPath = "output/avgpooltest";

--- a/tests/AvgPoolTest/input/unpoolTest.params
+++ b/tests/AvgPoolTest/input/unpoolTest.params
@@ -5,7 +5,6 @@ HyPerCol "column" = {
     ny = 8;  //218;
     dt = 1.0;
     randomSeed = 1234567890;  // Must be at least 8 digits long.  // if not set here,  clock time is used to generate seed
-    startTime = 0.0;
     stopTime = 10.0;       // Depends on number of VINE video frames
     progressInterval = 1.0;
     outputPath = "avgOutput/unpoolTest";

--- a/tests/BackgroundLayerTest/input/norepTest.params
+++ b/tests/BackgroundLayerTest/input/norepTest.params
@@ -5,7 +5,6 @@ HyPerCol "column" = {
     ny = 32;  //218;
     dt = 1.0;
     randomSeed = 1234567890;  // Must be at least 8 digits long.  // if not set here,  clock time is used to generate seed
-    startTime = 0.0;
     stopTime = 100.0;       // Depends on number of VINE video frames
     progressInterval = 1.0;
     outputPath = "output/norepTest/";

--- a/tests/BackgroundLayerTest/input/repTest.params
+++ b/tests/BackgroundLayerTest/input/repTest.params
@@ -5,7 +5,6 @@ HyPerCol "column" = {
     ny = 32;  //218;
     dt = 1.0;
     randomSeed = 1234567890;  // Must be at least 8 digits long.  // if not set here,  clock time is used to generate seed
-    startTime = 0.0;
     stopTime = 100.0;       // Depends on number of VINE video frames
     progressInterval = 1.0;
     outputPath = "output/repTest/";

--- a/tests/BasicSystemTest/input/BasicSystemTest.params
+++ b/tests/BasicSystemTest/input/BasicSystemTest.params
@@ -17,7 +17,6 @@ HyPerCol "column" = {
    nbatch = 1;
    dt = 1.0;  //time step in ms.
    randomSeed = 1234567890;  // Must be at least 8 digits long.  // if not set here,  clock time is used to generate seed
-   startTime = 0.0;
    stopTime = 10.0;  
    errorOnNotANumber = true;
    progressInterval = 10.0; //Program will output its progress at each progressInterval

--- a/tests/BatchCheckpointSystemTest/input/CheckpointParameters1.params
+++ b/tests/BatchCheckpointSystemTest/input/CheckpointParameters1.params
@@ -1,7 +1,6 @@
 debugParsing = false;
 
 HyPerCol "column" = {
-    startTime                           = 0;
     dt                                  = 1;
     stopTime                            = 50;
     progressInterval                    = 10;

--- a/tests/BatchCheckpointSystemTest/input/CheckpointParameters2.params
+++ b/tests/BatchCheckpointSystemTest/input/CheckpointParameters2.params
@@ -1,7 +1,6 @@
 debugParsing = false;
 
 HyPerCol "column" = {
-    startTime                           = 0;
     dt                                  = 1;
     stopTime                            = 50;
     progressInterval                    = 10;

--- a/tests/BatchMPICheckpointSystemTest/input/CheckpointParameters1.params
+++ b/tests/BatchMPICheckpointSystemTest/input/CheckpointParameters1.params
@@ -1,7 +1,6 @@
 debugParsing = false;
 
 HyPerCol "column" = {
-    startTime                           = 0;
     dt                                  = 1;
     stopTime                            = 50;
     progressInterval                    = 10;

--- a/tests/BatchMPICheckpointSystemTest/input/CheckpointParameters2.params
+++ b/tests/BatchMPICheckpointSystemTest/input/CheckpointParameters2.params
@@ -1,7 +1,6 @@
 debugParsing = false;
 
 HyPerCol "column" = {
-    startTime                           = 0;
     dt                                  = 1;
     stopTime                            = 50;
     progressInterval                    = 10;

--- a/tests/BatchMethodTest/input/BatchMethodTest.params
+++ b/tests/BatchMethodTest/input/BatchMethodTest.params
@@ -35,7 +35,6 @@
 debugParsing = true;
 
 HyPerCol "column" = {
-    startTime                           = 0;
     dt                                  = 1;
     stopTime                            = 10;
     progressInterval                    = 10;

--- a/tests/BatchMethodTest/input/images/test.params
+++ b/tests/BatchMethodTest/input/images/test.params
@@ -5,7 +5,6 @@ HyPerCol "column" = {
    ny = 32; 
    dt = 1.0;
    randomSeed = 1234567890;
-   startTime = 0.0;
    stopTime = 10.0;  
    progressInterval = 10.0;
    writeProgressToErr = false;  

--- a/tests/BinningLayerTest/input/BinningLayerTest.params
+++ b/tests/BinningLayerTest/input/BinningLayerTest.params
@@ -17,7 +17,6 @@ HyPerCol "column" = {
    nbatch = 1;
    dt = 1.0;  //time step in ms.	     
    randomSeed = 1234567890;  // Must be at least 8 digits long.  // if not set here,  clock time is used to generate seed
-   startTime = 0.0;
    stopTime = 1.0;  
    progressInterval = 1.0; //Program will output its progress at each progressInterval
    writeProgressToErr = false;  

--- a/tests/CheckpointSystemTest/input/CheckpointParameters1.params
+++ b/tests/CheckpointSystemTest/input/CheckpointParameters1.params
@@ -1,7 +1,6 @@
 debugParsing = false;
 
 HyPerCol "column" = {
-    startTime                           = 0;
     dt                                  = 1;
     stopTime                            = 50;
     progressInterval                    = 10;

--- a/tests/CheckpointSystemTest/input/CheckpointParameters2.params
+++ b/tests/CheckpointSystemTest/input/CheckpointParameters2.params
@@ -1,7 +1,6 @@
 debugParsing = false;
 
 HyPerCol "column" = {
-    startTime                           = 0;
     dt                                  = 1;
     stopTime                            = 50;
     progressInterval                    = 10;

--- a/tests/CheckpointWeightTest/input/CheckpointWeightTestNonshared.params
+++ b/tests/CheckpointWeightTest/input/CheckpointWeightTestNonshared.params
@@ -15,7 +15,6 @@ HyPerCol "column" = {
    nbatch = 1;
    dt = 1.0;
    randomSeed = 1234567890;
-   startTime = 0.0;
    stopTime = 10.0;  
    errorOnNotANumber = true;
    progressInterval = 10.0;

--- a/tests/CheckpointWeightTest/input/CheckpointWeightTestShared.params
+++ b/tests/CheckpointWeightTest/input/CheckpointWeightTestShared.params
@@ -15,7 +15,6 @@ HyPerCol "column" = {
    nbatch = 1;
    dt = 1.0;
    randomSeed = 1234567890;
-   startTime = 0.0;
    stopTime = 10.0;  
    errorOnNotANumber = true;
    progressInterval = 10.0;

--- a/tests/CloneHyPerConnTest/input/CloneHyPerConnTest.params
+++ b/tests/CloneHyPerConnTest/input/CloneHyPerConnTest.params
@@ -18,7 +18,6 @@ HyPerCol "column" = {
    ny = 32;
    dt = 1.0;
    randomSeed = 1554498580;  // if not set here,  clock time is used to generate seed
-   startTime = 0.0;
    stopTime = 10;
    progressInterval = 10;
    writeProgressToErr = false;

--- a/tests/CloneKernelConnTest/input/CloneKernelConnTest.params
+++ b/tests/CloneKernelConnTest/input/CloneKernelConnTest.params
@@ -18,7 +18,6 @@ HyPerCol "column" = {
    ny = 32;
    dt = 1.0;
    randomSeed = 1554498580;  // if not set here,  clock time is used to generate seed
-   startTime = 0.0;
    stopTime = 10;
    progressInterval = 10;
    writeProgressToErr = false;

--- a/tests/CloneVLayerTest/input/CloneVLayerTest.params
+++ b/tests/CloneVLayerTest/input/CloneVLayerTest.params
@@ -15,7 +15,6 @@ HyPerCol "column" = {
    nx = 256;   //size of the whole networks
    ny = 256;
    nbatch = 1;
-   startTime = 0.0;
    stopTime = 10.0;
    dt = 1.0;  //time step in ms.	     
    randomSeed = 1234567890;  // Must be at least 8 digits long.  // if not set here,  clock time is used to generate seed

--- a/tests/CommandLineRestartTest/input/CommandLineRestartTest.params
+++ b/tests/CommandLineRestartTest/input/CommandLineRestartTest.params
@@ -24,7 +24,6 @@
 debugParsing = false;
 
 HyPerCol "column" = {
-    startTime                           = 0;
     dt                                  = 1;
     stopTime                            = 10;
     progressInterval                    = 10;

--- a/tests/CommandLineRestartTest/src/main.cpp
+++ b/tests/CommandLineRestartTest/src/main.cpp
@@ -45,7 +45,7 @@ int main(int argc, char *argv[]) {
          outputLayer == nullptr,
          "Params file does not have a FailBeforeExpectedStartTimeLayer called \"Output\".\n");
    outputLayer->setExpectedStartTime(0.0);
-   status = hc->run(0.0, 10.0, 1.0);
+   status = hc->run(10.0, 1.0);
    FatalIf(status != PV_SUCCESS, "HyPerCol::run failed with arguments (0.0, 10.0, 1.0).\n");
    std::vector<float> withoutRestart = copyOutput(outputLayer);
    delete hc;
@@ -57,7 +57,7 @@ int main(int argc, char *argv[]) {
          outputLayer == nullptr,
          "Params file does not have a FailBeforeExpectedStartTimeLayer called \"Output\".\n");
    outputLayer->setExpectedStartTime(0.0);
-   status = hc->run(0.0, 5.0, 1.0);
+   status = hc->run(5.0, 1.0);
    FatalIf(status != PV_SUCCESS, "HyPerCol::run failed with arguments (0.0, 5.0, 1.0).\n");
    delete hc;
 

--- a/tests/ConfigFileSystemTest/input/ConfigFileSystemTest.params
+++ b/tests/ConfigFileSystemTest/input/ConfigFileSystemTest.params
@@ -16,7 +16,6 @@ HyPerCol "column" = {
    nbatch = 1;
    dt = 1.0;
    randomSeed = 1234567890;
-   startTime = 0.0;
    stopTime = 10.0;  
    errorOnNotANumber = true;
    progressInterval = 10.0;

--- a/tests/ConnectionRestartTest/input/ConnectionRestartTest.params
+++ b/tests/ConnectionRestartTest/input/ConnectionRestartTest.params
@@ -20,7 +20,6 @@ HyPerCol "column" = {
    nbatch = 1;
    dt = 1.0;
    randomSeed = 1234567890;  
-   startTime = 0.0;
    stopTime = 10.0;  
    errorOnNotANumber = true;
    progressInterval = 10.0; 

--- a/tests/ConstantLayerTest/input/ConstantLayerTest.params
+++ b/tests/ConstantLayerTest/input/ConstantLayerTest.params
@@ -13,7 +13,6 @@
 
 
 HyPerCol "column" = {
-    startTime                           = 0;
     dt                                  = 1;
     stopTime                            = 10;
     progressInterval                    = 10;

--- a/tests/ConvertRateToSpikeCountTest/input/ConvertRateToSpikeCountTest.params
+++ b/tests/ConvertRateToSpikeCountTest/input/ConvertRateToSpikeCountTest.params
@@ -25,7 +25,6 @@ HyPerCol "column" = {
    nbatch = 1;
    // dt // parameter sweep
    randomSeed = 1234567890;  // Must be at least 8 digits long.  // if not set here,  clock time is used to generate seed
-   startTime = 0.0;
    stopTime = 10.0;  
    errorOnNotANumber = true;
    verifyWrites = true;

--- a/tests/ConvertToGrayscaleTest/input/ConvertToGrayscaleTest.params
+++ b/tests/ConvertToGrayscaleTest/input/ConvertToGrayscaleTest.params
@@ -16,7 +16,6 @@ HyPerCol "column" = {
    ny = 32;
    dt = 1.0;
    randomSeed = 1234567890;
-   startTime = 0.0;
    stopTime = 10.0;  
    errorOnNotANumber = true;
    progressInterval = 10.0;

--- a/tests/CopyConnTest/input/CopyConnInitializeNonsharedTest.params
+++ b/tests/CopyConnTest/input/CopyConnInitializeNonsharedTest.params
@@ -1,7 +1,6 @@
 debugParsing = false;
 
 HyPerCol "column" = {
-    startTime                           = 0;
     dt                                  = 1;
     stopTime                            = 10;
     progressInterval                    = 10;

--- a/tests/CopyConnTest/input/CopyConnInitializeTest.params
+++ b/tests/CopyConnTest/input/CopyConnInitializeTest.params
@@ -1,7 +1,6 @@
 debugParsing = false;
 
 HyPerCol "column" = {
-    startTime                           = 0;
     dt                                  = 1;
     stopTime                            = 10;
     progressInterval                    = 10;

--- a/tests/CopyConnTest/input/CopyConnPlasticNonsharedTest.params
+++ b/tests/CopyConnTest/input/CopyConnPlasticNonsharedTest.params
@@ -1,7 +1,6 @@
 debugParsing = true;
 
 HyPerCol "column" = {
-    startTime                           = 0;
     dt                                  = 1;
     stopTime                            = 10;
     progressInterval                    = 10;

--- a/tests/CopyConnTest/input/CopyConnPlasticTest.params
+++ b/tests/CopyConnTest/input/CopyConnPlasticTest.params
@@ -1,7 +1,6 @@
 debugParsing = false;
 
 HyPerCol "column" = {
-    startTime                           = 0;
     dt                                  = 1;
     stopTime                            = 10;
     progressInterval                    = 10;

--- a/tests/DatastoreDelayTest/input/DatastoreDelayTest.params
+++ b/tests/DatastoreDelayTest/input/DatastoreDelayTest.params
@@ -14,7 +14,6 @@ HyPerCol "column" = {
    ny = 16;
    dt = 1.0;
    randomSeed = 30926100951;  // if not set here,  clock time is used to generate seed
-   startTime = 0.0;
    stopTime = 20.0;
    progressInterval = 20.0;
    writeProgressToErr = false;

--- a/tests/DelaysToFeaturesTest/input/test_delays.params
+++ b/tests/DelaysToFeaturesTest/input/test_delays.params
@@ -14,7 +14,6 @@ HyPerCol "column" = {
    ny = 32;
    dt = 1.0;
    randomSeed = 17406293508;  // if not set here,  clock time is used to generate seed
-   startTime = 0.0;
    stopTime = 16.0; 
    errorOnNotANumber = false;
    writeProgressToErr = false;

--- a/tests/DryRunFlagTest/input/DryRunFlagTest.params
+++ b/tests/DryRunFlagTest/input/DryRunFlagTest.params
@@ -34,7 +34,6 @@ HyPerCol "column" = {
    ny = 32; nbatch = 1; dt =
 1.0;  //time step in ms.
    randomSeed = 1234567890;  // Must be at least 8 digits long.  // if not set here,  clock time is used to generate seed
-   startTime = 0.0;
    stopTime
 =                           10.0;  errorOnNotANumber = // Comment at end of line, even though it's in the middle of a declaration
      true;

--- a/tests/DryRunFlagTest/input/correct.params
+++ b/tests/DryRunFlagTest/input/correct.params
@@ -2,7 +2,6 @@
 // Except for initial comments, it should be identical to output/pv.params.
 
 HyPerCol "column" = {
-    startTime                           = 0;
     dt                                  = 1;
     stopTime                            = 10;
     progressInterval                    = 10;

--- a/tests/FilenameParsingTest/input/FilenameParsingTest.params
+++ b/tests/FilenameParsingTest/input/FilenameParsingTest.params
@@ -10,7 +10,6 @@
 debugParsing = false;
 
 HyPerCol "column" = {
-    startTime                           = 0;
     dt                                  = 1;
     stopTime                            = 200;
     progressInterval                    = 10;

--- a/tests/GPULCATest/input/GPULCATest.params
+++ b/tests/GPULCATest/input/GPULCATest.params
@@ -13,7 +13,6 @@
 debugParsing = true;
 
 HyPerCol "column" = {
-    startTime                           = 0;
     dt                                  = 1;
     stopTime                            = 40;
     progressInterval                    = 40;

--- a/tests/GPUSystemTest/input/HyPerLCAGpuTest.params
+++ b/tests/GPUSystemTest/input/HyPerLCAGpuTest.params
@@ -5,7 +5,6 @@ HyPerCol "column" = {
     ny = 64;  //218;
     dt = 1.0;
     randomSeed = 1234567890;  // Must be at least 8 digits long.  // if not set here,  clock time is used to generate seed
-    startTime = 0.0;
     stopTime = 10.0;       // Depends on number of VINE video frames
     progressInterval = 1.0;
     //Change this

--- a/tests/GPUSystemTest/input/diffMarginPostTest.params
+++ b/tests/GPUSystemTest/input/diffMarginPostTest.params
@@ -5,7 +5,6 @@ HyPerCol "column" = {
     ny = 64;  //218;
     dt = 1.0;
     randomSeed = 1234567890;  // Must be at least 8 digits long.  // if not set here,  clock time is used to generate seed
-    startTime = 10.0;
     stopTime = 30.0;       // Depends on number of VINE video frames
     progressInterval = 1.0;
     //Change this

--- a/tests/GPUSystemTest/input/oneToTwo.params
+++ b/tests/GPUSystemTest/input/oneToTwo.params
@@ -5,7 +5,6 @@ HyPerCol "column" = {
     ny = 32;  //218;
     dt = 1.0;
     randomSeed = 1234567890;  // Must be at least 8 digits long.  // if not set here,  clock time is used to generate seed
-    startTime = 0.0;
     stopTime = 10.0;       // Depends on number of VINE video frames
     progressInterval = 1.0;
     //Change this

--- a/tests/GPUSystemTest/input/oneToTwoTranspose.params
+++ b/tests/GPUSystemTest/input/oneToTwoTranspose.params
@@ -5,7 +5,6 @@ HyPerCol "column" = {
     ny = 32;  //218;
     dt = 1.0;
     randomSeed = 1234567890;  // Must be at least 8 digits long.  // if not set here,  clock time is used to generate seed
-    startTime = 0.0;
     stopTime = 10.0;       // Depends on number of VINE video frames
     progressInterval = 1.0;
     //Change this

--- a/tests/GPUSystemTest/input/postRecvBatch.params
+++ b/tests/GPUSystemTest/input/postRecvBatch.params
@@ -16,7 +16,6 @@ HyPerCol "column" = {
    ny = 64;
    dt = 1.0;  //time step in ms.	     
    randomSeed = 1234567890;  // Must be at least 8 digits long.  // if not set here,  clock time is used to generate seed
-   startTime = 0.0;
    stopTime = 5.0;  
    nbatch = 16;
    threadBatch = 0;

--- a/tests/GPUSystemTest/input/postTest.params
+++ b/tests/GPUSystemTest/input/postTest.params
@@ -5,7 +5,6 @@ HyPerCol "column" = {
     ny = 64;  //218;
     dt = 1.0;
     randomSeed = 1234567890;  // Must be at least 8 digits long.  // if not set here,  clock time is used to generate seed
-    startTime = 10.0;
     stopTime = 30.0;       // Depends on number of VINE video frames
     progressInterval = 1.0;
     //Change this

--- a/tests/GPUSystemTest/input/postTestGpuGroup.params
+++ b/tests/GPUSystemTest/input/postTestGpuGroup.params
@@ -5,7 +5,6 @@ HyPerCol "column" = {
     ny = 64;  //218;
     dt = 1.0;
     randomSeed = 1234567890;  // Must be at least 8 digits long.  // if not set here,  clock time is used to generate seed
-    startTime = 0.0;
     stopTime = 10.0;       // Depends on number of VINE video frames
     progressInterval = 1.0;
     writeProgressToErr = true;

--- a/tests/GPUSystemTest/input/postTestNoTranspose.params
+++ b/tests/GPUSystemTest/input/postTestNoTranspose.params
@@ -5,7 +5,6 @@ HyPerCol "column" = {
     ny = 64;  //218;
     dt = 1.0;
     randomSeed = 1234567890;  // Must be at least 8 digits long.  // if not set here,  clock time is used to generate seed
-    startTime = 10.0;
     stopTime = 30.0;       // Depends on number of VINE video frames
     progressInterval = 1.0;
     //Change this

--- a/tests/GPUSystemTest/input/postTestOneToMany.params
+++ b/tests/GPUSystemTest/input/postTestOneToMany.params
@@ -5,7 +5,6 @@ HyPerCol "column" = {
     ny = 64;  //218;
     dt = 1.0;
     randomSeed = 1234567890;  // Must be at least 8 digits long.  // if not set here,  clock time is used to generate seed
-    startTime = 0.0;
     stopTime = 5.0;       // Depends on number of VINE video frames
     progressInterval = 1.0;
     //Change this

--- a/tests/GPUSystemTest/input/postTest_add_connection_test.params
+++ b/tests/GPUSystemTest/input/postTest_add_connection_test.params
@@ -5,7 +5,6 @@ HyPerCol "column" = {
     ny = 64;  //218;
     dt = 1.0;
     randomSeed = 1234567890;  // Must be at least 8 digits long.  // if not set here,  clock time is used to generate seed
-    startTime = 0.0;
     stopTime = 10.0;       // Depends on number of VINE video frames
     progressInterval = 1.0;
     //Change this

--- a/tests/GPUSystemTest/input/postTest_linked.params
+++ b/tests/GPUSystemTest/input/postTest_linked.params
@@ -5,7 +5,6 @@ HyPerCol "column" = {
     ny = 64;  //218;
     dt = 1.0;
     randomSeed = 1234567890;  // Must be at least 8 digits long.  // if not set here,  clock time is used to generate seed
-    startTime = 0.0;
     stopTime = 10.0;       // Depends on number of VINE video frames
     progressInterval = 1.0;
     //Change this

--- a/tests/GPUSystemTest/input/preRecvBatch.params
+++ b/tests/GPUSystemTest/input/preRecvBatch.params
@@ -16,7 +16,6 @@ HyPerCol "column" = {
    ny = 32;
    dt = 1.0;  //time step in ms.	     
    randomSeed = 1234567890;  // Must be at least 8 digits long.  // if not set here,  clock time is used to generate seed
-   startTime = 0.0;
    stopTime = 10.0;  
    nbatch = 4;
    threadBatch = 0;

--- a/tests/GPUSystemTest/input/preTest.params
+++ b/tests/GPUSystemTest/input/preTest.params
@@ -5,7 +5,6 @@ HyPerCol "column" = {
     ny = 64;  //218;
     dt = 1.0;
     randomSeed = 1234567890;  // Must be at least 8 digits long.  // if not set here,  clock time is used to generate seed
-    startTime = 0.0;
     stopTime = 5.0;       // Depends on number of VINE video frames
     progressInterval = 1;
     //Change this

--- a/tests/GPUSystemTest/input/stress_postTest.params
+++ b/tests/GPUSystemTest/input/stress_postTest.params
@@ -5,7 +5,6 @@ HyPerCol "column" = {
     ny = 512;  //218;
     dt = 1.0;
     randomSeed = 1234567890;  // Must be at least 8 digits long.  // if not set here,  clock time is used to generate seed
-    startTime = 0.0;
     stopTime = 10.0;       // Depends on number of VINE video frames
     progressInterval = 1.0;
     //Change this

--- a/tests/GPUSystemTest/input/twoToOneAccumulation.params
+++ b/tests/GPUSystemTest/input/twoToOneAccumulation.params
@@ -5,7 +5,6 @@ HyPerCol "column" = {
     ny = 32;  //218;
     dt = 1.0;
     randomSeed = 1234567890;  // Must be at least 8 digits long.  // if not set here,  clock time is used to generate seed
-    startTime = 0.0;
     stopTime = 10.0;       // Depends on number of VINE video frames
     progressInterval = 1.0;
     //Change this

--- a/tests/GenericSystemTest/input/GenericSystemTest.params
+++ b/tests/GenericSystemTest/input/GenericSystemTest.params
@@ -17,7 +17,6 @@ HyPerCol "column" = {
    nbatch = 1;
    dt = 1.0;  //time step in ms.	     
    randomSeed = 1234567890;  // Must be at least 8 digits long.  // if not set here,  clock time is used to generate seed
-   startTime = 0.0;
    stopTime = 10.0;  
    progressInterval = 10.0; //Program will output its progress at each progressInterval
    writeProgressToErr = false;  

--- a/tests/GroupNormalizationTest/input/GroupNormalizationTest.params
+++ b/tests/GroupNormalizationTest/input/GroupNormalizationTest.params
@@ -37,7 +37,6 @@ HyPerCol "column" = {
    ny = 16;
    dt = 1.0;  //time step in ms.
    randomSeed = 1234567890;  // Must be at least 8 digits long.  // if not set here,  clock time is used to generate seed
-   startTime = 0.0;
    stopTime = 5.0;  
    errorOnNotANumber = true;
    progressInterval = 10.0; //Program will output its progress at each progressInterval

--- a/tests/HyPerConnCheckpointerTest/input/HyPerConnCheckpointerTest_freshstart_triggering.params
+++ b/tests/HyPerConnCheckpointerTest/input/HyPerConnCheckpointerTest_freshstart_triggering.params
@@ -18,7 +18,6 @@
 debugParsing = false;
 
 HyPerCol "column" = {
-    startTime                           = 0;
     dt                                  = 1;
     stopTime                            = 20;
     progressInterval                    = 100;

--- a/tests/HyPerConnCheckpointerTest/input/HyPerConnCheckpointerTest_freshstart_updateperiod.params
+++ b/tests/HyPerConnCheckpointerTest/input/HyPerConnCheckpointerTest_freshstart_updateperiod.params
@@ -18,7 +18,6 @@
 debugParsing = false;
 
 HyPerCol "column" = {
-    startTime                           = 0;
     dt                                  = 1;
     stopTime                            = 20;
     progressInterval                    = 100;

--- a/tests/HyPerConnCheckpointerTest/input/HyPerConnCheckpointerTest_initfromCP_triggering.params
+++ b/tests/HyPerConnCheckpointerTest/input/HyPerConnCheckpointerTest_initfromCP_triggering.params
@@ -18,7 +18,6 @@
 debugParsing = false;
 
 HyPerCol "column" = {
-    startTime                           = 0;
     dt                                  = 1;
     stopTime                            = 12;
     progressInterval                    = 100;

--- a/tests/HyPerConnCheckpointerTest/input/HyPerConnCheckpointerTest_initfromCP_updateperiod.params
+++ b/tests/HyPerConnCheckpointerTest/input/HyPerConnCheckpointerTest_initfromCP_updateperiod.params
@@ -18,7 +18,6 @@
 debugParsing = false;
 
 HyPerCol "column" = {
-    startTime                           = 0;
     dt                                  = 1;
     stopTime                            = 12;
     progressInterval                    = 100;

--- a/tests/HyPerConnCheckpointerTest/src/HyPerConnCheckpointerTestProbe.cpp
+++ b/tests/HyPerConnCheckpointerTest/src/HyPerConnCheckpointerTestProbe.cpp
@@ -134,8 +134,8 @@ int HyPerConnCheckpointerTestProbe::readStateFromCheckpoint(PV::Checkpointer *ch
 }
 
 int HyPerConnCheckpointerTestProbe::calcUpdateNumber(double timevalue) {
-   pvAssert(timevalue >= parent->getStartTime());
-   int const step = (int)std::nearbyint(timevalue - parent->getStartTime());
+   pvAssert(timevalue >= 0.0);
+   int const step = (int)std::nearbyint(timevalue);
    pvAssert(step >= 0);
    int const updateNumber = (step + 3) / 4; // integer division
    return updateNumber;

--- a/tests/ImageOffsetTest/input/ImageOffsetTest.params
+++ b/tests/ImageOffsetTest/input/ImageOffsetTest.params
@@ -5,7 +5,6 @@ HyPerCol "column" = {
     ny = 16;  //218;
     dt = 1.0;
     randomSeed = 1234567890;  // Must be at least 8 digits long.  // if not set here,  clock time is used to generate seed
-    startTime = 0.0;
     stopTime = 10.0;       // Depends on number of VINE video frames
     progressInterval = 1.0;
     //Change this

--- a/tests/ImageOffsetTest/input/ImagePvpOffsetTest.params
+++ b/tests/ImageOffsetTest/input/ImagePvpOffsetTest.params
@@ -5,7 +5,6 @@ HyPerCol "column" = {
     ny = 16;  //218;
     dt = 1.0;
     randomSeed = 1234567890;  // Must be at least 8 digits long.  // if not set here,  clock time is used to generate seed
-    startTime = 0.0;
     stopTime = 10.0;       // Depends on number of VINE video frames
     progressInterval = 1.0;
     //Change this

--- a/tests/ImageSystemTest/input/ImageFileIO.params
+++ b/tests/ImageSystemTest/input/ImageFileIO.params
@@ -14,7 +14,6 @@ HyPerCol "column" = {
    ny = 8; 
    dt = 1.0;  //time step in ms.	     
    randomSeed = 1234567890;  // Must be at least 8 digits long.  // if not set here,  clock time is used to generate seed
-   startTime = 0.0;
    stopTime = 10.0;
    nbatch = 2;
    progressInterval = 10.0; //Program will output its progress at each progressInterval

--- a/tests/ImageSystemTest/input/ImagePvpFileIO.params
+++ b/tests/ImageSystemTest/input/ImagePvpFileIO.params
@@ -14,7 +14,6 @@ HyPerCol "column" = {
    ny = 8; 
    dt = 1.0;  //time step in ms.	     
    randomSeed = 1234567890;  // Must be at least 8 digits long.  // if not set here,  clock time is used to generate seed
-   startTime = 0.0;
    stopTime = 10.0;
    progressInterval = 10.0; //Program will output its progress at each progressInterval
    writeProgressToErr = false;  

--- a/tests/ImageSystemTest/input/ImagePvpFileIOSparse.params
+++ b/tests/ImageSystemTest/input/ImagePvpFileIOSparse.params
@@ -14,7 +14,6 @@ HyPerCol "column" = {
    ny = 8; 
    dt = 1.0;  //time step in ms.	     
    randomSeed = 1234567890;  // Must be at least 8 digits long.  // if not set here,  clock time is used to generate seed
-   startTime = 0.0;
    stopTime = 10.0;  
    progressInterval = 10.0; //Program will output its progress at each progressInterval
    writeProgressToErr = false;  

--- a/tests/ImageSystemTest/input/MovieFileIO.params
+++ b/tests/ImageSystemTest/input/MovieFileIO.params
@@ -14,7 +14,6 @@ HyPerCol "column" = {
    ny = 8; 
    dt = 1.0;  //time step in ms.	     
    randomSeed = 1234567890;  // Must be at least 8 digits long.  // if not set here,  clock time is used to generate seed
-   startTime = 0.0;
    stopTime = 2.0;
    nbatch = 3;
    progressInterval = 1.0; //Program will output its progress at each progressInterval

--- a/tests/ImageSystemTest/input/MoviePvpFileIO.params
+++ b/tests/ImageSystemTest/input/MoviePvpFileIO.params
@@ -14,7 +14,6 @@ HyPerCol "column" = {
    ny = 8; 
    dt = 1.0;  //time step in ms.	     
    randomSeed = 1234567890;  // Must be at least 8 digits long.  // if not set here,  clock time is used to generate seed
-   startTime = 0.0;
    stopTime = 2.0;
    nbatch = 3;
    progressInterval = 10.0; //Program will output its progress at each progressInterval

--- a/tests/ImageSystemTest/input/batchMovieFileIO.params
+++ b/tests/ImageSystemTest/input/batchMovieFileIO.params
@@ -14,7 +14,6 @@ HyPerCol "column" = {
    ny = 8; 
    dt = 1.0;  //time step in ms.	     
    randomSeed = 1234567890;  // Must be at least 8 digits long.  // if not set here,  clock time is used to generate seed
-   startTime = 0.0;
    stopTime = 1.0;
    nbatch = 4;
    progressInterval = 1.0; //Program will output its progress at each progressInterval

--- a/tests/ImportParamsTest/input/ImportParamsTest.params
+++ b/tests/ImportParamsTest/input/ImportParamsTest.params
@@ -16,7 +16,6 @@ HyPerCol "column" = {
    ny = 32;
    dt = 1.0;  //time step in ms.	     
    randomSeed = 1234567890;  // Must be at least 8 digits long.  // if not set here,  clock time is used to generate seed
-   startTime = 0.0;
    stopTime = 10.0;  
    progressInterval = 10.0; //Program will output its progress at each progressInterval
    writeProgressToErr = false;  

--- a/tests/ImprintConnTest/input/ImprintConnTest.params
+++ b/tests/ImprintConnTest/input/ImprintConnTest.params
@@ -5,7 +5,6 @@ HyPerCol "column" = {
     ny = 8;  //218;
     dt = 1.0;
     randomSeed = 1234567890;  // Must be at least 8 digits long.  // if not set here,  clock time is used to generate seed
-    startTime = 0.0;
     stopTime = 10.0;       // Depends on number of VINE video frames
     progressInterval = 1.0;
     outputPath = "output/";

--- a/tests/InitWeightsFileTest/input/InitWeightsFileTest.params
+++ b/tests/InitWeightsFileTest/input/InitWeightsFileTest.params
@@ -12,7 +12,6 @@
 debugParsing = false;
 
 HyPerCol "column" = {
-    startTime                           = 0;
     dt                                  = 1;
     stopTime                            = 10;
     progressInterval                    = 10;

--- a/tests/InitWeightsTest/input/test_initweights.params
+++ b/tests/InitWeightsTest/input/test_initweights.params
@@ -14,7 +14,6 @@ HyPerCol "column" = {
    ny = 32;
    dt = 1.0;
    randomSeed = 977074598;  // if not set here,  clock time is used to generate seed
-   startTime = 0.0;
    stopTime = 4.0;
    progressInterval = 5.0;
    writeProgressToErr = false;

--- a/tests/InitializeFromCheckpointDirTest/input/BaseRun.params
+++ b/tests/InitializeFromCheckpointDirTest/input/BaseRun.params
@@ -22,7 +22,6 @@ HyPerCol "column" = {
    nbatch = 4;
    dt = 1.0;
    randomSeed = 1234567890;
-   startTime = 0.0;
    stopTime = 10.0;  
    errorOnNotANumber = true;
    progressInterval = 10.0;

--- a/tests/InitializeFromCheckpointDirTest/input/InitializeFromCheckpointDirTest.params
+++ b/tests/InitializeFromCheckpointDirTest/input/InitializeFromCheckpointDirTest.params
@@ -22,7 +22,6 @@ HyPerCol "column" = {
    nbatch = 4;
    dt = 1.0;
    randomSeed = 1234567890;
-   startTime = 0.0;
    stopTime = 10.0;  
    errorOnNotANumber = true;
    progressInterval = 10.0;

--- a/tests/InputBCflagTest/input/InputBCflagTest.params
+++ b/tests/InputBCflagTest/input/InputBCflagTest.params
@@ -46,7 +46,6 @@
 debugParsing = false;
 
 HyPerCol "column" = {
-    startTime                           = 0;
     dt                                  = 1;
     stopTime                            = 4;
     progressInterval                    = 4;

--- a/tests/InputLayerNormalizeOffsetTest/input/resizeCrop.params
+++ b/tests/InputLayerNormalizeOffsetTest/input/resizeCrop.params
@@ -29,7 +29,6 @@
 debugParsing = false;
 
 HyPerCol "column" = {
-    startTime                           = 0;
     dt                                  = 1;
     stopTime                            = 10;
     progressInterval                    = 10;

--- a/tests/InputLayerNormalizeOffsetTest/input/resizePad.params
+++ b/tests/InputLayerNormalizeOffsetTest/input/resizePad.params
@@ -27,7 +27,6 @@
 debugParsing = false;
 
 HyPerCol "column" = {
-    startTime                           = 0;
     dt                                  = 1;
     stopTime                            = 10;
     progressInterval                    = 10;

--- a/tests/InputLayerNormalizeOffsetTest/input/translate.params
+++ b/tests/InputLayerNormalizeOffsetTest/input/translate.params
@@ -25,7 +25,6 @@
 debugParsing = false;
 
 HyPerCol "column" = {
-    startTime                           = 0;
     dt                                  = 1;
     stopTime                            = 10;
     progressInterval                    = 10;

--- a/tests/InputLayerNormalizeTest/input/InputLayerNormalizeTest.params
+++ b/tests/InputLayerNormalizeTest/input/InputLayerNormalizeTest.params
@@ -10,7 +10,6 @@
 debugParsing = false;
 
 HyPerCol "column" = {
-    startTime                           = 0;
     dt                                  = 1;
     stopTime                            = 1;
     progressInterval                    = 10;

--- a/tests/InputRegionLayerTest/input/InputRegionLayerTest.params
+++ b/tests/InputRegionLayerTest/input/InputRegionLayerTest.params
@@ -27,7 +27,6 @@
 debugParsing = false;
 
 HyPerCol "column" = {
-    startTime                           = 0;
     dt                                  = 1;
     stopTime                            = 10;
     progressInterval                    = 10;

--- a/tests/InputSystemTest/input/ImageLayerSystemTest.params
+++ b/tests/InputSystemTest/input/ImageLayerSystemTest.params
@@ -30,7 +30,6 @@ HyPerCol "column" = {
    nbatch                           = 1;
    dt                               = 1.0;
    randomSeed                       = 1234567890;
-   startTime                        = 0.0;
    stopTime                         = 320;
    progressInterval                 = 1000;
    writeProgressToErr               = false;

--- a/tests/InputSystemTest/input/PvpLayerSystemTest.params
+++ b/tests/InputSystemTest/input/PvpLayerSystemTest.params
@@ -29,7 +29,6 @@ HyPerCol "column" = {
    ny                               = 8;
    dt                               = 1.0;
    randomSeed                       = 1234567890;
-   startTime                        = 0.0;
    stopTime                         = 320;
    progressInterval                 = 1000;
    writeProgressToErr               = false;

--- a/tests/KernelActivationTest/input/KernelActivationTest-fullData.params
+++ b/tests/KernelActivationTest/input/KernelActivationTest-fullData.params
@@ -10,7 +10,6 @@ HyPerCol "column" = {
     ny = 16;
     dt = 1;
     randomSeed = 1328498006;
-    startTime = 0.0;
     stopTime = 5.0;
     progressInterval = 1000;
     writeProgressToErr = false;

--- a/tests/KernelActivationTest/input/KernelActivationTest-maskData.params
+++ b/tests/KernelActivationTest/input/KernelActivationTest-maskData.params
@@ -8,7 +8,6 @@ HyPerCol "column" = {
     ny = 16;
     dt = 1;
     randomSeed = 1328498006;
-    startTime = 0.0;
     stopTime = 5.0;
     progressInterval = 1000;
     writeProgressToErr = false;

--- a/tests/KernelTest/input/test_kernel.params
+++ b/tests/KernelTest/input/test_kernel.params
@@ -14,7 +14,6 @@ HyPerCol "column" = {
    ny = 32;
    dt = 1.0;
    randomSeed = 926268668;  // if not set here,  clock time is used to generate seed
-   startTime = 0.0;
    stopTime = 4.0;  // num images plus (num layers + 1) * delay
    progressInterval = 5.0;
    writeProgressToErr = false;

--- a/tests/KernelTest/input/test_kernel_normalizepost.params
+++ b/tests/KernelTest/input/test_kernel_normalizepost.params
@@ -14,7 +14,6 @@ HyPerCol "column" = {
    ny = 32;
    dt = 1.0;
    randomSeed = 926268668;  // if not set here,  clock time is used to generate seed
-   startTime = 0.0;
    stopTime = 4.0;  // num images plus (num layers + 1) * delay
    progressInterval = 5.0;
    writeProgressToErr = false;

--- a/tests/KernelTest/input/test_kernel_normalizepost_shrunken.params
+++ b/tests/KernelTest/input/test_kernel_normalizepost_shrunken.params
@@ -14,7 +14,6 @@ HyPerCol "column" = {
    ny = 32;
    dt = 1.0;
    randomSeed = 926268668;  // if not set here,  clock time is used to generate seed
-   startTime = 0.0;
    stopTime = 4.0;  // num images plus (num layers + 1) * delay
    progressInterval = 5.0;
    writeProgressToErr = false;

--- a/tests/LCATest/input/LCATest.params
+++ b/tests/LCATest/input/LCATest.params
@@ -11,7 +11,6 @@
 debugParsing = false;
 
 HyPerCol "column" = {
-    startTime                           = 0;
     dt                                  = 1;
     stopTime                            = 40;
     progressInterval                    = 40;

--- a/tests/LIFTest/input/LIFTest.params
+++ b/tests/LIFTest/input/LIFTest.params
@@ -16,7 +16,6 @@ HyPerCol "column" = {
    nbatch                           = 1;
    dt                               = 0.25;
    randomSeed                       = 1829107657; // if not set here,  clock time is used to generate seed
-   startTime                        = 0.0;
    stopTime                         = 2000.0;
    progressInterval                 = 100.0;
    writeProgressToErr               = false;

--- a/tests/LIFTest/input/LIFTest_GPU.params
+++ b/tests/LIFTest/input/LIFTest_GPU.params
@@ -15,7 +15,6 @@ HyPerCol "column" = {
    ny                               = 64;
    dt                               = 0.25;
    randomSeed                       = 1829107657; // if not set here,  clock time is used to generate seed
-   startTime                        = 0.0;
    stopTime                         = 2000.0;
    progressInterval                 = 100.0;
    writeProgressToErr               = false;

--- a/tests/LayerPhaseTest/input/LayerPhaseTest.params
+++ b/tests/LayerPhaseTest/input/LayerPhaseTest.params
@@ -55,7 +55,6 @@ HyPerCol "column" = {
    ny = 32;
    dt = 1.0;
    randomSeed = 505557946;  // Must be at least 8 digits long.  // if not set here,  clock time is used to generate seed
-   startTime = 0.0;
    stopTime = 20;
    progressInterval = 1;
    outputPath = "output";

--- a/tests/LayerRestartTest/input/LayerRestartTest-Check.params
+++ b/tests/LayerRestartTest/input/LayerRestartTest-Check.params
@@ -10,7 +10,6 @@ HyPerCol "column" = {
     ny = 256;
     dt = 1.0;
     randomSeed = 896426020;
-    startTime = 0.0;
     stopTime = 1.0;
     progressInterval = 1.0;
     writeProgressToErr = false;

--- a/tests/LayerRestartTest/input/LayerRestartTest-Read.params
+++ b/tests/LayerRestartTest/input/LayerRestartTest-Read.params
@@ -9,7 +9,6 @@ HyPerCol "column" = {
     ny = 256;
     dt = 1.0;
     randomSeed = 896426020;
-    startTime = 0.0;
     stopTime = 1.0;
     progressInterval = 1.0;
     writeProgressToErr = false;

--- a/tests/LayerRestartTest/input/LayerRestartTest-Write.params
+++ b/tests/LayerRestartTest/input/LayerRestartTest-Write.params
@@ -9,7 +9,6 @@ HyPerCol "column" = {
     ny = 256;
     dt = 1;
     randomSeed = 896426020;
-    startTime = 0.0;
     stopTime = 1.0;
     progressInterval = 1.0;
     writeProgressToErr = false;

--- a/tests/MPITest/input/MPI_test.params
+++ b/tests/MPITest/input/MPI_test.params
@@ -14,7 +14,6 @@ HyPerCol "column" = {
    ny = 32;
    dt = 1.0;
    randomSeed = 41896532;  // if not set here,  clock time is used to generate seed
-   startTime = 0.0;
    stopTime = 20.0;
    progressInterval = 200;
    writeProgressToErr = false;

--- a/tests/MarginWidthTest/input/MarginWidthTest.params
+++ b/tests/MarginWidthTest/input/MarginWidthTest.params
@@ -13,7 +13,6 @@ HyPerCol "column" = {
    ny = 256;
    dt = 1.0;
    randomSeed = 1149986818;  // Must be at least 8 digits long.  // if not set here,  clock time is used to generate seed
-   startTime = 0.0;
    stopTime = 1.0;  
    progressInterval = 1;
    errorOnNotANumber = false;

--- a/tests/MaskLayerTest/input/invertMaskTest.params
+++ b/tests/MaskLayerTest/input/invertMaskTest.params
@@ -5,7 +5,6 @@ HyPerCol "column" = {
     ny = 8;  //218;
     dt = 1.0;
     randomSeed = 1234567890;  // Must be at least 8 digits long.  // if not set here,  clock time is used to generate seed
-    startTime = 0.0;
     stopTime = 100.0;       // Depends on number of VINE video frames
     progressInterval = 1.0;
     outputPath = "output/";

--- a/tests/MaskLayerTest/input/maskTest.params
+++ b/tests/MaskLayerTest/input/maskTest.params
@@ -5,7 +5,6 @@ HyPerCol "column" = {
     ny = 8;  //218;
     dt = 1.0;
     randomSeed = 1234567890;  // Must be at least 8 digits long.  // if not set here,  clock time is used to generate seed
-    startTime = 0.0;
     stopTime = 100.0;       // Depends on number of VINE video frames
     progressInterval = 1.0;
     outputPath = "output/";

--- a/tests/MaskLayerTest/input/maskTestFeatures.params
+++ b/tests/MaskLayerTest/input/maskTestFeatures.params
@@ -5,7 +5,6 @@ HyPerCol "column" = {
     ny = 8;  //218;
     dt = 1.0;
     randomSeed = 1234567890;  // Must be at least 8 digits long.  // if not set here,  clock time is used to generate seed
-    startTime = 0.0;
     stopTime = 100.0;       // Depends on number of VINE video frames
     progressInterval = 1.0;
     outputPath = "output/";

--- a/tests/MaskLayerTest/input/maskTestNoFeatures.params
+++ b/tests/MaskLayerTest/input/maskTestNoFeatures.params
@@ -5,7 +5,6 @@ HyPerCol "column" = {
     ny = 8;  //218;
     dt = 1.0;
     randomSeed = 1234567890;  // Must be at least 8 digits long.  // if not set here,  clock time is used to generate seed
-    startTime = 0.0;
     stopTime = 100.0;       // Depends on number of VINE video frames
     progressInterval = 1.0;
     outputPath = "output/";

--- a/tests/MaxPoolTest/input/gateTest.params
+++ b/tests/MaxPoolTest/input/gateTest.params
@@ -5,7 +5,6 @@ HyPerCol "column" = {
     ny = 8;  //218;
     dt = 1.0;
     randomSeed = 1234567890;  // Must be at least 8 digits long.  // if not set here,  clock time is used to generate seed
-    startTime = 0.0;
     stopTime = 100.0;       // Depends on number of VINE video frames
     progressInterval = 1.0;
     outputPath = "output/gateTest";

--- a/tests/MaxPoolTest/input/maxpooltest.params
+++ b/tests/MaxPoolTest/input/maxpooltest.params
@@ -5,7 +5,6 @@ HyPerCol "column" = {
     ny = 8;  //218;
     dt = 1.0;
     randomSeed = 1234567890;  // Must be at least 8 digits long.  // if not set here,  clock time is used to generate seed
-    startTime = 0.0;
     stopTime = 100.0;       // Depends on number of VINE video frames
     progressInterval = 1.0;
     outputPath = "output/maxpooltest";

--- a/tests/MomentumConnSimpleCheckpointerTest/input/MomentumConnSimpleCheckpointerTest_freshstart_triggering.params
+++ b/tests/MomentumConnSimpleCheckpointerTest/input/MomentumConnSimpleCheckpointerTest_freshstart_triggering.params
@@ -19,7 +19,6 @@
 debugParsing = false;
 
 HyPerCol "column" = {
-    startTime                           = 0;
     dt                                  = 1;
     stopTime                            = 20;
     progressInterval                    = 100;

--- a/tests/MomentumConnSimpleCheckpointerTest/input/MomentumConnSimpleCheckpointerTest_freshstart_updateperiod.params
+++ b/tests/MomentumConnSimpleCheckpointerTest/input/MomentumConnSimpleCheckpointerTest_freshstart_updateperiod.params
@@ -19,7 +19,6 @@
 debugParsing = false;
 
 HyPerCol "column" = {
-    startTime                           = 0;
     dt                                  = 1;
     stopTime                            = 20;
     progressInterval                    = 100;

--- a/tests/MomentumConnSimpleCheckpointerTest/input/MomentumConnSimpleCheckpointerTest_initfromCP_triggering.params
+++ b/tests/MomentumConnSimpleCheckpointerTest/input/MomentumConnSimpleCheckpointerTest_initfromCP_triggering.params
@@ -19,7 +19,6 @@
 debugParsing = false;
 
 HyPerCol "column" = {
-    startTime                           = 0;
     dt                                  = 1;
     stopTime                            = 12;
     progressInterval                    = 100;

--- a/tests/MomentumConnSimpleCheckpointerTest/input/MomentumConnSimpleCheckpointerTest_initfromCP_updateperiod.params
+++ b/tests/MomentumConnSimpleCheckpointerTest/input/MomentumConnSimpleCheckpointerTest_initfromCP_updateperiod.params
@@ -19,7 +19,6 @@
 debugParsing = false;
 
 HyPerCol "column" = {
-    startTime                           = 0;
     dt                                  = 1;
     stopTime                            = 12;
     progressInterval                    = 100;

--- a/tests/MomentumConnSimpleCheckpointerTest/src/MomentumConnSimpleCheckpointerTestProbe.cpp
+++ b/tests/MomentumConnSimpleCheckpointerTest/src/MomentumConnSimpleCheckpointerTestProbe.cpp
@@ -143,8 +143,8 @@ int MomentumConnSimpleCheckpointerTestProbe::readStateFromCheckpoint(
 }
 
 int MomentumConnSimpleCheckpointerTestProbe::calcUpdateNumber(double timevalue) {
-   pvAssert(timevalue >= parent->getStartTime());
-   int const step = (int)std::nearbyint(timevalue - parent->getStartTime());
+   pvAssert(timevalue >= 0.0);
+   int const step = (int)std::nearbyint(timevalue);
    pvAssert(step >= 0);
    int const updateNumber = (step + 3) / 4; // integer division
    return updateNumber;

--- a/tests/MomentumConnViscosityCheckpointerTest/input/MomentumConnViscosityCheckpointerTest_freshstart_triggering.params
+++ b/tests/MomentumConnViscosityCheckpointerTest/input/MomentumConnViscosityCheckpointerTest_freshstart_triggering.params
@@ -19,7 +19,6 @@
 debugParsing = false;
 
 HyPerCol "column" = {
-    startTime                           = 0;
     dt                                  = 1;
     stopTime                            = 20;
     progressInterval                    = 100;

--- a/tests/MomentumConnViscosityCheckpointerTest/input/MomentumConnViscosityCheckpointerTest_freshstart_updateperiod.params
+++ b/tests/MomentumConnViscosityCheckpointerTest/input/MomentumConnViscosityCheckpointerTest_freshstart_updateperiod.params
@@ -19,7 +19,6 @@
 debugParsing = false;
 
 HyPerCol "column" = {
-    startTime                           = 0;
     dt                                  = 1;
     stopTime                            = 20;
     progressInterval                    = 100;

--- a/tests/MomentumConnViscosityCheckpointerTest/input/MomentumConnViscosityCheckpointerTest_initfromCP_triggering.params
+++ b/tests/MomentumConnViscosityCheckpointerTest/input/MomentumConnViscosityCheckpointerTest_initfromCP_triggering.params
@@ -19,7 +19,6 @@
 debugParsing = false;
 
 HyPerCol "column" = {
-    startTime                           = 0;
     dt                                  = 1;
     stopTime                            = 12;
     progressInterval                    = 100;

--- a/tests/MomentumConnViscosityCheckpointerTest/input/MomentumConnViscosityCheckpointerTest_initfromCP_updateperiod.params
+++ b/tests/MomentumConnViscosityCheckpointerTest/input/MomentumConnViscosityCheckpointerTest_initfromCP_updateperiod.params
@@ -19,7 +19,6 @@
 debugParsing = false;
 
 HyPerCol "column" = {
-    startTime                           = 0;
     dt                                  = 1;
     stopTime                            = 12;
     progressInterval                    = 100;

--- a/tests/MomentumConnViscosityCheckpointerTest/src/MomentumConnViscosityCheckpointerTestProbe.cpp
+++ b/tests/MomentumConnViscosityCheckpointerTest/src/MomentumConnViscosityCheckpointerTestProbe.cpp
@@ -144,8 +144,8 @@ int MomentumConnViscosityCheckpointerTestProbe::readStateFromCheckpoint(
 }
 
 int MomentumConnViscosityCheckpointerTestProbe::calcUpdateNumber(double timevalue) {
-   pvAssert(timevalue >= parent->getStartTime());
-   int const step = (int)std::nearbyint(timevalue - parent->getStartTime());
+   pvAssert(timevalue >= 0.0);
+   int const step = (int)std::nearbyint(timevalue);
    pvAssert(step >= 0);
    int const updateNumber = (step + 3) / 4; // integer division
    return updateNumber;

--- a/tests/MomentumLCATest/input/MomentumLCATest.params
+++ b/tests/MomentumLCATest/input/MomentumLCATest.params
@@ -17,7 +17,6 @@ HyPerCol "column" = {
    nbatch = 1;
    dt = 1.0;
    randomSeed = 1234567890;
-   startTime = 0.0;
    stopTime = 10.0;  
    progressInterval = 1.0;
    errorOnNotANumber = false;

--- a/tests/MomentumTest/input/momentumTest.params
+++ b/tests/MomentumTest/input/momentumTest.params
@@ -5,7 +5,6 @@ HyPerCol "column" = {
     ny = 2;  //218;
     dt = 1.0;
     randomSeed = 1234567890;  // Must be at least 8 digits long.  // if not set here,  clock time is used to generate seed
-    startTime = 0.0;
     stopTime = 10.0;       // Depends on number of VINE video frames
     progressInterval = 1.0;
     //Change this

--- a/tests/MomentumTest/input/viscosityTest.params
+++ b/tests/MomentumTest/input/viscosityTest.params
@@ -5,7 +5,6 @@ HyPerCol "column" = {
     ny = 2;  //218;
     dt = 1.0;
     randomSeed = 1234567890;  // Must be at least 8 digits long.  // if not set here,  clock time is used to generate seed
-    startTime = 0.0;
     stopTime = 10.0;       // Depends on number of VINE video frames
     progressInterval = 1.0;
     //Change this

--- a/tests/MtoNOutputStateTest/input/MtoNOutputStateTest.params
+++ b/tests/MtoNOutputStateTest/input/MtoNOutputStateTest.params
@@ -13,7 +13,6 @@
 debugParsing = false;
 
 HyPerCol "column" = {
-    startTime                           = 0;
     dt                                  = 1;
     stopTime                            = 10;
     progressInterval                    = 10;

--- a/tests/MtoNOutputStateTest/src/IndexLayer.cpp
+++ b/tests/MtoNOutputStateTest/src/IndexLayer.cpp
@@ -33,7 +33,7 @@ void IndexLayer::ioParam_InitVType(enum ParamsIOFlag ioFlag) {
 }
 
 int IndexLayer::setInitialValues() {
-   return updateState(parent->getStartTime(), parent->getDeltaTime());
+   return updateState(0.0 /*timestamp*/, parent->getDeltaTime());
 }
 
 int IndexLayer::updateState(double timef, double dt) {

--- a/tests/NormalizeSubclassSystemTest/input/NormalizeSubclassSystemTest.params
+++ b/tests/NormalizeSubclassSystemTest/input/NormalizeSubclassSystemTest.params
@@ -23,7 +23,6 @@ HyPerCol "column" = {
    ny = 16;
    dt = 1.0;
    randomSeed = 1337540566;
-   startTime = 0.0;
    stopTime = 5.0;
    progressInterval = 10.0;
    writeProgressToErr = false;

--- a/tests/NormalizeSystemTest/input/NormalizeSystemTest.params
+++ b/tests/NormalizeSystemTest/input/NormalizeSystemTest.params
@@ -17,7 +17,6 @@ HyPerCol "column" = {
    ny = 16;
    dt = 1.0;
    randomSeed = 1337540566;
-   startTime = 0.0;
    stopTime = 5.0;
    progressInterval = 10.0;
    writeProgressToErr = false;

--- a/tests/ParameterSweepTest/input/ParameterSweepTest.params
+++ b/tests/ParameterSweepTest/input/ParameterSweepTest.params
@@ -14,7 +14,6 @@ HyPerCol "column" = {
    ny = 16;
    dt = 1.0;
    randomSeed = 1946576187;  // if not set here,  clock time is used to generate seed
-   startTime = 0.0;
    stopTime = 10.0;
    progressInterval = 10;
    writeProgressToErr = false;

--- a/tests/ParamsLuaTest/input/ParamsLuaTest.params
+++ b/tests/ParamsLuaTest/input/ParamsLuaTest.params
@@ -17,7 +17,6 @@ HyPerCol "column" = {
    nbatch = 1;
    dt = 1.0;  //time step in ms.
    randomSeed = 1234567890;  // Must be at least 8 digits long.  // if not set here,  clock time is used to generate seed
-   startTime = 0.0;
    stopTime = 1.0;  
    errorOnNotANumber = true;
    progressInterval = 10.0; //Program will output its progress at each progressInterval

--- a/tests/PlasticCloneConnTest/input/MomentumPlasticCloneConnTest.params
+++ b/tests/PlasticCloneConnTest/input/MomentumPlasticCloneConnTest.params
@@ -19,7 +19,6 @@
 debugParsing = true;
 
 HyPerCol "column" = {
-    startTime                           = 0;
     dt                                  = 1;
     stopTime                            = 100;
     progressInterval                    = 100;

--- a/tests/PlasticCloneConnTest/input/PlasticCloneConnTest.params
+++ b/tests/PlasticCloneConnTest/input/PlasticCloneConnTest.params
@@ -19,7 +19,6 @@
 debugParsing = true;
 
 HyPerCol "column" = {
-    startTime                           = 0;
     dt                                  = 1;
     stopTime                            = 100;
     progressInterval                    = 100;

--- a/tests/PlasticConnTest/input/PlasticConnTest.params
+++ b/tests/PlasticConnTest/input/PlasticConnTest.params
@@ -14,7 +14,6 @@ HyPerCol "column" = {
    ny = 32;
    dt = 1.0;
    randomSeed = 1364931845;  // if not set here,  clock time is used to generate seed
-   startTime = 0.0;
    stopTime = 100.0;
    progressInterval = 100.0;
    writeProgressToErr = false;

--- a/tests/PlasticTransposeConnTest/input/PlasticTransposeConnTest.params
+++ b/tests/PlasticTransposeConnTest/input/PlasticTransposeConnTest.params
@@ -25,7 +25,6 @@ HyPerCol "column" = {
    ny = 8;
    dt = 1.0;  //time step in ms.
    randomSeed = 1234567890;  // Must be at least 8 digits long.  // if not set here,  clock time is used to generate seed
-   startTime = 0.0;
    stopTime = 10.0;  
    errorOnNotANumber = true;
    progressInterval = 10.0; //Program will output its progress at each progressInterval

--- a/tests/PointProbeTest/input/PointProbeTest.params
+++ b/tests/PointProbeTest/input/PointProbeTest.params
@@ -5,7 +5,6 @@ HyPerCol "column" = {
     ny = 8;  //218;
     dt = 1.0;
     randomSeed = 1234567890;  // Must be at least 8 digits long.  // if not set here,  clock time is used to generate seed
-    startTime = 0.0;
     stopTime = 10.0;       // Depends on number of VINE video frames
     progressInterval = 1.0;
     outputPath = "output/";

--- a/tests/PoolingConnCheckpointerTest/input/PoolingConnCheckpointerTest_freshstart.params
+++ b/tests/PoolingConnCheckpointerTest/input/PoolingConnCheckpointerTest_freshstart.params
@@ -17,7 +17,6 @@
 debugParsing = false;
 
 HyPerCol "column" = {
-    startTime                           = 0;
     dt                                  = 1;
     stopTime                            = 20;
     progressInterval                    = 100;

--- a/tests/PoolingConnCheckpointerTest/input/PoolingConnCheckpointerTest_initfromCP.params
+++ b/tests/PoolingConnCheckpointerTest/input/PoolingConnCheckpointerTest_initfromCP.params
@@ -17,7 +17,6 @@
 debugParsing = false;
 
 HyPerCol "column" = {
-    startTime                           = 0;
     dt                                  = 1;
     stopTime                            = 12;
     progressInterval                    = 100;

--- a/tests/PoolingConnCheckpointerTest/input/pv_freshstart_triggering.params
+++ b/tests/PoolingConnCheckpointerTest/input/pv_freshstart_triggering.params
@@ -6,7 +6,6 @@
 // Started from checkpoint "output_freshstart_triggering/checkpoints/Checkpoint08"
 
 HyPerCol "column" = {
-    startTime                           = 0;
     dt                                  = 1;
     stopTime                            = 20;
     progressInterval                    = 100;

--- a/tests/PoolingConnCheckpointerTest/src/PoolingConnCheckpointerTestProbe.cpp
+++ b/tests/PoolingConnCheckpointerTest/src/PoolingConnCheckpointerTestProbe.cpp
@@ -140,8 +140,8 @@ int PoolingConnCheckpointerTestProbe::readStateFromCheckpoint(PV::Checkpointer *
 }
 
 int PoolingConnCheckpointerTestProbe::calcUpdateNumber(double timevalue) {
-   pvAssert(timevalue >= parent->getStartTime());
-   int const step = (int)std::nearbyint(timevalue - parent->getStartTime());
+   pvAssert(timevalue >= 0.0);
+   int const step = (int)std::nearbyint(timevalue);
    pvAssert(step >= 0);
    int const updateNumber = (step + 3) / 4; // integer division
    return updateNumber;

--- a/tests/PoolingGPUTest/input/ForwardPoolingTest.params
+++ b/tests/PoolingGPUTest/input/ForwardPoolingTest.params
@@ -1,7 +1,6 @@
 debugParsing = false;
 
 HyPerCol "Column" = {
-    startTime                           = 0;
     dt                                  = 1;
     stopTime                            = 5;
     progressInterval                    = 1;

--- a/tests/PoolingGPUTest/input/TransposePoolingNonoverlapping.params
+++ b/tests/PoolingGPUTest/input/TransposePoolingNonoverlapping.params
@@ -1,7 +1,6 @@
 debugParsing = false;
 
 HyPerCol "Column" = {
-    startTime                           = 0;
     dt                                  = 1;
     stopTime                            = 1;
     progressInterval                    = 1;

--- a/tests/RandStateSystemTest/input/RandStateSystemTest1.params
+++ b/tests/RandStateSystemTest/input/RandStateSystemTest1.params
@@ -14,7 +14,6 @@ HyPerCol "column" = {
    ny                           = 64;
    dt                           = 1.0;
    randomSeed                   = 1020304050;  // Must be at least 8 digits long.  // if not set here,  clock time is used to generate seed
-   startTime                    = 0.0;
    stopTime                     = 50.0;
    progressInterval             = 50.0;
    writeProgressToErr           = false;

--- a/tests/RandStateSystemTest/input/RandStateSystemTest2.params
+++ b/tests/RandStateSystemTest/input/RandStateSystemTest2.params
@@ -14,7 +14,6 @@ HyPerCol "column" = {
    ny                           = 64;
    dt                           = 1.0;
    randomSeed                   = 1020304050;  // Must be at least 8 digits long.  // if not set here,  clock time is used to generate seed
-   startTime                    = 0.0;
    stopTime                     = 50.0;
    progressInterval             = 50.0;
    writeProgressToErr           = false;

--- a/tests/RandomOrderTest/input/RandomOrderTest.params
+++ b/tests/RandomOrderTest/input/RandomOrderTest.params
@@ -5,7 +5,6 @@ HyPerCol "column" = {
    ny                 = 4; 
    dt                 = 1.0;
    randomSeed         = 1234567890;
-   startTime          = 0.0;
    stopTime           = 20.0;
    nbatch             = 2;
    progressInterval   = 10.0;

--- a/tests/ReceiveFromPostTest/input/manyToOnePatchSizeTest.params
+++ b/tests/ReceiveFromPostTest/input/manyToOnePatchSizeTest.params
@@ -5,7 +5,6 @@ HyPerCol "column" = {
     ny = 32;  //218;
     dt = 1.0;
     randomSeed = 1234567890;  // Must be at least 8 digits long.  // if not set here,  clock time is used to generate seed
-    startTime = 0.0;
     stopTime = 10.0;       // Depends on number of VINE video frames
     progressInterval = 1.0;
     outputPath = "output/manyToOnePatchSizeTest";

--- a/tests/ReceiveFromPostTest/input/oneToManyPatchSizeTest.params
+++ b/tests/ReceiveFromPostTest/input/oneToManyPatchSizeTest.params
@@ -5,7 +5,6 @@ HyPerCol "column" = {
     ny = 8;  //218;
     dt = 1.0;
     randomSeed = 1234567890;  // Must be at least 8 digits long.  // if not set here,  clock time is used to generate seed
-    startTime = 0.0;
     stopTime = 10.0;       // Depends on number of VINE video frames
     progressInterval = 1.0;
     outputPath = "output/oneToManyPatchSizeTest";

--- a/tests/ReceiveFromPostTest/input/postRecvBatch.params
+++ b/tests/ReceiveFromPostTest/input/postRecvBatch.params
@@ -16,7 +16,6 @@ HyPerCol "column" = {
    ny = 64;
    dt = 1.0;  //time step in ms.	     
    randomSeed = 1234567890;  // Must be at least 8 digits long.  // if not set here,  clock time is used to generate seed
-   startTime = 0.0;
    stopTime = 5.0;  
    nbatch = 8;
    threadBatch = 0;

--- a/tests/ReceiveFromPostTest/input/postTest.params
+++ b/tests/ReceiveFromPostTest/input/postTest.params
@@ -5,7 +5,6 @@ HyPerCol "column" = {
     ny = 32;  //218;
     dt = 1.0;
     randomSeed = 1234567890;  // Must be at least 8 digits long.  // if not set here,  clock time is used to generate seed
-    startTime = 0.0;
     stopTime = 10.0;       // Depends on number of VINE video frames
     progressInterval = 1.0;
     //Change this

--- a/tests/ReceiveFromPostTest/input/postTestNoTranspose.params
+++ b/tests/ReceiveFromPostTest/input/postTestNoTranspose.params
@@ -5,7 +5,6 @@ HyPerCol "column" = {
     ny = 32;  //218;
     dt = 1.0;
     randomSeed = 1234567890;  // Must be at least 8 digits long.  // if not set here,  clock time is used to generate seed
-    startTime = 0.0;
     stopTime = 10.0;       // Depends on number of VINE video frames
     progressInterval = 1.0;
     //Change this

--- a/tests/ReceiveFromPostTest/input/postTestNoTranspose_GPU.params
+++ b/tests/ReceiveFromPostTest/input/postTestNoTranspose_GPU.params
@@ -5,7 +5,6 @@ HyPerCol "column" = {
     ny = 32;  //218;
     dt = 1.0;
     randomSeed = 1234567890;  // Must be at least 8 digits long.  // if not set here,  clock time is used to generate seed
-    startTime = 0.0;
     stopTime = 10.0;       // Depends on number of VINE video frames
     progressInterval = 1.0;
     //Change this

--- a/tests/ReceiveFromPostTest/input/postTest_ManyToOne.params
+++ b/tests/ReceiveFromPostTest/input/postTest_ManyToOne.params
@@ -5,7 +5,6 @@ HyPerCol "column" = {
     ny = 32;  //218;
     dt = 1.0;
     randomSeed = 1234567890;  // Must be at least 8 digits long.  // if not set here,  clock time is used to generate seed
-    startTime = 0.0;
     stopTime = 10.0;       // Depends on number of VINE video frames
     progressInterval = 1.0;
     //Change this

--- a/tests/ReceiveFromPostTest/input/postTest_OneToMany.params
+++ b/tests/ReceiveFromPostTest/input/postTest_OneToMany.params
@@ -5,7 +5,6 @@ HyPerCol "column" = {
     ny = 32;  //218;
     dt = 1.0;
     randomSeed = 1234567890;  // Must be at least 8 digits long.  // if not set here,  clock time is used to generate seed
-    startTime = 0.0;
     stopTime = 10.0;       // Depends on number of VINE video frames
     progressInterval = 1.0;
     //Change this

--- a/tests/ReceiveFromPostTest/input/postTest_margins.params
+++ b/tests/ReceiveFromPostTest/input/postTest_margins.params
@@ -5,7 +5,6 @@ HyPerCol "column" = {
     ny = 32;  //218;
     dt = 1.0;
     randomSeed = 1234567890;  // Must be at least 8 digits long.  // if not set here,  clock time is used to generate seed
-    startTime = 0.0;
     stopTime = 10.0;       // Depends on number of VINE video frames
     progressInterval = 1.0;
     //Change this

--- a/tests/ReduceAcrossBatchTest/input/ReduceAcrossBatchTest.params
+++ b/tests/ReduceAcrossBatchTest/input/ReduceAcrossBatchTest.params
@@ -26,7 +26,6 @@ HyPerCol "column" = {
    nbatch = 4;
    dt = 1.0; 
    randomSeed = 1234567890; 
-   startTime = 0.0;
    stopTime = 1.0;  
    errorOnNotANumber = true;
    progressInterval = 10.0;

--- a/tests/RescaleLayerTest/input/RescaleLayerTest.params
+++ b/tests/RescaleLayerTest/input/RescaleLayerTest.params
@@ -15,7 +15,6 @@ HyPerCol "column" = {
    ny = 16;
    dt = 1.0;
    randomSeed = 928962559;
-   startTime = 0.0;
    stopTime = 9.0;
    errorOnNotANumber = true;
    progressInterval = 1.0;

--- a/tests/RescaleLayerTest/src/RescaleLayerTestProbe.cpp
+++ b/tests/RescaleLayerTest/src/RescaleLayerTestProbe.cpp
@@ -45,7 +45,7 @@ int RescaleLayerTestProbe::communicateInitInfo(
 
 int RescaleLayerTestProbe::outputState(double timed) {
    int status = StatsProbe::outputState(timed);
-   if (timed == parent->getStartTime()) {
+   if (timed == 0.0) {
       return PV_SUCCESS;
    }
    float tolerance      = 2.0e-5f;

--- a/tests/ResetStateOnTriggerTest/input/ResetStateOnTriggerGPU.params
+++ b/tests/ResetStateOnTriggerTest/input/ResetStateOnTriggerGPU.params
@@ -17,7 +17,6 @@ HyPerCol "column" = {
    nbatch = 4;
    dt = 1.0;
    randomSeed = 1234567890;
-   startTime = 0.0;
    stopTime = 10.0;  
    progressInterval = 1.0;
    errorOnNotANumber = false;

--- a/tests/ResetStateOnTriggerTest/input/ResetStateOnTriggerTest.params
+++ b/tests/ResetStateOnTriggerTest/input/ResetStateOnTriggerTest.params
@@ -31,7 +31,6 @@
 
 debugParsing = false;
 HyPerCol "column" = {
-    startTime                           = 0;
     dt                                  = 1;
     stopTime                            = 100;
     progressInterval                    = 5;

--- a/tests/ResetStateOnTriggerTest/src/ResetStateOnTriggerTestProbe.cpp
+++ b/tests/ResetStateOnTriggerTest/src/ResetStateOnTriggerTestProbe.cpp
@@ -22,7 +22,7 @@ int ResetStateOnTriggerTestProbe::initialize(char const *name, PV::HyPerCol *hc)
 
 int ResetStateOnTriggerTestProbe::calcValues(double timevalue) {
    int nBatch = getNumValues();
-   if (timevalue > parent->getStartTime()) {
+   if (timevalue > 0.0) {
       int N                 = targetLayer->getNumNeurons();
       int NGlobal           = targetLayer->getNumGlobalNeurons();
       PVLayerLoc const *loc = targetLayer->getLayerLoc();

--- a/tests/SegmentTest/input/centerpoint.params
+++ b/tests/SegmentTest/input/centerpoint.params
@@ -5,7 +5,6 @@ HyPerCol "column" = {
     ny = 8;  //218;
     dt = 1.0;
     randomSeed = 1234567890;  // Must be at least 8 digits long.  // if not set here,  clock time is used to generate seed
-    startTime = 0.0;
     stopTime = 2.0;       // Depends on number of VINE video frames
     progressInterval = 1.0;
     outputPath = "output";

--- a/tests/SegmentTest/input/segmentResize.params
+++ b/tests/SegmentTest/input/segmentResize.params
@@ -4,7 +4,6 @@ HyPerCol "column" = {
     nx = 8; //1242;  // KITTI synced value
     ny = 8;  //218; dt = 1.0;
     randomSeed = 1234567890;  // Must be at least 8 digits long.  // if not set here,  clock time is used to generate seed
-    startTime = 0.0;
     stopTime = 2.0;       // Depends on number of VINE video frames
     progressInterval = 1.0;
     outputPath = "output/";

--- a/tests/SegmentTest/input/testInOutSegmentify.params
+++ b/tests/SegmentTest/input/testInOutSegmentify.params
@@ -5,7 +5,6 @@ HyPerCol "column" = {
     ny = 8;  //218;
     dt = 1.0;
     randomSeed = 1234567890;  // Must be at least 8 digits long.  // if not set here,  clock time is used to generate seed
-    startTime = 0.0;
     stopTime = 2.0;       // Depends on number of VINE video frames
     progressInterval = 1.0;
     outputPath = "output/";

--- a/tests/ShrunkenPatchFlagTest/input/ShrunkenPatchFlagTest.params
+++ b/tests/ShrunkenPatchFlagTest/input/ShrunkenPatchFlagTest.params
@@ -9,7 +9,6 @@ HyPerCol "column" = {
    ny                               = 8;
    dt                               = 1.0;
    randomSeed                       = 1234567890;
-   startTime                        = 0.0;
    stopTime                         = 320.0;
    progressInterval                 = 1000;
    writeProgressToErr               = false;

--- a/tests/ShrunkenPatchTest/input/ShrunkenPatchTest.params
+++ b/tests/ShrunkenPatchTest/input/ShrunkenPatchTest.params
@@ -14,7 +14,6 @@ HyPerCol "column" = {
    ny = 32;
    dt = 1.0;
    randomSeed = 1047149415;  // if not set here,  clock time is used to generate seed
-   startTime = 0.0;
    stopTime = 10.0;  // num images plus (num layers + 1) * delay
    progressInterval = 200;
    writeProgressToErr = false;

--- a/tests/StochasticReleaseTest/input/StochasticReleaseTestPost.params
+++ b/tests/StochasticReleaseTest/input/StochasticReleaseTestPost.params
@@ -18,7 +18,6 @@ HyPerCol "column" = {
    ny = 64;
    dt = 1.0;  //time step in ms.	  
    randomSeed = 2717937891;
-   startTime = 0.0;
    stopTime = 25.0;  
    progressInterval = 5.0; //Program will output its progress at each progressInterval
    writeProgressToErr = false;

--- a/tests/StochasticReleaseTest/input/StochasticReleaseTestPre.params
+++ b/tests/StochasticReleaseTest/input/StochasticReleaseTestPre.params
@@ -18,7 +18,6 @@ HyPerCol "column" = {
    ny = 64;
    dt = 1.0;  //time step in ms.	  
    randomSeed = 2717937891;
-   startTime = 0.0;
    stopTime = 25.0;  
    progressInterval = 5.0; //Program will output its progress at each progressInterval
    writeProgressToErr = false;

--- a/tests/SumPoolTest/input/sumpooltest.params
+++ b/tests/SumPoolTest/input/sumpooltest.params
@@ -5,7 +5,6 @@ HyPerCol "column" = {
     ny = 8;  //218;
     dt = 1.0;
     randomSeed = 1234567890;  // Must be at least 8 digits long.  // if not set here,  clock time is used to generate seed
-    startTime = 0.0;
     stopTime = 10.0;       // Depends on number of VINE video frames
     progressInterval = 1.0;
     outputPath = "output/sumpooltest";

--- a/tests/SumPoolTest/input/unpoolTest.params
+++ b/tests/SumPoolTest/input/unpoolTest.params
@@ -5,7 +5,6 @@ HyPerCol "column" = {
     ny = 8;  //218;
     dt = 1.0;
     randomSeed = 1234567890;  // Must be at least 8 digits long.  // if not set here,  clock time is used to generate seed
-    startTime = 0.0;
     stopTime = 10.0;       // Depends on number of VINE video frames
     progressInterval = 1.0;
     outputPath = "sumOutput/unpoolTest";

--- a/tests/TotalEnergyTest/input/TotalEnergyTest.params
+++ b/tests/TotalEnergyTest/input/TotalEnergyTest.params
@@ -15,7 +15,6 @@ HyPerCol "column" = {
    ny = 60;
    dt = 1.0;
    randomSeed = 1234567890;
-   startTime = 0.0;
    stopTime = 10.0;  
    progressInterval = 1.0;
    errorOnNotANumber = false;

--- a/tests/TransposeConnTest/input/TransposeConnTest.params
+++ b/tests/TransposeConnTest/input/TransposeConnTest.params
@@ -5,7 +5,6 @@ debugParsing = true;
 HyPerCol "column" = {
     nx                                  = 32;
     ny                                  = 32;
-    startTime                           = 0.0;
     stopTime                            = 1.0;
     dt                                  = 1.0;
     randomSeed                          = 570934122;

--- a/tests/TransposeHyPerConnTest/input/TransposeHyPerConnTest.params
+++ b/tests/TransposeHyPerConnTest/input/TransposeHyPerConnTest.params
@@ -5,7 +5,6 @@ debugParsing = false;
 HyPerCol "column" = {
     nx                                  = 32;
     ny                                  = 32;
-    startTime                           = 0.0;
     stopTime                            = 1.0;
     dt                                  = 1.0;
     randomSeed                          = 570934122;

--- a/tests/TriggerTest/input/TriggerTest.params
+++ b/tests/TriggerTest/input/TriggerTest.params
@@ -11,7 +11,6 @@ HyPerCol "column" = {
    ny                               = 8;
    dt                               = 1.0;
    randomSeed                       = 1234567890;
-   startTime                        = 0.0;
    stopTime                         = 500.0;
    progressInterval                 = 1;
    writeProgressToErr               = false;

--- a/tests/UnequalPatchSizeTest/input/UnequalPatchSizeTest.params
+++ b/tests/UnequalPatchSizeTest/input/UnequalPatchSizeTest.params
@@ -15,7 +15,6 @@ HyPerCol "column" = {
    ny = 16;
    dt = 1.0;
    randomSeed = 1234567890;
-   startTime = 0.0;
    stopTime = 2.0;  
    errorOnNotANumber = true;
    progressInterval = 10.0;

--- a/tests/UpdateFromCloneTest/input/momentumUpdateFromCloneTest.params
+++ b/tests/UpdateFromCloneTest/input/momentumUpdateFromCloneTest.params
@@ -5,7 +5,6 @@ HyPerCol "column" = {
     ny = 32;  //218;
     dt = 1.0;
     randomSeed = 1234567890;  // Must be at least 8 digits long.  // if not set here,  clock time is used to generate seed
-    startTime = 0.0;
     stopTime = 5.0;       // Depends on number of VINE video frames
     progressInterval = 1.0;
     //Change this

--- a/tests/UpdateFromCloneTest/input/updateFromCloneTest.params
+++ b/tests/UpdateFromCloneTest/input/updateFromCloneTest.params
@@ -5,7 +5,6 @@ HyPerCol "column" = {
     ny = 32;  //218;
     dt = 1.0;
     randomSeed = 1234567890;  // Must be at least 8 digits long.  // if not set here,  clock time is used to generate seed
-    startTime = 0.0;
     stopTime = 1.0;       // Depends on number of VINE video frames
     progressInterval = 1.0;
     //Change this

--- a/tests/WriteActivitySparseTest/input/GenerateOutput.params
+++ b/tests/WriteActivitySparseTest/input/GenerateOutput.params
@@ -12,7 +12,6 @@
 debugParsing = false;
 
 HyPerCol "column" = {
-    startTime                           = 0;
     dt                                  = 1;
     stopTime                            = 10;
     progressInterval                    = 10;

--- a/tests/WriteActivitySparseTest/input/TestOutput.params
+++ b/tests/WriteActivitySparseTest/input/TestOutput.params
@@ -30,7 +30,6 @@
 debugParsing = false;
 
 HyPerCol "column" = {
-    startTime                           = 0;
     dt                                  = 1;
     stopTime                            = 10;
     progressInterval                    = 10;

--- a/tests/WriteSparseFileTest/input/WriteSparseFileTest.params
+++ b/tests/WriteSparseFileTest/input/WriteSparseFileTest.params
@@ -16,7 +16,6 @@ HyPerCol "column" = {
    ny = 32;
    dt = 1.0;  //time step in ms.	     
    randomSeed = 1234567890;  // Must be at least 8 digits long.  // if not set here,  clock time is used to generate seed
-   startTime = 0.0;
    stopTime = 10.0;  
    progressInterval = 10.0; //Program will output its progress at each progressInterval
    writeProgressToErr = false;  

--- a/tests/test_border_activity/input/test_border_activity.params
+++ b/tests/test_border_activity/input/test_border_activity.params
@@ -3,7 +3,6 @@ debugParsing = false;
 HyPerCol "column" = {
    nx = 64;
    ny = 64;
-   startTime = 0.0;
    stopTime = 3.0;
    dt = 1.0;
    progressInterval = 2000;

--- a/tests/test_constant_input/input/test_constant_input.params
+++ b/tests/test_constant_input/input/test_constant_input.params
@@ -3,7 +3,6 @@ debugParsing = false;
 HyPerCol "test_constant_input_column" = {
     nx = 16;
     ny = 16;
-    startTime = 0.0;
     stopTime = 5.0;
     dt = 1.0;
     progressInterval = 1.0;

--- a/tests/test_gauss2d/input/test_gauss2d.params
+++ b/tests/test_gauss2d/input/test_gauss2d.params
@@ -6,7 +6,6 @@ debugParsing = false;
 HyPerCol "test_gauss2d_column" = {
    nx = 16;
    ny = 16;
-   startTime = 0.0;
    stopTime = 1.0;
    progressInterval = 1.0;
    writeProgressToErr = false;

--- a/tests/test_mirror_BCs/input/test_mirror_BCs.params
+++ b/tests/test_mirror_BCs/input/test_mirror_BCs.params
@@ -5,7 +5,6 @@
 debugParsing = false;
 
 HyPerCol "test_mirror_BCs_column" = {
-   startTime = 0.0;
    dt = 1.0;
    stopTime = 1.0;
    outputPath = "output/";

--- a/tests/test_mpi_specifyrowscolumns/input/test_mpi_specifyrowscolumns.params
+++ b/tests/test_mpi_specifyrowscolumns/input/test_mpi_specifyrowscolumns.params
@@ -3,7 +3,6 @@
 debugParsing = false;
 
 HyPerCol "column" = {
-    startTime = 0.0;
     dt = 1.0;
     stopTime = 1.0;
     progressInterval = 1.0;


### PR DESCRIPTION
This pull request eliminates the startTime parameter from HyPerCol. HyPerCol::run always starts the simulation time at zero. Only one system test set startTime to a nonzero value, and its functioning does not depend on that value.