### PR TITLE
compareparams.cpp in tools directory

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -11,6 +11,7 @@ project(PetaVision)
 set(PV_DIR_DEFAULT "${CMAKE_CURRENT_SOURCE_DIR}/src")
 set(PV_TEST_DIR "${CMAKE_CURRENT_SOURCE_DIR}/tests")
 set(PV_DEMOS_DIR "${CMAKE_CURRENT_SOURCE_DIR}/demos")
+set(PV_TOOLS_DIR "${CMAKE_CURRENT_SOURCE_DIR}/tools")
 
 # Defaults
 set(PV_BUILD_DEMOS_DEFAULT OFF)
@@ -42,3 +43,5 @@ endif()
 if (${PV_BUILD_DEMOS})
    add_subdirectory(${PV_DEMOS_DIR})
 endif()
+
+add_subdirectory(${PV_TOOLS_DIR})

--- a/cmake/PVAddExecutable.cmake
+++ b/cmake/PVAddExecutable.cmake
@@ -2,7 +2,7 @@
 # Adds an OpenPV based executable. Takes a target name and a list of files
 # to build the target
 #
-# Exepcted in scope variables to be set:
+# Expected in scope variables to be set:
 #
 # PV_CONFIG_FILE_DIR
 # PV_INCLUDE_DIR: path to OpenPV include files

