### PR TITLE
Fixing error when reading sparse pvp file in python

### DIFF
--- a/python/pvtools/pvpFile.py
+++ b/python/pvtools/pvpFile.py
@@ -217,7 +217,7 @@ class pvpOpen(object):
                 self.pvpFile.seek(self.framePos[frame], os.SEEK_SET)
                 time = np.fromfile(self.pvpFile,np.float64,1)[0]
                 timeList.append(time)
-                numActive = np.fromfile(self.pvpFile,np.uint32,1)
+                numActive = np.fromfile(self.pvpFile,np.uint32,1).item()
                 currentData = np.fromfile(self.pvpFile,entryPattern,numActive)
                 dataIdx = currentData['index']
                 dataValues = currentData['activation']


### PR DESCRIPTION
numActive should be a scalar, but is instead a single element vector. Changed it so that the scalar value is extracted from said vector.