### PR TITLE
Cuda memory fix

### DIFF
--- a/src/components/Weights.cpp
+++ b/src/components/Weights.cpp
@@ -116,7 +116,6 @@ void Weights::allocateCudaBuffers() {
          "Weights::allocateCudaBuffers() called for weights \"%s\" without having set "
          "CudaDevice.\n",
          getName().c_str());
-   pvAssert(mDevicePatches == nullptr); // Should only be called once, by allocateDataStructures();
    pvAssert(mDeviceData == nullptr); // Should only be called once, by allocateDataStructures();
 #ifdef PV_USE_CUDNN
    pvAssert(mCUDNNData == nullptr); // Should only be called once, by allocateDataStructures();
@@ -126,18 +125,9 @@ void Weights::allocateCudaBuffers() {
                     * getGeometry()->getNumPatchesF();
    std::size_t size;
 
-   Patch const *hostPatches = &getGeometry()->getPatch(0); // Patches allocated as one vector
-   size                     = (std::size_t)numPatches * sizeof(*hostPatches);
-   mDevicePatches           = mCudaDevice->createBuffer(size, &description);
-   pvAssert(mDevicePatches);
-   // Copy patch geometry information onto CUDA device because it never changes.
-   mDevicePatches->copyToDevice(hostPatches);
-
-   auto const *hostGSynPatchStart = getGeometry()->getGSynPatchStart().data();
-   size                           = (std::size_t)numPatches * sizeof(*hostGSynPatchStart);
-   mDeviceGSynPatchStart          = mCudaDevice->createBuffer(size, &description);
-   // Copy GSynPatchStart array onto CUDA device because it never changes.
-   mDeviceGSynPatchStart->copyToDevice(hostGSynPatchStart);
+   // Apr 10, 2018: mDevicePatches and mDeviceGSynPatchStart have been moved to
+   // PresynapticPerspectiveGPUDelivery, since they are needed for the presynaptic perspective,
+   // but not the postsynaptic perspective.
 
    if (getNumDataPatches() > 0) {
       std::vector<int> hostPatchToDataLookupVector(numPatches);

--- a/src/components/Weights.hpp
+++ b/src/components/Weights.hpp
@@ -261,8 +261,6 @@ class Weights {
 
    void setCudaDevice(PVCuda::CudaDevice *device) { mCudaDevice = device; }
 
-   PVCuda::CudaBuffer *getDevicePatches() const { return mDevicePatches; }
-   PVCuda::CudaBuffer *getDeviceGSynPatchStart() const { return mDeviceGSynPatchStart; }
    PVCuda::CudaBuffer *getDevicePatchToDataLookup() const { return mDevicePatchToDataLookup; }
    PVCuda::CudaBuffer *getDeviceData() const { return mDeviceData; }
 #ifdef PV_USE_CUDNN
@@ -306,8 +304,6 @@ class Weights {
 #ifdef PV_USE_CUDA
    bool mUsingGPUFlag                           = false;
    PVCuda::CudaDevice *mCudaDevice              = nullptr;
-   PVCuda::CudaBuffer *mDevicePatches           = nullptr;
-   PVCuda::CudaBuffer *mDeviceGSynPatchStart    = nullptr;
    PVCuda::CudaBuffer *mDevicePatchToDataLookup = nullptr;
    PVCuda::CudaBuffer *mDeviceData              = nullptr;
 #ifdef PV_USE_CUDNN

--- a/src/delivery/PresynapticPerspectiveGPUDelivery.hpp
+++ b/src/delivery/PresynapticPerspectiveGPUDelivery.hpp
@@ -75,6 +75,7 @@ class PresynapticPerspectiveGPUDelivery : public HyPerDelivery {
    std::vector<std::vector<float>> mThreadGSyn; // needed since deliverUnitInput is not on the GPU
    PVCuda::CudaRecvPre *mRecvKernel   = nullptr;
    PVCuda::CudaBuffer *mDevicePatches = nullptr;
+   PVCuda::CudaBuffer *mDeviceGSynPatchStart = nullptr;
 
 }; // end class PresynapticPerspectiveGPUDelivery
 

--- a/src/layers/ImageLayer.cpp
+++ b/src/layers/ImageLayer.cpp
@@ -66,6 +66,11 @@ void ImageLayer::populateFileList() {
             mFileList.push_back(noWhiteSpace);
          }
       }
+      FatalIf(
+            mFileList.empty(),
+            "%s inputPath file list \"%s\" is empty.\n",
+            getDescription_c(),
+            getInputPath().c_str());
    }
 }
 

--- a/src/weightupdaters/HebbianUpdater.cpp
+++ b/src/weightupdaters/HebbianUpdater.cpp
@@ -333,14 +333,14 @@ Response::Status HebbianUpdater::registerData(Checkpointer *checkpointer) {
       // Do we need to get PrepareCheckpointWrite messages, to call blockingNormalize_dW()?
    }
    std::string nameString = std::string(name);
-   checkpointer->registerCheckpointData(
-         nameString,
-         "lastUpdateTime",
-         &mLastUpdateTime,
-         (std::size_t)1,
-         true /*broadcast*/,
-         false /*not constant*/);
    if (mPlasticityFlag && !mTriggerLayer) {
+      checkpointer->registerCheckpointData(
+            nameString,
+            "lastUpdateTime",
+            &mLastUpdateTime,
+            (std::size_t)1,
+            true /*broadcast*/,
+            false /*not constant*/);
       checkpointer->registerCheckpointData(
             nameString,
             "weightUpdateTime",


### PR DESCRIPTION
This pull request addresses an issue with CUDA memory allocation and a couple of other issues.

Previously, a Weights object would allocate some cuda memory for buffers used only from the presynaptic perspective, regardless of whether the weights were used from that perspective on the gpu. These unnecessary CUDA allocations have been eliminated.

Additionally, ImageLayer now checks whether the list of files is empty and exits with an error in that case, instead of throwing a vector out-of-range exception.

Finally, connections only checkpoint the lastUpdateTime.bin file if the connection is plastic and a trigger layer is not used. Previously, lastUpdateTime would always be checkpointed.