--- a/src/columns/Arguments.hpp
+++ b/src/columns/Arguments.hpp
@@ -1,5 +1,5 @@
 /*
- * PVArguments.hpp
+ * Arguments.hpp
  *
  *  Created on: Sep 21, 2015
  *      Author: pschultz

--- a/src/io/PVParams.cpp
+++ b/src/io/PVParams.cpp
@@ -1128,9 +1128,7 @@ int PVParams::parseBuffer(char const *buffer, long int bufferLength) {
             break;
          }
       }
-      if (hypercolGroup == nullptr) {
-         Fatal() << "PVParams::parseBuffer: no HyPerCol group\n";
-      }
+      FatalIf(hypercolGroup == nullptr, "PVParams::parseBuffer: no HyPerCol group\n");
    }
 
    // Each ParameterSweep needs to have its group/parameter pair added to the database, if it's not
@@ -1426,7 +1424,7 @@ void PVParams::ioParamString(
          else {
             // parameter was not set in params file; use the default.  But default might or might
             // not be nullptr.
-            if (icComm->globalCommRank() == 0 && warnIfAbsent == true) {
+            if (worldRank == 0 and warnIfAbsent == true) {
                if (defaultValue != nullptr) {
                   WarnLog().printf(
                         "Using default value \"%s\" for string parameter \"%s\" in group \"%s\"\n",
@@ -1449,7 +1447,7 @@ void PVParams::ioParamString(
             FatalIf(
                   *paramStringValue == nullptr,
                   "Global rank %d process unable to copy param %s in group \"%s\": %s\n",
-                  icComm->globalCommRank(),
+                  worldRank,
                   paramName,
                   groupName,
                   strerror(errno));
@@ -1476,7 +1474,7 @@ void PVParams::ioParamStringRequired(
             FatalIf(
                   *paramStringValue == nullptr,
                   "Global Rank %d process unable to copy param %s in group \"%s\": %s\n",
-                  icComm->globalCommRank(),
+                  worldRank,
                   paramName,
                   groupName,
                   strerror(errno));
@@ -1484,7 +1482,7 @@ void PVParams::ioParamStringRequired(
          else if (!stringPresent(groupName, paramName)) {
             // Setting the param to NULL explicitly is allowed;
             // if the string parameter is not present at all, error out.
-            if (icComm->globalCommRank() == 0) {
+            if (worldRank == 0) {
                ErrorLog().printf(
                      "%s \"%s\": string parameter \"%s\" is required.\n",
                      groupKeywordFromName(groupName),

--- a/src/utils/CMakeLists.txt
+++ b/src/utils/CMakeLists.txt
@@ -3,6 +3,7 @@ set (PVLibSrcCpp ${PVLibSrcCpp}
    ${SUBDIR}/BufferUtilsPvp.cpp
    ${SUBDIR}/BufferUtilsRescale.cpp
    ${SUBDIR}/Clock.cpp
+   ${SUBDIR}/CompareParamsFiles.cpp
    ${SUBDIR}/PVAssert.cpp
    ${SUBDIR}/PVAlloc.cpp
    ${SUBDIR}/PVLog.cpp
@@ -16,6 +17,7 @@ set (PVLibSrcHpp ${PVLibSrcHpp}
    ${SUBDIR}/BufferUtilsPvp.hpp
    ${SUBDIR}/BufferUtilsRescale.hpp
    ${SUBDIR}/Clock.hpp
+   ${SUBDIR}/CompareParamsFiles.hpp
    ${SUBDIR}/MapLookupByType.hpp
    ${SUBDIR}/PVAssert.hpp
    ${SUBDIR}/PVAlloc.hpp

--- a/src/utils/CompareParamsFiles.cpp
+++ b/src/utils/CompareParamsFiles.cpp
@@ -1,0 +1,296 @@
+/*
+ * CompareParamsFiles.cpp
+ *
+ *  Created on: Dec 17, 2018
+ *      Author: pschultz
+ */
+
+#include "CompareParamsFiles.hpp"
+#include "include/pv_common.h"
+
+namespace PV {
+
+int compareParamsFiles(
+      std::string const &paramsFile1,
+      std::string const &paramsFile2,
+      Communicator *comm) {
+   int status = PV_SUCCESS;
+   PVParams params1{paramsFile1.c_str(), INITIAL_LAYER_ARRAY_SIZE, comm};
+   PVParams params2{paramsFile2.c_str(), INITIAL_LAYER_ARRAY_SIZE, comm};
+
+   // create a map between groups in paramsFile1 and those in paramsFile2.
+   std::map<ParameterGroup *, ParameterGroup *> parameterGroupMap;
+   char const *groupName = nullptr;
+   for (int idx = 0; (groupName = params1.groupNameFromIndex(idx)) != nullptr; idx++) {
+      ParameterGroup *g1 = params1.group(groupName);
+      ParameterGroup *g2 = params2.group(groupName);
+      if (g2 == nullptr) {
+         ErrorLog().printf(
+               "Group name \"%s\" is in \"%s\" but not in \"%s\".\n",
+               groupName,
+               paramsFile1.c_str(),
+               paramsFile2.c_str());
+         status = PV_FAILURE;
+      }
+      else {
+         parameterGroupMap.emplace(std::make_pair(g1, g2));
+      }
+   }
+   for (int idx = 0; (groupName = params2.groupNameFromIndex(idx)) != nullptr; idx++) {
+      if (params1.group(groupName) == nullptr) {
+         ErrorLog().printf(
+               "Group name \"%s\" is in \"%s\" but not in \"%s\".\n",
+               groupName,
+               paramsFile2.c_str(),
+               paramsFile1.c_str());
+         status = PV_FAILURE;
+      }
+   }
+
+   for (auto &p : parameterGroupMap) {
+      status |= compareParameterGroups(p.first, p.second);
+   }
+   return status;
+}
+
+int compareParameterGroups(ParameterGroup *group1, ParameterGroup *group2) {
+   int status = PV_SUCCESS;
+   if (strcmp(group1->name(), group2->name())) {
+      ErrorLog().printf(
+            "Groups have different names (\"%s\" versus \"%s\")\n", group1->name(), group2->name());
+      status = PV_FAILURE;
+   }
+   if (strcmp(group1->getGroupKeyword(), group2->getGroupKeyword())) {
+      ErrorLog().printf(
+            "Keywords for group \"%s\" do not match (\"%s\" versus \"%s\").\n",
+            group1->name(),
+            group1->getGroupKeyword(),
+            group2->getGroupKeyword());
+      status = PV_FAILURE;
+   }
+   ParameterStack *numericStack1 = group1->copyStack();
+   ParameterStack *numericStack2 = group2->copyStack();
+   status |= compareParameterNumericStacks(group1->name(), numericStack1, numericStack2);
+   delete numericStack1;
+   delete numericStack2;
+
+   ParameterArrayStack *arrayStack1 = group1->copyArrayStack();
+   ParameterArrayStack *arrayStack2 = group2->copyArrayStack();
+   status |= compareParameterArrayStacks(group1->name(), arrayStack1, arrayStack2);
+   delete arrayStack1;
+   delete arrayStack2;
+
+   ParameterStringStack *stringStack1 = group1->copyStringStack();
+   ParameterStringStack *stringStack2 = group2->copyStringStack();
+   status |= compareParameterStringStacks(group1->name(), stringStack1, stringStack2);
+   delete stringStack1;
+   delete stringStack2;
+
+   return status;
+}
+
+int compareParameterNumericStacks(
+      char const *groupName,
+      ParameterStack *stack1,
+      ParameterStack *stack2) {
+   int status = PV_SUCCESS;
+
+   // Vector of booleans indicating for each element of stack2 whether the name exists in stack1
+   std::vector<bool> inStack1(stack2->size(), false);
+   for (int i = 0; i < stack1->size(); i++) {
+      Parameter *param1      = stack1->peek(i);
+      char const *paramName1 = param1->name();
+      bool found             = false;
+      for (int j = 0; j < stack2->size(); j++) {
+         Parameter *param2      = stack2->peek(j);
+         char const *paramName2 = param2->name();
+         if (!strcmp(paramName1, paramName2)) {
+            found       = true;
+            inStack1[j] = true;
+            if (param1->value() != param2->value()) {
+               ErrorLog().printf(
+                     "Parameter \"%s\" in group \"%s\" has different values (%f versus %f).\n",
+                     paramName1,
+                     groupName,
+                     param1->value(),
+                     param2->value());
+               status = PV_FAILURE;
+            }
+            break;
+         }
+      }
+      if (!found) {
+         ErrorLog().printf(
+               "Parameter \"%s\" was found in group \"%s\" of one stack but not the other.\n",
+               paramName1,
+               groupName);
+         status = PV_FAILURE;
+      }
+   }
+   for (int j = 0; j < stack2->size(); j++) {
+      if (!inStack1[j]) {
+         ErrorLog().printf(
+               "Parameter \"%s\" was found in group \"%s\" of one stack but not the other.\n",
+               stack2->peek(j)->name(),
+               groupName);
+         status = PV_FAILURE;
+      }
+   }
+   return status;
+}
+
+int compareParameterArrayStacks(
+      char const *groupName,
+      ParameterArrayStack *stack1,
+      ParameterArrayStack *stack2) {
+   int status = PV_SUCCESS;
+
+   // Vector of booleans indicating for each element of stack2 whether the name exists in stack1
+   std::vector<bool> inStack1(stack2->size(), false);
+   for (int i = 0; i < stack1->size(); i++) {
+      ParameterArray *param1 = stack1->peek(i);
+      char const *paramName1 = param1->name();
+      bool found             = false;
+      for (int j = 0; j < stack2->size(); j++) {
+         ParameterArray *param2 = stack2->peek(j);
+         char const *paramName2 = param2->name();
+         if (!strcmp(paramName1, paramName2)) {
+            found       = true;
+            inStack1[j] = true;
+            status |= compareParameterArray(groupName, param1, param2);
+            break;
+         }
+      }
+      if (!found) {
+         ErrorLog().printf(
+               "Array parameter \"%s\" was found in group \"%s\" of one stack but not the other.\n",
+               paramName1,
+               groupName);
+         status = PV_FAILURE;
+      }
+   }
+   for (int j = 0; j < stack2->size(); j++) {
+      if (!inStack1[j]) {
+         ErrorLog().printf(
+               "Array parameter \"%s\" was found in group \"%s\" of one stack but not the other.\n",
+               stack2->peek(j)->name(),
+               groupName);
+         status = PV_FAILURE;
+      }
+   }
+   return status;
+}
+
+int compareParameterArray(char const *groupName, ParameterArray *array1, ParameterArray *array2) {
+   int status = PV_SUCCESS;
+   if (strcmp(array1->name(), array2->name())) {
+      ErrorLog().printf(
+            "Arrays have different names (\"%s\" versus \"%s\")\n", array1->name(), array2->name());
+   }
+   if (array1->getArraySize() != array2->getArraySize()) {
+      ErrorLog().printf(
+            "Array \"%s\" in group \"%s\" differs in size (%d versus %d).\n",
+            array1->name(),
+            groupName,
+            array1->getArraySize(),
+            array2->getArraySize());
+   }
+   int size1, size2;
+   double const *values1 = array1->getValuesDbl(&size1);
+   double const *values2 = array2->getValuesDbl(&size2);
+   int size              = size1 <= size2 ? size1 : size2;
+   int badIndex          = 0;
+   for (int i = 0; i < size; i++) {
+      if (values1[i] != values2[i]) {
+         badIndex = i + 1;
+         ErrorLog().printf(
+               "Group %s, array %s, index %d differs (%f versus %f).\n",
+               groupName,
+               array1->name(),
+               badIndex,
+               values1[i],
+               values2[i]);
+         status = PV_FAILURE;
+      }
+   }
+   return status;
+}
+
+int compareParameterStringStacks(
+      char const *groupName,
+      ParameterStringStack *stack1,
+      ParameterStringStack *stack2) {
+   int status = PV_SUCCESS;
+
+   // Vector of booleans indicating for each element of stack2 whether the name exists in stack1
+   std::vector<bool> inStack1(stack2->size(), false);
+   for (int i = 0; i < stack1->size(); i++) {
+      ParameterString *param1 = stack1->peek(i);
+      char const *paramName1  = param1->getName();
+      bool found              = false;
+      for (int j = 0; j < stack2->size(); j++) {
+         ParameterString *param2 = stack2->peek(j);
+         char const *paramName2  = param2->getName();
+         if (!strcmp(paramName1, paramName2)) {
+            found       = true;
+            inStack1[j] = true;
+            status |= compareParameterString(groupName, param1, param2);
+            break;
+         }
+      }
+      if (!found) {
+         ErrorLog().printf(
+               "String parameter \"%s\" was found in group \"%s\" of one stack but not the "
+               "other.\n",
+               paramName1,
+               groupName);
+         status = PV_FAILURE;
+      }
+   }
+   for (int j = 0; j < stack2->size(); j++) {
+      if (!inStack1[j]) {
+         ErrorLog().printf(
+               "String parameter \"%s\" was found in group \"%s\" of one stack "
+               "but not the other.\n",
+               stack2->peek(j)->getName(),
+               groupName);
+         status = PV_FAILURE;
+      }
+   }
+   return status;
+}
+
+int compareParameterString(
+      char const *groupName,
+      ParameterString *string1,
+      ParameterString *string2) {
+   int status = PV_SUCCESS;
+   if (strcmp(string1->getName(), string2->getName())) {
+      ErrorLog().printf(
+            "ParameterStrings have different names (\"%s\" versus \"%s\")\n",
+            string1->getName(),
+            string2->getName());
+      status = PV_FAILURE;
+   }
+   char const *nullString = "(null)";
+   char const *value1     = string1->getValue();
+   if (value1 == nullptr) {
+      value1 = nullString;
+   }
+   char const *value2 = string2->getValue();
+   if (value2 == nullptr) {
+      value2 = nullString;
+   }
+   if (strcmp(value1, value2)) {
+      ErrorLog().printf(
+            "String parameter \"%s\" in group \"%s\" differs (\"%s\" versus \"%s\").\n",
+            string1->getName(),
+            groupName,
+            value1,
+            value2);
+      status = PV_FAILURE;
+   }
+   return status;
+}
+
+} // end namespace PV

--- a/src/utils/CompareParamsFiles.hpp
+++ b/src/utils/CompareParamsFiles.hpp
@@ -20,24 +20,69 @@
 
 namespace PV {
 
+/**
+ * Compares two params files, printing error messages describing any differences.
+ * The Communicator argument is needed by the PVParams constructor.
+ * Return value is PV_SUCCESS if the params files are equivalent, and PV_FAILURE if not.
+ */
 int compareParamsFiles(
       std::string const &paramsFile1,
       std::string const &paramsFile2,
       Communicator *comm);
+
+/**
+ * Compares two ParameterGroup objects, printing error messages describing any differences.
+ * Return value is PV_SUCCESS if the groups are equivalent, and PV_FAILURE if not.
+ */
 int compareParameterGroups(ParameterGroup *group1, ParameterGroup *group2);
+
+/**
+ * Compares two ParameterStack objects, printing error messages describing any differences.
+ * The groupName argument is used in any error messages, since ParameterStack does not
+ * have a name data member.
+ * Return value is PV_SUCCESS if the params files are equivalent, and PV_FAILURE if not.
+ */
 int compareParameterNumericStacks(
       char const *groupName,
       ParameterStack *stack1,
       ParameterStack *stack2);
+
+/**
+ * Compares two ParameterArrayStack objects, printing error messages describing any differences.
+ * The groupName argument is used in any error messages, since ParameterArrayStack does not
+ * have a name data member.
+ * Return value is PV_SUCCESS if the params files are equivalent, and PV_FAILURE if not.
+ */
 int compareParameterArrayStacks(
       char const *groupName,
       ParameterArrayStack *stack1,
       ParameterArrayStack *stack2);
+
+/**
+ * Compares two ParameterArray objects, printing error messages describing any differences.
+ * The groupName argument is used in any error messages, since ParameterArray does not
+ * have a name data member.
+ * Return value is PV_SUCCESS if the params files are equivalent, and PV_FAILURE if not.
+ */
 int compareParameterArray(char const *groupName, ParameterArray *array1, ParameterArray *array2);
+
+/**
+ * Compares two ParameterStringStack objects, printing error messages describing any differences.
+ * The groupName argument is used in any error messages, since ParameterStringStack does not
+ * have a name data member.
+ * Return value is PV_SUCCESS if the params files are equivalent, and PV_FAILURE if not.
+ */
 int compareParameterStringStacks(
       char const *groupName,
       ParameterStringStack *stack1,
       ParameterStringStack *stack2);
+
+/**
+ * Compares two ParameterString objects, printing error messages describing any differences.
+ * The groupName argument is used in any error messages, since ParameterString does not
+ * have a name data member.
+ * Return value is PV_SUCCESS if the params files are equivalent, and PV_FAILURE if not.
+ */
 int compareParameterString(
       char const *groupName,
       ParameterString *string1,

--- a/src/utils/CompareParamsFiles.hpp
+++ b/src/utils/CompareParamsFiles.hpp
@@ -1,0 +1,48 @@
+/*
+ * CompareParamsFiles.hpp
+ *
+ *  Created on: Dec 17, 2018
+ *      Author: pschultz
+ *
+ *  A set of utility functions for comparing the contents of two params files,
+ *  without regard to the order of parameter groups, or the order of parameters
+ *  within a group.
+ *  Used by the compareparams tool and the DryRunFlagTest system test.
+ *  All functions in this file return PV_SUCCESS if the objects are equivalent,
+ *  or PV_FAILURE if the objects differ.
+ */
+
+#ifndef COMPAREPARAMSFILES_HPP_
+#define COMPAREPARAMSFILES_HPP_
+
+#include "columns/Communicator.hpp"
+#include "io/PVParams.hpp"
+
+namespace PV {
+
+int compareParamsFiles(
+      std::string const &paramsFile1,
+      std::string const &paramsFile2,
+      Communicator *comm);
+int compareParameterGroups(ParameterGroup *group1, ParameterGroup *group2);
+int compareParameterNumericStacks(
+      char const *groupName,
+      ParameterStack *stack1,
+      ParameterStack *stack2);
+int compareParameterArrayStacks(
+      char const *groupName,
+      ParameterArrayStack *stack1,
+      ParameterArrayStack *stack2);
+int compareParameterArray(char const *groupName, ParameterArray *array1, ParameterArray *array2);
+int compareParameterStringStacks(
+      char const *groupName,
+      ParameterStringStack *stack1,
+      ParameterStringStack *stack2);
+int compareParameterString(
+      char const *groupName,
+      ParameterString *string1,
+      ParameterString *string2);
+
+} // end namespace PV
+
+#endif // COMPAREPARAMSFILES_HPP_

--- a/tests/DryRunFlagTest/src/DryRunFlagTest.cpp
+++ b/tests/DryRunFlagTest/src/DryRunFlagTest.cpp
@@ -7,35 +7,9 @@
 #include <columns/buildandrun.hpp>
 #include <sys/types.h>
 #include <unistd.h>
-#include <utils/PVAssert.hpp>
+#include <utils/CompareParamsFiles.hpp>
 
 int deleteOutputDirectory(PV::Communicator *comm);
-void compareParamsFiles(char const *paramsFile1, char const *paramsFile2, PV::Communicator *comm);
-void compareParameterGroups(PV::ParameterGroup *group1, PV::ParameterGroup *group2);
-void compareParameterNumericStacks(
-      char const *groupName,
-      PV::ParameterStack *stack1,
-      PV::ParameterStack *stack2);
-void compareParameterNumeric(
-      char const *groupName,
-      PV::Parameter *parameter1,
-      PV::Parameter *parameter2);
-void compareParameterArrayStacks(
-      char const *groupName,
-      PV::ParameterArrayStack *stack1,
-      PV::ParameterArrayStack *stack2);
-void compareParameterArray(
-      char const *groupName,
-      PV::ParameterArray *array1,
-      PV::ParameterArray *array2);
-void compareParameterStringStacks(
-      char const *groupName,
-      PV::ParameterStringStack *stack1,
-      PV::ParameterStringStack *stack2);
-void compareParameterString(
-      char const *groupName,
-      PV::ParameterString *string1,
-      PV::ParameterString *string2);
 
 int main(int argc, char *argv[]) {
 
@@ -68,7 +42,14 @@ int main(int argc, char *argv[]) {
       Fatal().printf("%s: running with dry-run flag set failed on process %d.\n", argv[0], rank);
    }
 
-   compareParamsFiles("output/pv.params", "input/correct.params", pv_obj.getCommunicator());
+   status = PV::compareParamsFiles(
+         std::string("output/pv.params"),
+         std::string("input/correct.params"),
+         pv_obj.getCommunicator());
+   if (status != PV_SUCCESS) {
+      Fatal().printf("%s failed.\n", argv[0]);
+   }
+   return status;
 }
 
 int deleteOutputDirectory(PV::Communicator *comm) {
@@ -80,237 +61,4 @@ int deleteOutputDirectory(PV::Communicator *comm) {
    }
    MPI_Bcast(&status, 1, MPI_INT, 0, comm->communicator());
    return status;
-}
-
-void compareParamsFiles(char const *paramsFile1, char const *paramsFile2, PV::Communicator *comm) {
-   PV::PVParams params1{paramsFile1, INITIAL_LAYER_ARRAY_SIZE, comm};
-   PV::PVParams params2{paramsFile2, INITIAL_LAYER_ARRAY_SIZE, comm};
-
-   // create a map between groups in paramsFile1 and those in paramsFile2.
-   std::map<PV::ParameterGroup *, PV::ParameterGroup *> parameterGroupMap;
-   char const *groupName = nullptr;
-   for (int idx = 0; (groupName = params1.groupNameFromIndex(idx)) != nullptr; idx++) {
-      PV::ParameterGroup *g1 = params1.group(groupName);
-      PV::ParameterGroup *g2 = params2.group(groupName);
-      FatalIf(
-            g2 == nullptr,
-            "Group name \"%s\" is in \"%s\" but not in \"%s\".\n",
-            groupName,
-            paramsFile1,
-            paramsFile2);
-      parameterGroupMap.emplace(std::make_pair(g1, g2));
-   }
-   for (int idx = 0; (groupName = params2.groupNameFromIndex(idx)) != nullptr; idx++) {
-      FatalIf(
-            params1.group(groupName) == nullptr,
-            "Group name \"%s\" is in \"%s\" but not in \"%s\".\n",
-            groupName,
-            paramsFile2,
-            paramsFile1);
-   }
-
-   for (auto &p : parameterGroupMap) {
-      compareParameterGroups(p.first, p.second);
-   }
-   return;
-}
-
-void compareParameterGroups(PV::ParameterGroup *group1, PV::ParameterGroup *group2) {
-   pvAssert(!strcmp(group1->name(), group2->name()));
-   FatalIf(
-         strcmp(group1->getGroupKeyword(), group2->getGroupKeyword()),
-         "Keywords for group \"%s\" do not match (\"%s\" versus \"%s\").\n",
-         group1->name(),
-         group1->getGroupKeyword(),
-         group2->getGroupKeyword());
-   PV::ParameterStack *numericStack1 = group1->copyStack();
-   PV::ParameterStack *numericStack2 = group2->copyStack();
-   compareParameterNumericStacks(group1->name(), numericStack1, numericStack2);
-
-   PV::ParameterArrayStack *arrayStack1 = group1->copyArrayStack();
-   PV::ParameterArrayStack *arrayStack2 = group2->copyArrayStack();
-   compareParameterArrayStacks(group1->name(), arrayStack1, arrayStack2);
-
-   PV::ParameterStringStack *stringStack1 = group1->copyStringStack();
-   PV::ParameterStringStack *stringStack2 = group2->copyStringStack();
-   compareParameterStringStacks(group1->name(), stringStack1, stringStack2);
-}
-
-void compareParameterNumericStacks(
-      char const *groupName,
-      PV::ParameterStack *stack1,
-      PV::ParameterStack *stack2) {
-   FatalIf(
-         stack1->size() != stack2->size(),
-         "Numeric stacks for \"%s\" have different sizes: %d versus %d.\n",
-         groupName,
-         stack1->size(),
-         stack2->size());
-   // create a map between stack1 and stack2
-   int const size = stack1->size();
-   std::map<PV::Parameter *, PV::Parameter *> parameterMap;
-   for (int i = 0; i < size; i++) {
-      PV::Parameter *param1  = stack1->peek(i);
-      char const *paramName1 = param1->name();
-      bool found             = false;
-      for (int j = 0; j < size; j++) {
-         PV::Parameter *param2  = stack2->peek(j);
-         char const *paramName2 = param2->name();
-         if (!strcmp(paramName1, paramName2)) {
-            parameterMap.emplace(std::make_pair(param1, param2));
-            found = true;
-            break;
-         }
-      }
-      if (!found) {
-         Fatal() << "Parameter \"" << paramName1 << "\" was found in group \"" << groupName
-                 << "\" of one stack but not the other.\n";
-      }
-   }
-   pvAssert(parameterMap.size() == size);
-
-   for (auto &p : parameterMap) {
-      compareParameterNumeric(groupName, p.first, p.second);
-   }
-}
-
-void compareParameterNumeric(
-      char const *groupName,
-      PV::Parameter *parameter1,
-      PV::Parameter *parameter2) {
-   pvAssert(!strcmp(parameter1->name(), parameter2->name()));
-   FatalIf(
-         parameter1->value() != parameter2->value(),
-         "Numeric parameter \"%s\" in group \"%s\" differs (%f versus %f).\n",
-         parameter1->name(),
-         groupName,
-         parameter1->value(),
-         parameter2->value());
-}
-
-void compareParameterArrayStacks(
-      char const *groupName,
-      PV::ParameterArrayStack *stack1,
-      PV::ParameterArrayStack *stack2) {
-   FatalIf(
-         stack1->size() != stack2->size(),
-         "Numeric stacks for \"%s\" have different sizes: %d versus %d.\n",
-         groupName,
-         stack1->size(),
-         stack2->size());
-   // create a map between stack1 and stack2
-   int const size = stack1->size();
-   std::map<PV::ParameterArray *, PV::ParameterArray *> parameterArrayMap;
-   for (int i = 0; i < size; i++) {
-      PV::ParameterArray *param1 = stack1->peek(i);
-      char const *paramName1     = param1->name();
-      bool found                 = false;
-      for (int j = 0; j < size; j++) {
-         PV::ParameterArray *param2 = stack2->peek(j);
-         char const *paramName2     = param2->name();
-         if (!strcmp(paramName1, paramName2)) {
-            parameterArrayMap.emplace(std::make_pair(param1, param2));
-            found = true;
-            break;
-         }
-      }
-      if (!found) {
-         Fatal() << "Parameter \"" << paramName1 << "\" was found in group \"" << groupName
-                 << "\" of one stack but not the other.\n";
-      }
-   }
-   pvAssert(parameterArrayMap.size() == size);
-
-   for (auto &p : parameterArrayMap) {
-      compareParameterArray(groupName, p.first, p.second);
-   }
-}
-
-void compareParameterArray(
-      char const *groupName,
-      PV::ParameterArray *array1,
-      PV::ParameterArray *array2) {
-   pvAssert(!strcmp(array1->name(), array2->name()));
-   FatalIf(
-         array1->getArraySize() != array2->getArraySize(),
-         "Array \"%s\" in group \"%s\" differs in size (%d versus %d).\n",
-         array1->name(),
-         groupName,
-         array1->getArraySize(),
-         array2->getArraySize());
-   int size              = array1->getArraySize();
-   double const *values1 = array1->getValuesDbl(&size);
-   double const *values2 = array2->getValuesDbl(&size);
-   int badIndex          = 0;
-   for (int i = 0; i < size; i++) {
-      if (values1[i] != values2[i]) {
-         badIndex = i + 1;
-         ErrorLog() << "Group " << groupName << ", array " << array1->name() << ", index "
-                    << badIndex << " differs (" << values1[i] << " versus " << values2[i] << ").\n";
-      }
-   }
-   if (badIndex > 0) {
-      exit(EXIT_FAILURE);
-   }
-}
-
-void compareParameterStringStacks(
-      char const *groupName,
-      PV::ParameterStringStack *stack1,
-      PV::ParameterStringStack *stack2) {
-   FatalIf(
-         stack1->size() != stack2->size(),
-         "Numeric stacks for \"%s\" have different sizes: %d versus %d.\n",
-         groupName,
-         stack1->size(),
-         stack2->size());
-   // create a map between stack1 and stack2
-   int const size = stack1->size();
-   std::map<PV::ParameterString *, PV::ParameterString *> parameterStringMap;
-   for (int i = 0; i < size; i++) {
-      PV::ParameterString *param1 = stack1->peek(i);
-      char const *paramName1      = param1->getName();
-      bool found                  = false;
-      for (int j = 0; j < size; j++) {
-         PV::ParameterString *param2 = stack2->peek(j);
-         char const *paramName2      = param2->getName();
-         if (!strcmp(paramName1, paramName2)) {
-            parameterStringMap.emplace(std::make_pair(param1, param2));
-            found = true;
-            break;
-         }
-      }
-      if (!found) {
-         Fatal() << "Parameter \"" << paramName1 << "\" was found in group \"" << groupName
-                 << "\" of one stack but not the other.\n";
-      }
-   }
-   pvAssert(parameterStringMap.size() == size);
-
-   for (auto &p : parameterStringMap) {
-      compareParameterString(groupName, p.first, p.second);
-   }
-}
-
-void compareParameterString(
-      char const *groupName,
-      PV::ParameterString *string1,
-      PV::ParameterString *string2) {
-   pvAssert(!strcmp(string1->getName(), string2->getName()));
-   char const *nullString = "(null)";
-   char const *value1     = string1->getValue();
-   if (value1 == nullptr) {
-      value1 = nullString;
-   }
-   char const *value2 = string2->getValue();
-   if (value2 == nullptr) {
-      value2 = nullString;
-   }
-   FatalIf(
-         strcmp(value1, value2),
-         "String parameter \"%s\" in group \"%s\" differs (\"%s\" versus \"%s\").\n",
-         string1->getName(),
-         groupName,
-         value1,
-         value2);
 }

--- a/tools/CMakeLists.txt
+++ b/tools/CMakeLists.txt
@@ -1,0 +1,16 @@
+include(PVAddExecutable)
+
+set(PV_PROJECT_NAME compareparams)
+
+#include_directories("${CMAKE_CURRENT_SOURCE_DIR}/src")
+set(${PV_PROJECT_NAME}_SRCCPP
+  compareparams.cpp
+)
+
+pv_add_executable(${PV_PROJECT_NAME}
+  SRC ${${PV_PROJECT_NAME}_SRCCPP}
+)
+
+pv_add_executable(readpvpheader SRC readpvpheader.c)
+
+add_dependencies(${PV_PROJECT_NAME} pv)

--- a/tools/compareparams.cpp
+++ b/tools/compareparams.cpp
@@ -55,7 +55,7 @@ int main(int argc, char *argv[]) {
 
    // Was the help message requested?
    if (showHelp) {
-      showHelpMessage(progPath);
+      showHelpMessage(progName);
       return EXIT_SUCCESS;
    }
 

--- a/tools/compareparams.cpp
+++ b/tools/compareparams.cpp
@@ -1,0 +1,97 @@
+/**
+ * compareparams, a C++ program to compare the contents of two params files.
+ * Usage: compareparams file1.params file2.params
+ */
+
+#include <columns/PV_Init.hpp>
+#include <utils/CompareParamsFiles.hpp>
+
+#include <cstdlib> // EXIT_SUCCESS, EXIT_FAILURE
+#include <cstring> // strdup
+#include <getopt.h> // getopt_long
+#include <libgen.h> // strdup
+#include <unistd.h> // optind, used by getopt_long
+#include <vector> // vector of long options
+
+void showHelpMessage(std::string const &progName);
+
+int main(int argc, char *argv[]) {
+   // Get base name of program path, for use in print-statements.
+   char *progPath       = strdup(argv[0]);
+   std::string progName = basename(progPath);
+   free(progPath);
+
+   // Initialize PetaVision and get the Communicator.
+   // Even though we run on a single process, we need the communicator because the PVParams
+   // constructor requires it.
+   int initargc    = 1;
+   char **initargs = (char **)calloc((std::size_t)2, sizeof(char *));
+   initargs[0]     = strdup(progName.c_str());
+   initargs[1]     = nullptr;
+   auto *pvInitObj = new PV::PV_Init(&initargc, &initargs, false /*no unrecognized args*/);
+   free(initargs[0]);
+   free(initargs);
+   initargs = nullptr;
+
+   bool error   = false;
+   int showHelp = 0;
+   vector<struct option> longopts{
+         {"help", 0, &showHelp, 1}, {"usage", 0, &showHelp, 1}, {nullptr, 0, nullptr, 0}};
+   int result = 0;
+   while (result != -1) {
+      result = getopt_long(argc, argv, "hu", longopts.data(), &optind);
+      switch (result) {
+         case (int)'h': showHelp = 1; break;
+         case (int)'u': showHelp = 1; break;
+         case -1: break;
+         case 0: break;
+         default:
+            error = true; // getopt_long() produces the relevant error message.
+      }
+   }
+   if (error) {
+      return EXIT_FAILURE;
+   }
+
+   // Was the help message requested?
+   if (showHelp) {
+      showHelpMessage(progPath);
+      return EXIT_SUCCESS;
+   }
+
+   // Require exactly two filenames
+   if (optind + 2 != argc) {
+      std::cerr << progName << " requires exactly two arguments (" << argc - optind
+                << " were given).\n";
+      return EXIT_FAILURE;
+   }
+
+   std::string file1 = argv[optind];
+   std::string file2 = argv[optind + 1];
+   auto *comm        = pvInitObj->getCommunicator();
+
+   std::stringstream configStream("NumRows:0\nNumColumns:0\nBatchWidth:0\n");
+
+   int status = PV::compareParamsFiles(file1, file2, comm);
+   delete pvInitObj;
+   if (status == PV_SUCCESS) {
+      std::cout << file1 << " and " << file2 << " are equivalent.\n";
+   }
+   else {
+      return EXIT_FAILURE;
+   }
+   return status == PV_SUCCESS ? EXIT_SUCCESS : EXIT_FAILURE;
+}
+
+void showHelpMessage(std::string const &progName) {
+   std::cout << progName << " [options]\n";
+   std::cout << progName << " file1.params file2.params\n";
+   std::cout << "\n";
+   std::cout << "Options:\n";
+   std::cout << "    -h, --help, -u, --usage\n";
+   std::cout << "        Display this help text and exit. No other arguments are processed.\n";
+   std::cout << "\n";
+   std::cout << "The program takes two input paths, which should be PetaVision .params files.\n";
+   std::cout << "It compares them, irrespective of ordering of parameter groups or of \n";
+   std::cout << "ordering within a group, and outputs the differences.\n";
+}

--- a/valgrind/petavision-linux.supp
+++ b/valgrind/petavision-linux.supp
@@ -1,8 +1,8 @@
 # Valgrind suppression file for PetaVision compiled on the NMC Linux clusters.
-# There are memory leaks, etc., in Open MPI and GDAL.  Running a typical
-# PetaVision job under valgrind therefor finds hundreds of errors we can't do
-# anything about.  This suppression file prevents valgrind from  reporting on
-# them so we notice when there's an error in the PetaVision code itself.
+# There are memory leaks, etc., in Open MPI.  Running a typical PetaVision job
+# under valgrind therefor finds hundreds of errors we can't do anything about.
+# This suppression file prevents valgrind from  reporting on them so we notice
+# when there's an error in the PetaVision code itself.
 #
 # Example usage: to run the command
 #     Debug/BasicSystemTest -p input/BasicSystemTest.params
@@ -20,20 +20,6 @@
    Memcheck:Leak
    ...
    fun:getenv
-}
-
-{
-   <suppress_leak_GDALAllRegister>
-   Memcheck:Leak
-   ...
-   fun:GDALAllRegister
-}
-
-{
-   <suppress_leak_GDALOpenInternal>
-   Memcheck:Leak
-   ...
-   fun:_Z16GDALOpenInternalPKc10GDALAccessPKS0_
 }
 
 {


### PR DESCRIPTION
The compareParamsFiles() function and the related functions it calls
have been moved from DryRunFlagTest to the utils directory.
The functions have also been rewritten to return PV_SUCCESS/PV_FAILURE
instead of failing on the first discrepancy. They output error
messages (but not fatal errors) when they encounter a difference in
params.

A new executable in the tools directory, whose source file is
tools/compareparams.cpp, makes use of the compareParamsFile() function
to print out descriptions of the differences between two params files
specified on the command line.

DryRunFlagTest has been adapted to use the new behavior of
compareParamsFiles().

Finally, a CMakeLists.txt file has been added to the tools directory,
and the main CMakeLists.txt file now adds the tools directory.

When building from the base build directory, executables readpvpfile
and compareparams are compiled into the build/tools directory.