### PR TITLE
Compiler warnings

### DIFF
--- a/src/arch/cuda/CudaDevice.cpp
+++ b/src/arch/cuda/CudaDevice.cpp
@@ -100,7 +100,7 @@ int CudaDevice::query_device_info() {
    InfoLog().printf("Number of Cuda devices found: %d\n", num_devices);
    InfoLog().printf("\n");
 
-   for (unsigned int i = 0; i < num_devices; i++) {
+   for (int i = 0; i < num_devices; i++) {
       query_device(i);
    }
    return 0;

--- a/src/checkpointing/CheckpointableFileStream.hpp
+++ b/src/checkpointing/CheckpointableFileStream.hpp
@@ -48,7 +48,7 @@ class CheckpointableFileStream : public FileStream, public CheckpointerDataInter
    virtual void read(void *data, long length) override;
    virtual void setOutPos(long pos, std::ios_base::seekdir seekAnchor) override;
    virtual void setOutPos(long pos, bool fromBeginning) override;
-   virtual void setInPos(long pos, std::ios_base::seekdir seekAnchor);
+   virtual void setInPos(long pos, std::ios_base::seekdir seekAnchor) override;
    virtual void setInPos(long pos, bool fromBeginning) override;
 
   private:

--- a/src/checkpointing/Checkpointer.cpp
+++ b/src/checkpointing/Checkpointer.cpp
@@ -463,7 +463,7 @@ bool Checkpointer::registerCheckpointEntry(
    }
    std::string const &name = checkpointEntry->getName();
    for (auto &c : mCheckpointRegistry) {
-      if (c->getName() == checkpointEntry->getName()) {
+      if (c->getName() == name) {
          return false;
       }
    }
@@ -526,7 +526,7 @@ void Checkpointer::findWarmStartDirectory() {
                for (ftsent = fts_children(fts, 0); ftsent != nullptr; ftsent = ftsent->fts_link) {
                   if (ftsent->fts_statp->st_mode & S_IFDIR) {
                      long int x;
-                     int k = sscanf(ftsent->fts_name, "Checkpoint%ld", &x);
+                     sscanf(ftsent->fts_name, "Checkpoint%ld", &x);
                      if (x > cpIndex) {
                         cpIndex    = x;
                         indexedDir = ftsent->fts_name;

--- a/src/columns/Communicator.cpp
+++ b/src/columns/Communicator.cpp
@@ -146,7 +146,6 @@ Communicator::~Communicator() {
  */
 int Communicator::neighborInit() {
    int num_neighbors = 0;
-   int num_borders   = 0;
 
    // initialize neighbor and border lists
    // (local borders and remote neighbors form the complete neighborhood)

--- a/src/columns/HyPerCol.cpp
+++ b/src/columns/HyPerCol.cpp
@@ -141,7 +141,8 @@ int HyPerCol::initialize(PV_Init *initObj) {
       int status = chdir(working_dir.c_str());
       if (status) {
          Fatal(chdirMessage);
-         chdirMessage.printf("Unable to switch directory to \"%s\"\n", working_dir.c_str());
+         chdirMessage.printf(
+               "%s unable to switch directory to \"%s\"\n", programName, working_dir.c_str());
          chdirMessage.printf("chdir error: %s\n", strerror(errno));
       }
    }
@@ -618,8 +619,6 @@ int HyPerCol::advanceTime(double sim_time) {
    // At this point all activity from the previous time step has
    // been delivered to the data store.
    //
-
-   int status = PV_SUCCESS;
 
    // Each layer's phase establishes a priority for updating
    for (int phase = 0; phase < mNumPhases; phase++) {

--- a/src/columns/HyPerCol.cpp
+++ b/src/columns/HyPerCol.cpp
@@ -1145,7 +1145,7 @@ void HyPerCol::initializeCUDA(std::string const &in_device) {
       if (deviceVec.size() == 1) {
          device = deviceVec[0];
       }
-      else if (deviceVec.size() >= numMpi) {
+      else if (deviceVec.size() >= (std::size_t)numMpi) {
          device = deviceVec[mCommunicator->globalCommRank()];
       }
       else {

--- a/src/columns/Publisher.cpp
+++ b/src/columns/Publisher.cpp
@@ -141,15 +141,15 @@ int Publisher::exchangeBorders(const PVLayerLoc *loc, int delay /*default 0*/) {
    int exchangeVectorSize = 2 * (mBorderExchanger->getNumNeighbors() - 1);
    for (int b = 0; b < loc->nbatch; b++) {
       // don't send interior
-      pvAssert(requestsVector->size() == b * exchangeVectorSize);
+      pvAssert(requestsVector->size() == (std::size_t)(b * exchangeVectorSize));
 
       float *data = recvBuffer(b, delay);
       std::vector<MPI_Request> batchElementMPIRequest{};
       mBorderExchanger->exchange(data, batchElementMPIRequest);
-      pvAssert(batchElementMPIRequest.size() == exchangeVectorSize);
+      pvAssert(batchElementMPIRequest.size() == (std::size_t)exchangeVectorSize);
       requestsVector->insert(
             requestsVector->end(), batchElementMPIRequest.begin(), batchElementMPIRequest.end());
-      pvAssert(requestsVector->size() == (b + 1) * exchangeVectorSize);
+      pvAssert(requestsVector->size() == (std::size_t)((b + 1) * exchangeVectorSize));
    }
 
 #endif // PV_USE_MPI

--- a/src/columns/Publisher.cpp
+++ b/src/columns/Publisher.cpp
@@ -62,6 +62,11 @@ void Publisher::checkpointDataStore(
          std::make_shared<CheckpointEntryDataStore>(
                objectName, bufferName, checkpointer->getMPIBlock(), store, &mLayerCube->loc),
          false /*not constant*/);
+   FatalIf(
+         !registerSucceeded,
+         "%s failed to register %s for checkpointing.\n",
+         objectName,
+         bufferName);
 }
 
 void Publisher::updateAllActiveIndices() {

--- a/src/components/ANNActivityBuffer.cpp
+++ b/src/components/ANNActivityBuffer.cpp
@@ -423,6 +423,10 @@ void ANNActivityBuffer::checkVertices() const {
          }
       }
    }
+   FatalIf(
+         status != PV_SUCCESS,
+         "%s requires V-coordinates to be nondecreasing.\n",
+         getDescription_c());
 }
 
 void ANNActivityBuffer::updateBufferCPU(double simTime, double deltaTime) {

--- a/src/components/ANNActivityBuffer.cpp
+++ b/src/components/ANNActivityBuffer.cpp
@@ -356,16 +356,17 @@ void ANNActivityBuffer::setVertices() {
    }
    // Check for NaN
    assert(mSlopeNegInf == mSlopeNegInf && mSlopePosInf == mSlopePosInf && mNumVertices > 0);
-   assert(vectorA.size() == mNumVertices && vectorV.size() == mNumVertices);
-   mVerticesV = (float *)malloc((size_t)mNumVertices * sizeof(*mVerticesV));
-   mVerticesA = (float *)malloc((size_t)mNumVertices * sizeof(*mVerticesA));
+   std::size_t numVertices = (std::size_t)mNumVertices;
+   assert(vectorA.size() == numVertices && vectorV.size() == numVertices);
+   mVerticesV = (float *)malloc(numVertices * sizeof(*mVerticesV));
+   mVerticesA = (float *)malloc(numVertices * sizeof(*mVerticesA));
    if (mVerticesV == NULL || mVerticesA == NULL) {
       ErrorLog().printf(
             "%s: unable to allocate memory for vertices:%s\n", getDescription_c(), strerror(errno));
       exit(EXIT_FAILURE);
    }
-   memcpy(mVerticesV, &vectorV[0], mNumVertices * sizeof(*mVerticesV));
-   memcpy(mVerticesA, &vectorA[0], mNumVertices * sizeof(*mVerticesA));
+   memcpy(mVerticesV, &vectorV[0], numVertices * sizeof(*mVerticesV));
+   memcpy(mVerticesA, &vectorA[0], numVertices * sizeof(*mVerticesA));
 }
 
 void ANNActivityBuffer::setSlopes() {

--- a/src/components/ActivityComponent.cpp
+++ b/src/components/ActivityComponent.cpp
@@ -96,7 +96,6 @@ ActivityComponent::communicateInitInfo(std::shared_ptr<CommunicateInitInfoMessag
    }
 #endif // PV_USE_CUDA
 
-   auto &hierarchy         = message->mHierarchy;
    auto communicateMessage = std::make_shared<CommunicateInitInfoMessage>(
          mTable,
          message->mDeltaTime,
@@ -168,7 +167,10 @@ Response::Status ActivityComponent::readStateFromCheckpoint(Checkpointer *checkp
 Response::Status
 ActivityComponent::setCudaDevice(std::shared_ptr<SetCudaDeviceMessage const> message) {
    Response::Status status = ComponentBasedObject::setCudaDevice(message);
-   return notify(message, mCommunicator->globalCommRank() == 0 /*printFlag*/);
+   if (Response::completed(status)) {
+      status = notify(message, mCommunicator->globalCommRank() == 0 /*printFlag*/);
+   }
+   return status;
 }
 
 Response::Status ActivityComponent::copyInitialStateToGPU() {

--- a/src/components/ActivityComponent.hpp
+++ b/src/components/ActivityComponent.hpp
@@ -65,7 +65,7 @@ class ActivityComponent : public ComponentBasedObject {
 
    void initialize(char const *name, PVParams *params, Communicator const *comm);
 
-   virtual void setObjectType();
+   virtual void setObjectType() override;
 
    virtual void createComponentTable(char const *tableDescription) override;
 
@@ -87,7 +87,8 @@ class ActivityComponent : public ComponentBasedObject {
    Response::Status readStateFromCheckpoint(Checkpointer *checkpointer) override;
 
 #ifdef PV_USE_CUDA
-   virtual Response::Status setCudaDevice(std::shared_ptr<SetCudaDeviceMessage const> message);
+   virtual Response::Status
+   setCudaDevice(std::shared_ptr<SetCudaDeviceMessage const> message) override;
    virtual Response::Status copyInitialStateToGPU() override;
 #endif // PV_USE_CUDA
 

--- a/src/components/ActivityComponentActivityOnly.hpp
+++ b/src/components/ActivityComponentActivityOnly.hpp
@@ -28,7 +28,7 @@ class ActivityComponentActivityOnly : public ActivityComponent {
 
    void initialize(char const *name, PVParams *params, Communicator const *comm);
 
-   virtual void setObjectType();
+   virtual void setObjectType() override;
 
    virtual ActivityBuffer *createActivity() override;
 };

--- a/src/components/AdaptiveTimeScaleController.cpp
+++ b/src/components/AdaptiveTimeScaleController.cpp
@@ -119,10 +119,10 @@ void CheckpointEntryTimeScaleInfo::write(
       double simTime,
       bool verifyWritesFlag) const {
    if (getMPIBlock()->getRank() == 0) {
-      int batchWidth   = (int)mTimeScaleInfoPtr->mTimeScale.size();
-      std::string path = generatePath(checkpointDirectory, "bin");
+      std::size_t batchWidth = mTimeScaleInfoPtr->mTimeScale.size();
+      std::string path       = generatePath(checkpointDirectory, "bin");
       FileStream fileStream{path.c_str(), std::ios_base::out, verifyWritesFlag};
-      for (int b = 0; b < batchWidth; b++) {
+      for (std::size_t b = 0; b < batchWidth; b++) {
          fileStream.write(&mTimeScaleInfoPtr->mTimeScale.at(b), sizeof(double));
          fileStream.write(&mTimeScaleInfoPtr->mTimeScaleTrue.at(b), sizeof(double));
          fileStream.write(&mTimeScaleInfoPtr->mTimeScaleMax.at(b), sizeof(double));
@@ -147,7 +147,7 @@ void CheckpointEntryTimeScaleInfo::remove(std::string const &checkpointDirectory
 
 void CheckpointEntryTimeScaleInfo::read(std::string const &checkpointDirectory, double *simTimePtr)
       const {
-   int batchWidth = (int)mTimeScaleInfoPtr->mTimeScale.size();
+   std::size_t batchWidth = (int)mTimeScaleInfoPtr->mTimeScale.size();
    if (getMPIBlock()->getRank() == 0) {
       std::string path = generatePath(checkpointDirectory, "bin");
       FileStream fileStream{path.c_str(), std::ios_base::in, false};

--- a/src/components/ArborList.cpp
+++ b/src/components/ArborList.cpp
@@ -124,8 +124,7 @@ int ArborList::convertDelay(double delay, double deltaTime) {
 }
 
 int ArborList::maxDelaySteps() {
-   int maxDelay        = 0;
-   int const numArbors = getNumAxonalArbors();
+   int maxDelay = 0;
    for (auto &d : mDelay) {
       if (d > maxDelay) {
          maxDelay = d;

--- a/src/components/BatchIndexer.cpp
+++ b/src/components/BatchIndexer.cpp
@@ -31,7 +31,6 @@ BatchIndexer::BatchIndexer(
 }
 
 int BatchIndexer::nextIndex(int localBatchIndex) {
-   int result   = getIndex(localBatchIndex);
    int newIndex = mIndices.at(localBatchIndex) + mSkipAmounts.at(localBatchIndex);
    if (newIndex >= mFileCount) {
       shuffleLookupTable();

--- a/src/components/BatchIndexer.hpp
+++ b/src/components/BatchIndexer.hpp
@@ -28,6 +28,8 @@ class BatchIndexer : public CheckpointerDataInterface {
    void setIndices(const std::vector<int> &indices) { mIndices = indices; }
    void setWrapToStartIndex(bool value) { mWrapToStartIndex = value; }
    bool getWrapToStartIndex() { return mWrapToStartIndex; }
+   int getStartIndex(int b) const { return mStartIndices.at(b); }
+   int getSkipAmount(int b) const { return mSkipAmounts.at(b); }
    std::vector<int> getIndices() { return mIndices; }
 
    virtual Response::Status

--- a/src/components/BinningActivityBuffer.cpp
+++ b/src/components/BinningActivityBuffer.cpp
@@ -158,14 +158,11 @@ void BinningActivityBuffer::updateBufferCPU(double simTime, double deltaTime) {
    pvAssert(origLoc->nx == currLoc->nx);
    pvAssert(origLoc->ny == currLoc->ny);
    pvAssert(origLoc->nf == 1);
-   int nx = currLoc->nx;
-   int ny = currLoc->ny;
 
    pvAssert(origLoc->halo.lt == currLoc->halo.lt);
    pvAssert(origLoc->halo.rt == currLoc->halo.rt);
    pvAssert(origLoc->halo.dn == currLoc->halo.dn);
    pvAssert(origLoc->halo.up == currLoc->halo.up);
-   PVHalo const *halo = &origLoc->halo;
 
    int numBins    = currLoc->nf;
    float binRange = mBinMax - mBinMin;

--- a/src/components/BoundaryConditions.cpp
+++ b/src/components/BoundaryConditions.cpp
@@ -289,7 +289,6 @@ void BoundaryConditions::mirrorToSouth(
    int ny           = loc->ny;
    int nf           = loc->nf;
    int leftBorder   = loc->halo.lt;
-   int rightBorder  = loc->halo.rt;
    int topBorder    = loc->halo.up;
    int bottomBorder = loc->halo.dn;
    int nbatch       = loc->nbatch;

--- a/src/components/CloneActivityComponent.hpp
+++ b/src/components/CloneActivityComponent.hpp
@@ -32,7 +32,7 @@ class CloneActivityComponent : public ActivityComponent {
 
    void initialize(char const *name, PVParams *params, Communicator const *comm);
 
-   virtual void setObjectType();
+   virtual void setObjectType() override;
 
    virtual void createComponentTable(char const *tableDescription) override;
 

--- a/src/components/CloneInternalStateBuffer.hpp
+++ b/src/components/CloneInternalStateBuffer.hpp
@@ -29,7 +29,7 @@ class CloneInternalStateBuffer : public InternalStateBuffer {
    /**
     * @brief initVType: CloneInternalStateBuffer does not use InitVType.
     */
-   virtual void ioParam_InitVType(enum ParamsIOFlag ioFlag);
+   virtual void ioParam_InitVType(enum ParamsIOFlag ioFlag) override;
 
    /** @} */
   public:
@@ -50,7 +50,7 @@ class CloneInternalStateBuffer : public InternalStateBuffer {
    /**
     * Sets the read-only pointer to the original layer's read-only pointer.
     */
-   virtual void setReadOnlyPointer();
+   virtual void setReadOnlyPointer() override;
 
   protected:
    InternalStateBuffer *mOriginalBuffer = nullptr;

--- a/src/components/CloneWeightsPair.hpp
+++ b/src/components/CloneWeightsPair.hpp
@@ -66,7 +66,8 @@ class CloneWeightsPair : public WeightsPair {
 
    virtual void createPreWeights(std::string const &weightsName) override;
    virtual void createPostWeights(std::string const &weightsName) override;
-   virtual void setDefaultWriteStep(std::shared_ptr<CommunicateInitInfoMessage const> message);
+   virtual void
+   setDefaultWriteStep(std::shared_ptr<CommunicateInitInfoMessage const> message) override;
 
    virtual Response::Status allocateDataStructures() override;
 

--- a/src/components/GSynAccumulator.hpp
+++ b/src/components/GSynAccumulator.hpp
@@ -44,7 +44,7 @@ class GSynAccumulator : public RestrictedBuffer {
 
    virtual ~GSynAccumulator();
 
-   virtual void updateBufferCPU(double simTime, double deltaTime);
+   virtual void updateBufferCPU(double simTime, double deltaTime) override;
 
   protected:
    GSynAccumulator() {}
@@ -55,7 +55,7 @@ class GSynAccumulator : public RestrictedBuffer {
 
    virtual void initializeChannelCoefficients();
 
-   int ioParamsFillGroup(enum ParamsIOFlag ioFlag);
+   virtual int ioParamsFillGroup(enum ParamsIOFlag ioFlag) override;
 
    Response::Status
    communicateInitInfo(std::shared_ptr<CommunicateInitInfoMessage const> message) override;

--- a/src/components/GapActivityBuffer.cpp
+++ b/src/components/GapActivityBuffer.cpp
@@ -89,7 +89,6 @@ void GapActivityBuffer::updateBufferCPU(double simTime, double deltaTime) {
    int nx                          = loc->nx;
    int ny                          = loc->ny;
    int nf                          = loc->nf;
-   int num_neurons                 = nx * ny * nf;
    PVHalo const &origHalo          = mOriginalActivity->getLayerLoc()->halo;
    int lt                          = loc->halo.lt;
    int rt                          = loc->halo.rt;
@@ -104,7 +103,6 @@ void GapActivityBuffer::updateBufferCPU(double simTime, double deltaTime) {
    int const numNeuronsAcrossBatch = numNeurons * loc->nbatch;
    float const *V                  = mInternalState->getBufferData();
    float const *checkActive        = mOriginalActivity->getBufferData();
-   int numCheckActive              = (nx + orig_lt + orig_rt) * (ny + orig_dn + orig_up) * nf;
    float *A                        = mBufferData.data();
 #ifdef PV_USE_OPENMP_THREADS
 #pragma omp parallel for schedule(static)

--- a/src/components/HyPerActivityBuffer.hpp
+++ b/src/components/HyPerActivityBuffer.hpp
@@ -38,7 +38,7 @@ class HyPerActivityBuffer : public VInputActivityBuffer {
     * Note that it does not check whether the internal state buffer has updated; the calling
     * routine needs make sure to do so before updating the activity buffer.
     */
-   virtual void updateBufferCPU(double simTime, double deltaTime);
+   virtual void updateBufferCPU(double simTime, double deltaTime) override;
 };
 
 } // namespace PV

--- a/src/components/HyPerActivityComponent.hpp
+++ b/src/components/HyPerActivityComponent.hpp
@@ -31,7 +31,7 @@ class HyPerActivityComponent : public ActivityComponent {
 
    void initialize(char const *name, PVParams *params, Communicator const *comm);
 
-   virtual void setObjectType();
+   virtual void setObjectType() override;
 
    virtual void createComponentTable(char const *tableDescription) override;
 

--- a/src/components/ImageActivityBuffer.cpp
+++ b/src/components/ImageActivityBuffer.cpp
@@ -136,8 +136,7 @@ Buffer<float> ImageActivityBuffer::retrieveData(int inputIndex) {
 }
 
 void ImageActivityBuffer::readImage(std::string filename) {
-   const PVLayerLoc *loc = getLayerLoc();
-   bool usingTempFile    = false;
+   bool usingTempFile = false;
 
    // Attempt to download our input file if we've been passed a URL or AWS path
    if (filename.find("://") != std::string::npos) {

--- a/src/components/InputActivityBuffer.cpp
+++ b/src/components/InputActivityBuffer.cpp
@@ -493,7 +493,6 @@ void InputActivityBuffer::initializeBatchIndexer() {
    pvAssert(getMPIBlock());
    pvAssert(getMPIBlock()->getRank() == 0);
    int localBatchCount  = getLayerLoc()->nbatch;
-   int mpiBatchCount    = getMPIBlock()->getBatchDimension();
    int mpiGlobalCount   = getMPIBlock()->getGlobalBatchDimension();
    int globalBatchCount = localBatchCount * mpiGlobalCount;
    int batchOffset      = localBatchCount * getMPIBlock()->getStartBatch();
@@ -547,8 +546,7 @@ void InputActivityBuffer::writeToTimestampStream(double simTime) {
       for (int b = 0; b < blockBatchCount; ++b) {
          int index = mBatchIndexer->getIndex(b);
          outStrStream << "[" << getName() << "] time: " << simTime << ", batch element: " << b + kb0
-                      << ", index: " << mBatchIndexer->getIndex(b) << ","
-                      << describeInput(mBatchIndexer->getIndex(b)) << "\n";
+                      << ", index: " << index << "," << describeInput(index) << "\n";
       }
       size_t len = outStrStream.str().length();
       mTimestampStream->write(outStrStream.str().c_str(), len);

--- a/src/components/InputActivityBuffer.cpp
+++ b/src/components/InputActivityBuffer.cpp
@@ -582,7 +582,7 @@ void InputActivityBuffer::retrieveInput(double simTime, double deltaTime) {
    if (getMPIBlock()->getRank() == 0) {
       int displayPeriodIndex = std::floor(simTime / (mDisplayPeriod * deltaTime));
       if (displayPeriodIndex % mJitterChangeInterval == 0) {
-         for (int b = 0; b < mRandomShiftX.size(); b++) {
+         for (std::size_t b = 0; b < mRandomShiftX.size(); b++) {
             mRandomShiftX[b] = -mMaxShiftX + (mRNG() % (2 * mMaxShiftX + 1));
             mRandomShiftY[b] = -mMaxShiftY + (mRNG() % (2 * mMaxShiftY + 1));
             if (mXFlipEnabled) {

--- a/src/components/InputRegionActivityComponent.hpp
+++ b/src/components/InputRegionActivityComponent.hpp
@@ -31,7 +31,7 @@ class InputRegionActivityComponent : public ActivityComponent {
    InputRegionActivityComponent();
    void initialize(const char *name, PVParams *params, Communicator const *comm);
 
-   virtual void setObjectType();
+   virtual void setObjectType() override;
 
    virtual ActivityBuffer *createActivity() override;
 

--- a/src/components/InternalStateBuffer.hpp
+++ b/src/components/InternalStateBuffer.hpp
@@ -52,7 +52,7 @@ class InternalStateBuffer : public RestrictedBuffer {
 
    virtual void setObjectType() override;
 
-   int ioParamsFillGroup(enum ParamsIOFlag ioFlag);
+   virtual int ioParamsFillGroup(enum ParamsIOFlag ioFlag) override;
 
    virtual Response::Status
    registerData(std::shared_ptr<RegisterDataMessage<Checkpointer> const> message) override;

--- a/src/components/KneeTimeScaleController.cpp
+++ b/src/components/KneeTimeScaleController.cpp
@@ -32,7 +32,7 @@ KneeTimeScaleController::calcTimesteps(double timeValue, std::vector<double> con
    std::vector<double> timeScales(
          AdaptiveTimeScaleController::calcTimesteps(timeValue, rawTimeScales));
 
-   for (int i = 0; i < timeScales.size(); ++i) {
+   for (std::size_t i = 0; i < timeScales.size(); ++i) {
       // Scale timescalemax if it's above the knee
       if (mTimeScaleInfo.mTimeScaleMax[i] > mKneeThresh) {
          mTimeScaleInfo.mTimeScaleMax[i] =

--- a/src/components/LIFActivityComponent.cpp
+++ b/src/components/LIFActivityComponent.cpp
@@ -245,8 +245,7 @@ Response::Status LIFActivityComponent::allocateDataStructures() {
    ComponentBuffer::checkDimensionsEqual(mInternalState, mVth);
    ComponentBuffer::checkDimensionsEqual(mInternalState, mActivity);
 
-   PVLayerLoc const *loc = getLayerLoc();
-   mRandState            = new Random(getLayerLoc(), false /*restricted*/);
+   mRandState = new Random(getLayerLoc(), false /*restricted*/);
    return Response::SUCCESS;
 }
 

--- a/src/components/LIFActivityComponent.hpp
+++ b/src/components/LIFActivityComponent.hpp
@@ -85,7 +85,7 @@ class LIFActivityComponent : public ActivityComponent {
 
    void initialize(char const *name, PVParams *params, Communicator const *comm);
 
-   virtual void setObjectType();
+   virtual void setObjectType() override;
 
    virtual void createComponentTable(char const *tableDescription) override;
 

--- a/src/components/LayerOutputComponent.cpp
+++ b/src/components/LayerOutputComponent.cpp
@@ -71,7 +71,10 @@ void LayerOutputComponent::ioParam_initialWriteTime(enum ParamsIOFlag ioFlag) {
                   "initialWriteTime:\n",
                   getDescription_c(),
                   mInitialWriteTime);
-            warningMessage.printf("    initialWriteTime adjusted to %f\n", mInitialWriteTime);
+            warningMessage.printf(
+                  "    initialWriteTime adjusted from %f to %f\n",
+                  storeInitialWriteTime,
+                  mInitialWriteTime);
          }
       }
    }
@@ -173,7 +176,6 @@ Response::Status LayerOutputComponent::respondLayerOutputState(
 
 Response::Status LayerOutputComponent::outputState(double simTime, double deltaTime) {
    if (simTime >= (mWriteTime - (deltaTime / 2)) and mWriteStep >= 0) {
-      int writeStatus = PV_SUCCESS;
       mWriteTime += mWriteStep;
       PVLayerCube cube = mPublisher->getPublisher()->createCube(0 /*delay*/);
       if (mPublisher->getSparseLayer()) {

--- a/src/components/LayerOutputComponent.cpp
+++ b/src/components/LayerOutputComponent.cpp
@@ -83,7 +83,7 @@ Response::Status LayerOutputComponent::communicateInitInfo(
       setDefaultWriteStep(message);
    }
    auto status = BaseObject::communicateInitInfo(message);
-   if (!Response::completed) {
+   if (!Response::completed(status)) {
       return status;
    }
    mWriteTime = mInitialWriteTime;

--- a/src/components/MaskActivityBuffer.cpp
+++ b/src/components/MaskActivityBuffer.cpp
@@ -213,7 +213,6 @@ void MaskActivityBuffer::updateBufferCPU(double simTime, double deltaTime) {
 #pragma omp parallel for
 #endif
       for (int ni = 0; ni < numNeurons; ni++) {
-         int kThisRes = ni;
          int kThisExt = kIndexExtended(
                ni, nx, ny, nf, loc->halo.lt, loc->halo.rt, loc->halo.dn, loc->halo.up);
          bool maskVal = true;

--- a/src/components/MomentumLCAActivityComponent.hpp
+++ b/src/components/MomentumLCAActivityComponent.hpp
@@ -35,7 +35,7 @@ class MomentumLCAActivityComponent : public BaseMomentumActivityComponent {
 
    void initialize(char const *name, PVParams *parameters, Communicator const *comm);
 
-   virtual void setObjectType();
+   virtual void setObjectType() override;
 
    virtual void createComponentTable(char const *tableDescription) override;
 

--- a/src/components/PatchGeometry.cpp
+++ b/src/components/PatchGeometry.cpp
@@ -91,14 +91,14 @@ int PatchGeometry::verifyPatchSize(int numPreRestricted, int numPostRestricted, 
    int log2ScaleDiff;
    std::stringstream errMsgStream;
    if (numPreRestricted > numPostRestricted) {
-      int stride = numPreRestricted / numPostRestricted;
+      int stride    = numPreRestricted / numPostRestricted;
+      log2ScaleDiff = (int)std::nearbyint(std::log2(stride));
       if (stride * numPostRestricted != numPreRestricted) {
          errMsgStream << "presynaptic ?-dimension (" << numPreRestricted << ") "
                       << "is greater than but not a multiple of "
                       << "presynaptic ?-dimension (" << numPostRestricted << ")";
       }
       else {
-         log2ScaleDiff = (int)std::nearbyint(std::log2(stride));
          if (2 << (log2ScaleDiff - 1) != stride) {
             errMsgStream << "presynaptic ?-dimension (" << numPreRestricted << ") is a multiple "
                          << "of postsynaptic ?-dimension (" << numPostRestricted << ") "
@@ -107,7 +107,9 @@ int PatchGeometry::verifyPatchSize(int numPreRestricted, int numPostRestricted, 
       }
    }
    else if (numPreRestricted < numPostRestricted) {
-      int tstride = numPostRestricted / numPreRestricted;
+      int tstride          = numPostRestricted / numPreRestricted;
+      int negLog2ScaleDiff = (int)std::nearbyint(std::log2(tstride));
+      log2ScaleDiff        = -negLog2ScaleDiff;
       if (tstride * numPreRestricted != numPostRestricted) {
          errMsgStream << "postsynaptic ?-dimension (" << numPostRestricted << ") "
                       << "is greater than but not an even multiple of "
@@ -120,22 +122,20 @@ int PatchGeometry::verifyPatchSize(int numPreRestricted, int numPostRestricted, 
                       << tstride;
       }
       else {
-         int negLog2ScaleDiff = (int)std::nearbyint(std::log2(tstride));
          if (2 << (negLog2ScaleDiff - 1) != tstride) {
             errMsgStream << "postsynaptic ?-dimension (" << numPostRestricted << ") is a multiple "
                          << "of presynaptic ?-dimension (" << numPreRestricted << ") "
                          << "but the quotient " << tstride << " is not a power of 2";
          }
-         log2ScaleDiff = -negLog2ScaleDiff;
       }
    }
    else {
       pvAssert(numPreRestricted == numPostRestricted);
+      log2ScaleDiff = 0;
       if (patchSize % 2 != 1) {
          errMsgStream << "presynaptic and postsynaptic ?-dimensions are both equal to "
                       << numPreRestricted << ", but patch size " << patchSize << " is not odd";
       }
-      log2ScaleDiff = 0;
    }
    std::string errorMessage(errMsgStream.str());
    if (!errorMessage.empty()) {

--- a/src/components/PatchGeometry.cpp
+++ b/src/components/PatchGeometry.cpp
@@ -316,8 +316,6 @@ void PatchGeometry::setTransposeItemIndices() {
 
          int const kernelIndexFPre =
                featureIndex(kernelIndexPre, mNumKernelsX, mNumKernelsY, mNumKernelsF);
-         int const itemInPatchFPre =
-               featureIndex(itemInPatchPre, mPatchSizeX, mPatchSizeY, mPatchSizeF);
 
          int itemInPatchFPost = kernelIndexFPre;
          int patchSizeFPost   = mNumKernelsF;

--- a/src/components/PoolingIndexLayerInputBuffer.hpp
+++ b/src/components/PoolingIndexLayerInputBuffer.hpp
@@ -29,7 +29,7 @@ class PoolingIndexLayerInputBuffer : public LayerInputBuffer {
    void initialize(char const *name, PVParams *params, Communicator const *comm);
    virtual void setObjectType() override;
 
-   virtual void resetGSynBuffers(double simulationTime, double dt);
+   virtual void resetGSynBuffers(double simulationTime, double dt) override;
 
   protected:
 };

--- a/src/components/PtwiseProductGSynAccumulator.cpp
+++ b/src/components/PtwiseProductGSynAccumulator.cpp
@@ -46,12 +46,10 @@ Response::Status PtwiseProductGSynAccumulator::communicateInitInfo(
 }
 
 void PtwiseProductGSynAccumulator::updateBufferCPU(double simTime, double deltaTime) {
-   PVLayerLoc const *loc = getLayerLoc();
-   float const *gSynExc  = mLayerInput->getChannelData(CHANNEL_EXC);
-   float const *gSynInh  = mLayerInput->getChannelData(CHANNEL_INH);
-   float *bufferData     = mBufferData.data();
-   int numNeurons        = getBufferSizeAcrossBatch();
-   int numChannels       = (int)mChannelCoefficients.size();
+   float const *gSynExc = mLayerInput->getChannelData(CHANNEL_EXC);
+   float const *gSynInh = mLayerInput->getChannelData(CHANNEL_INH);
+   float *bufferData    = mBufferData.data();
+   int numNeurons       = getBufferSizeAcrossBatch();
 #ifdef PV_USE_OPENMP_THREADS
 #pragma omp parallel for schedule(static)
 #endif

--- a/src/components/PtwiseProductGSynAccumulator.hpp
+++ b/src/components/PtwiseProductGSynAccumulator.hpp
@@ -29,12 +29,12 @@ class PtwiseProductGSynAccumulator : public GSynAccumulator {
     * @brief channelIndices: PtwiseProductGSynAccumulator does not use channelIndices.
     * channel coefficients will be specified.
     */
-   virtual void ioParam_channelIndices(enum ParamsIOFlag ioFlag);
+   virtual void ioParam_channelIndices(enum ParamsIOFlag ioFlag) override;
 
    /**
     * @brief channelIndices: PtwiseProductGSynAccumulator does not use channelCoefficients.
     */
-   virtual void ioParam_channelCoefficients(enum ParamsIOFlag ioFlag);
+   virtual void ioParam_channelCoefficients(enum ParamsIOFlag ioFlag) override;
 
    /** @} */
   public:
@@ -42,7 +42,7 @@ class PtwiseProductGSynAccumulator : public GSynAccumulator {
 
    virtual ~PtwiseProductGSynAccumulator();
 
-   virtual void updateBufferCPU(double simTime, double deltaTime);
+   virtual void updateBufferCPU(double simTime, double deltaTime) override;
 
   protected:
    PtwiseProductGSynAccumulator() {}

--- a/src/components/PtwiseQuotientGSynAccumulator.cpp
+++ b/src/components/PtwiseQuotientGSynAccumulator.cpp
@@ -48,12 +48,10 @@ Response::Status PtwiseQuotientGSynAccumulator::communicateInitInfo(
 }
 
 void PtwiseQuotientGSynAccumulator::updateBufferCPU(double simTime, double deltaTime) {
-   PVLayerLoc const *loc = getLayerLoc();
-   float const *gSynExc  = mLayerInput->getChannelData(CHANNEL_EXC);
-   float const *gSynInh  = mLayerInput->getChannelData(CHANNEL_INH);
-   float *bufferData     = mBufferData.data();
-   int numNeurons        = getBufferSizeAcrossBatch();
-   int numChannels       = (int)mChannelCoefficients.size();
+   float const *gSynExc = mLayerInput->getChannelData(CHANNEL_EXC);
+   float const *gSynInh = mLayerInput->getChannelData(CHANNEL_INH);
+   float *bufferData    = mBufferData.data();
+   int numNeurons       = getBufferSizeAcrossBatch();
 #ifdef PV_USE_OPENMP_THREADS
 #pragma omp parallel for schedule(static)
 #endif

--- a/src/components/PtwiseQuotientGSynAccumulator.hpp
+++ b/src/components/PtwiseQuotientGSynAccumulator.hpp
@@ -29,12 +29,12 @@ class PtwiseQuotientGSynAccumulator : public GSynAccumulator {
     * @brief channelIndices: PtwiseQuotientGSynAccumulator does not use channelIndices.
     * channel coefficients will be specified.
     */
-   virtual void ioParam_channelIndices(enum ParamsIOFlag ioFlag);
+   virtual void ioParam_channelIndices(enum ParamsIOFlag ioFlag) override;
 
    /**
     * @brief channelIndices: PtwiseQuotientGSynAccumulator does not use channelCoefficients.
     */
-   virtual void ioParam_channelCoefficients(enum ParamsIOFlag ioFlag);
+   virtual void ioParam_channelCoefficients(enum ParamsIOFlag ioFlag) override;
 
    /** @} */
   public:
@@ -42,7 +42,7 @@ class PtwiseQuotientGSynAccumulator : public GSynAccumulator {
 
    virtual ~PtwiseQuotientGSynAccumulator();
 
-   virtual void updateBufferCPU(double simTime, double deltaTime);
+   virtual void updateBufferCPU(double simTime, double deltaTime) override;
 
   protected:
    PtwiseQuotientGSynAccumulator() {}

--- a/src/components/RescaleActivityBuffer.cpp
+++ b/src/components/RescaleActivityBuffer.cpp
@@ -749,9 +749,6 @@ void RescaleActivityBuffer::updateBufferCPU(double simTime, double deltaTime) {
          }
       }
       else if (mMethodCode == LOGREG) {
-         int nx = loc->nx;
-         int ny = loc->ny;
-         int nf = loc->nf;
 // Loop through all nx and ny
 // each y value specifies a different target so ok to thread here (sum, sumsq are defined inside
 // loop)

--- a/src/components/RescaleActivityBuffer.cpp
+++ b/src/components/RescaleActivityBuffer.cpp
@@ -31,7 +31,7 @@ void RescaleActivityBuffer::initialize(
 Response::Status RescaleActivityBuffer::communicateInitInfo(
       std::shared_ptr<CommunicateInitInfoMessage const> message) {
    auto status = ActivityBuffer::communicateInitInfo(message);
-   if (!Response::completed) {
+   if (!Response::completed(status)) {
       return status;
    }
    if (mOriginalBuffer == nullptr) {

--- a/src/components/RetinaActivityBuffer.hpp
+++ b/src/components/RetinaActivityBuffer.hpp
@@ -102,7 +102,7 @@ class RetinaActivityBuffer : public ActivityBuffer {
    void setRetinaParams(double deltaTime);
 
    // TODO: Eliminate code duplication with LIF - Make RandState a component
-   Response::Status readStateFromCheckpoint(Checkpointer *checkpointer);
+   Response::Status readStateFromCheckpoint(Checkpointer *checkpointer) override;
 
    void readRandStateFromCheckpoint(Checkpointer *checkpointer);
 

--- a/src/components/SegmentBuffer.cpp
+++ b/src/components/SegmentBuffer.cpp
@@ -144,8 +144,6 @@ int SegmentBuffer::checkLabelBufSize(int newSize) {
       return PV_SUCCESS;
    }
 
-   const PVLayerLoc *loc = getLayerLoc();
-
    // Grow buffer
    mLabelBuf = (int *)realloc(mLabelBuf, newSize * sizeof(int));
    mMaxXBuf  = (int *)realloc(mMaxXBuf, newSize * sizeof(int));

--- a/src/components/SegmentifyBuffer.cpp
+++ b/src/components/SegmentifyBuffer.cpp
@@ -256,7 +256,6 @@ void SegmentifyBuffer::checkLabelValBuf(int newSize) {
 
 void SegmentifyBuffer::buildLabelToIdx(int batchIdx) {
    Communicator const *icComm = mCommunicator;
-   int numMpi                 = icComm->commSize();
    int rank                   = icComm->commRank();
 
    mLabelToIdx.clear();
@@ -366,8 +365,6 @@ void SegmentifyBuffer::calculateLabelVals(int batchIdx) {
    } // End of yi loop
 
    int numLabels = mLabelToIdx.size();
-
-   int rank = icComm->commRank();
 
    // We need to reduce our labelVec array
    for (int fi = 0; fi < srcLoc->nf; fi++) {

--- a/src/components/SingleChannelGSynAccumulator.cpp
+++ b/src/components/SingleChannelGSynAccumulator.cpp
@@ -50,11 +50,9 @@ Response::Status SingleChannelGSynAccumulator::communicateInitInfo(
 }
 
 void SingleChannelGSynAccumulator::updateBufferCPU(double simTime, double deltaTime) {
-   PVLayerLoc const *loc = getLayerLoc();
-   float const *gSynExc  = mLayerInput->getChannelData(CHANNEL_EXC);
-   float *bufferData     = mBufferData.data();
-   int numNeurons        = getBufferSizeAcrossBatch();
-   int numChannels       = (int)mChannelCoefficients.size();
+   float const *gSynExc = mLayerInput->getChannelData(CHANNEL_EXC);
+   float *bufferData    = mBufferData.data();
+   int numNeurons       = getBufferSizeAcrossBatch();
 #ifdef PV_USE_OPENMP_THREADS
 #pragma omp parallel for schedule(static)
 #endif

--- a/src/components/SingleChannelGSynAccumulator.hpp
+++ b/src/components/SingleChannelGSynAccumulator.hpp
@@ -29,12 +29,12 @@ class SingleChannelGSynAccumulator : public GSynAccumulator {
     * @brief channelIndices: SingleChannelGSynAccumulator does not use channelIndices.
     * channel coefficients will be specified.
     */
-   virtual void ioParam_channelIndices(enum ParamsIOFlag ioFlag);
+   virtual void ioParam_channelIndices(enum ParamsIOFlag ioFlag) override;
 
    /**
     * @brief channelIndices: SingleChannelGSynAccumulator does not use channelCoefficients.
     */
-   virtual void ioParam_channelCoefficients(enum ParamsIOFlag ioFlag);
+   virtual void ioParam_channelCoefficients(enum ParamsIOFlag ioFlag) override;
 
    /** @} */
   public:
@@ -42,7 +42,7 @@ class SingleChannelGSynAccumulator : public GSynAccumulator {
 
    virtual ~SingleChannelGSynAccumulator();
 
-   virtual void updateBufferCPU(double simTime, double deltaTime);
+   virtual void updateBufferCPU(double simTime, double deltaTime) override;
 
   protected:
    SingleChannelGSynAccumulator() {}

--- a/src/components/SquaredGSynAccumulator.cpp
+++ b/src/components/SquaredGSynAccumulator.cpp
@@ -30,11 +30,9 @@ void SquaredGSynAccumulator::setObjectType() { mObjectType = "SquaredGSynAccumul
 void SquaredGSynAccumulator::initializeChannelCoefficients() { mChannelCoefficients = {1.0f}; }
 
 void SquaredGSynAccumulator::updateBufferCPU(double simTime, double deltaTime) {
-   PVLayerLoc const *loc = getLayerLoc();
-   float const *gSynExc  = mLayerInput->getChannelData(CHANNEL_EXC);
-   float *bufferData     = mBufferData.data();
-   int numNeurons        = getBufferSizeAcrossBatch();
-   int numChannels       = (int)mChannelCoefficients.size();
+   float const *gSynExc = mLayerInput->getChannelData(CHANNEL_EXC);
+   float *bufferData    = mBufferData.data();
+   int numNeurons       = getBufferSizeAcrossBatch();
 #ifdef PV_USE_OPENMP_THREADS
 #pragma omp parallel for schedule(static)
 #endif

--- a/src/components/SquaredGSynAccumulator.hpp
+++ b/src/components/SquaredGSynAccumulator.hpp
@@ -23,7 +23,7 @@ class SquaredGSynAccumulator : public SingleChannelGSynAccumulator {
 
    virtual ~SquaredGSynAccumulator();
 
-   virtual void updateBufferCPU(double simTime, double deltaTime);
+   virtual void updateBufferCPU(double simTime, double deltaTime) override;
 
   protected:
    SquaredGSynAccumulator() {}

--- a/src/cudakernels/CudaPoolingDeliverKernel.cpp
+++ b/src/cudakernels/CudaPoolingDeliverKernel.cpp
@@ -112,8 +112,7 @@ void CudaPoolingDeliverKernel::setArgs(
    float *gSynHead               = (float *)gSynBuffer->getPointer();
    mGSyn                         = &gSynHead[channel * numGSynNeuronsAcrossBatch];
 
-   size_t gSynSize = gSynBuffer->getSize();
-   mCudnnGSyn      = device->createBuffer(numGSynNeuronsAcrossBatch, &str);
+   mCudnnGSyn = device->createBuffer(numGSynNeuronsAcrossBatch, &str);
 }
 
 int CudaPoolingDeliverKernel::calcBorderExcess(
@@ -164,7 +163,7 @@ int CudaPoolingDeliverKernel::do_run() {
    // Permute the PV-ordered GSyn channel to CUDNN ordering.
    int const nxPost = mPostLoc->nx;
    int const nyPost = mPostLoc->ny;
-   int const nfPost = mPostLoc->nf;
+   pvAssert(mPostLoc->nf == nf);
    pvAssert(mPostLoc->nbatch == mPreLoc->nbatch);
    // Calculate grid and work size
    numNeurons              = nbatch * nxPost * nyPost * nf;

--- a/src/delivery/HyPerDelivery.cpp
+++ b/src/delivery/HyPerDelivery.cpp
@@ -31,7 +31,7 @@ int HyPerDelivery::ioParamsFillGroup(enum ParamsIOFlag ioFlag) {
    if (ioFlag == PARAMS_IO_READ) {
       status = BaseDelivery::ioParamsFillGroup(ioFlag);
    }
-   return PV_SUCCESS;
+   return status;
 }
 
 Response::Status

--- a/src/delivery/HyPerDeliveryFacade.hpp
+++ b/src/delivery/HyPerDeliveryFacade.hpp
@@ -90,7 +90,7 @@ class HyPerDeliveryFacade : public BaseDelivery {
    virtual Response::Status allocateDataStructures() override;
 
    virtual Response::Status
-   registerData(std::shared_ptr<RegisterDataMessage<Checkpointer> const> message);
+   registerData(std::shared_ptr<RegisterDataMessage<Checkpointer> const> message) override;
 
    virtual Response::Status
    initializeState(std::shared_ptr<InitializeStateMessage const> message) override;

--- a/src/delivery/PoolingDelivery.cpp
+++ b/src/delivery/PoolingDelivery.cpp
@@ -36,8 +36,6 @@ int PoolingDelivery::ioParamsFillGroup(enum ParamsIOFlag ioFlag) {
 }
 
 void PoolingDelivery::ioParam_pvpatchAccumulateType(enum ParamsIOFlag ioFlag) {
-   PVParams *params = parameters();
-
    parameters()->ioParamStringRequired(
          ioFlag, name, "pvpatchAccumulateType", &mPvpatchAccumulateTypeString);
    if (ioFlag == PARAMS_IO_READ) {

--- a/src/delivery/PoolingDelivery.cpp
+++ b/src/delivery/PoolingDelivery.cpp
@@ -32,7 +32,7 @@ int PoolingDelivery::ioParamsFillGroup(enum ParamsIOFlag ioFlag) {
    ioParam_updateGSynFromPostPerspective(ioFlag);
    ioParam_needPostIndexLayer(ioFlag);
    ioParam_postIndexLayerName(ioFlag);
-   return PV_SUCCESS;
+   return status;
 }
 
 void PoolingDelivery::ioParam_pvpatchAccumulateType(enum ParamsIOFlag ioFlag) {

--- a/src/delivery/PoolingDelivery.cpp
+++ b/src/delivery/PoolingDelivery.cpp
@@ -224,19 +224,13 @@ void PoolingDelivery::initializeDeliverKernelArgs() {
    PVCuda::CudaBuffer *d_postGSyn     = mPostGSyn->getCudaBuffer();
    Weights *weights                   = mWeightsPair->getPostWeights();
    pvAssert(weights);
+   cudnnPoolingMode_t poolingMode = mAccumulateType == MAXPOOLING
+                                          ? CUDNN_POOLING_MAX
+                                          : CUDNN_POOLING_AVERAGE_COUNT_INCLUDE_PADDING;
+
    int const nxpPost = weights->getPatchSizeX();
    int const nypPost = weights->getPatchSizeY();
-   cudnnPoolingMode_t poolingMode;
-   int multiplier = 1;
-   switch (mAccumulateType) {
-      case MAXPOOLING: poolingMode = CUDNN_POOLING_MAX; break;
-      case SUMPOOLING:
-         poolingMode = CUDNN_POOLING_AVERAGE_COUNT_INCLUDE_PADDING;
-         multiplier  = nxpPost * nypPost;
-         break;
-      case AVGPOOLING: poolingMode = CUDNN_POOLING_AVERAGE_COUNT_INCLUDE_PADDING; break;
-      default: pvAssert(0); break;
-   }
+   int multiplier    = mAccumulateType == SUMPOOLING ? nxpPost * nypPost : 1;
 
    mRecvKernel = new PVCuda::CudaPoolingDeliverKernel(mCudaDevice);
    mRecvKernel->setArgs(

--- a/src/delivery/PresynapticPerspectiveConvolveDelivery.cpp
+++ b/src/delivery/PresynapticPerspectiveConvolveDelivery.cpp
@@ -214,8 +214,7 @@ void PresynapticPerspectiveConvolveDelivery::deliverUnitInput(float *recvBuffer)
    int numAxonalArbors = mArborList->getNumAxonalArbors();
    for (int arbor = 0; arbor < numAxonalArbors; arbor++) {
       for (int b = 0; b < nbatch; b++) {
-         float *recvBatch                                   = recvBuffer + b * numPostRestricted;
-         SparseList<float>::Entry const *activeIndicesBatch = NULL;
+         float *recvBatch = recvBuffer + b * numPostRestricted;
 
 #ifdef PV_USE_OPENMP_THREADS
          clearThreadGSyn();

--- a/src/delivery/PresynapticPerspectiveStochasticDelivery.cpp
+++ b/src/delivery/PresynapticPerspectiveStochasticDelivery.cpp
@@ -215,7 +215,6 @@ void PresynapticPerspectiveStochasticDelivery::deliver(float *destBuffer) {
 }
 
 void PresynapticPerspectiveStochasticDelivery::deliverUnitInput(float *recvBuffer) {
-   PVLayerLoc const *preLoc  = mPreData->getLayerLoc();
    PVLayerLoc const *postLoc = mPostGSyn->getLayerLoc();
    Weights *weights          = mWeightsPair->getPreWeights();
 

--- a/src/delivery/PresynapticPerspectiveStochasticDelivery.cpp
+++ b/src/delivery/PresynapticPerspectiveStochasticDelivery.cpp
@@ -6,6 +6,7 @@
  */
 
 #include "PresynapticPerspectiveStochasticDelivery.hpp"
+#include <cmath>
 
 // Note: there is a lot of code duplication between PresynapticPerspectiveConvolveDelivery
 // and PresynapticPerspectiveStochasticDelivery.
@@ -264,7 +265,7 @@ void PresynapticPerspectiveStochasticDelivery::deliverUnitInput(float *recvBuffe
                float const *weightDataHead  = weights->getDataFromPatchIndex(arbor, kPreExt);
                float const *weightDataStart = &weightDataHead[patch->offset];
                taus_uint4 *rng              = mRandState->getRNG(kPreExt);
-               long along                   = (long)cl_random_max();
+               long along                   = (long)std::floor((double)a * cl_random_max());
 
                float *v                  = postPatchStart + y * sy;
                float const *weightValues = weightDataStart + y * syw;

--- a/src/delivery/TransposePoolingDelivery.cpp
+++ b/src/delivery/TransposePoolingDelivery.cpp
@@ -36,7 +36,7 @@ void TransposePoolingDelivery::setObjectType() { mObjectType = "TransposePooling
 int TransposePoolingDelivery::ioParamsFillGroup(enum ParamsIOFlag ioFlag) {
    int status = BaseDelivery::ioParamsFillGroup(ioFlag);
    ioParam_updateGSynFromPostPerspective(ioFlag);
-   return PV_SUCCESS;
+   return status;
 }
 
 void TransposePoolingDelivery::ioParam_receiveGpu(enum ParamsIOFlag ioFlag) {

--- a/src/delivery/TransposePoolingDelivery.cpp
+++ b/src/delivery/TransposePoolingDelivery.cpp
@@ -309,17 +309,6 @@ void TransposePoolingDelivery::deliverPresynapticPerspective(float *destBuffer) 
          break;
    }
 
-   float w = 1.0f;
-   if (mAccumulateType == PoolingDelivery::AVGPOOLING) {
-      PVLayerLoc const *preLoc  = mPreData->getLayerLoc();
-      PVLayerLoc const *postLoc = mPostGSyn->getLayerLoc();
-      float relative_XScale     = (float)preLoc->nx / (float)postLoc->nx;
-      float relative_YScale     = (float)preLoc->ny / (float)postLoc->ny;
-      float nxp                 = (float)mPatchSize->getPatchSizeX();
-      float nyp                 = (float)mPatchSize->getPatchSizeY();
-      w                         = 1.0f / (nxp * relative_XScale * nyp * relative_YScale);
-   }
-
    PVLayerCube activityCube = mPreData->getPublisher()->createCube(0 /*delay*/);
 
    float *gSyn = destBuffer;
@@ -480,16 +469,7 @@ void TransposePoolingDelivery::deliverPresynapticPerspective(float *destBuffer) 
             int offset = kfPre;
             int sf     = preWeights->getPatchSizeF();
 
-            float w = 1.0f;
-            if (mAccumulateType == PoolingDelivery::MAXPOOLING) {
-               w = 1.0f;
-            }
-            else if (mAccumulateType == PoolingDelivery::MAXPOOLING) {
-               float const nxp     = (float)mPatchSize->getPatchSizeX();
-               float const nyp     = (float)mPatchSize->getPatchSizeY();
-               float const normVal = nxp * nyp;
-               w                   = 1.0f / normVal;
-            }
+            float w      = 1.0f;
             void *auxPtr = NULL;
             for (int y = 0; y < ny; y++) {
                (accumulateFunctionPointer)(
@@ -501,7 +481,6 @@ void TransposePoolingDelivery::deliverPresynapticPerspective(float *destBuffer) 
       float relative_YScale = (float)preLoc->ny / (float)postLoc->ny;
       float nxp             = (float)mPatchSize->getPatchSizeX();
       float nyp             = (float)mPatchSize->getPatchSizeY();
-      w                     = 1.0f / (nxp * relative_XScale * nyp * relative_YScale);
 
 #ifdef PV_USE_OPENMP_THREADS
       // Set back into gSyn

--- a/src/delivery/TransposePoolingDelivery.cpp
+++ b/src/delivery/TransposePoolingDelivery.cpp
@@ -477,10 +477,6 @@ void TransposePoolingDelivery::deliverPresynapticPerspective(float *destBuffer) 
             }
          }
       }
-      float relative_XScale = (float)preLoc->nx / (float)postLoc->nx;
-      float relative_YScale = (float)preLoc->ny / (float)postLoc->ny;
-      float nxp             = (float)mPatchSize->getPatchSizeX();
-      float nyp             = (float)mPatchSize->getPatchSizeY();
 
 #ifdef PV_USE_OPENMP_THREADS
       // Set back into gSyn

--- a/src/initv/InitVFromFile.cpp
+++ b/src/initv/InitVFromFile.cpp
@@ -55,13 +55,13 @@ void InitVFromFile::calcV(float *V, const PVLayerLoc *loc) {
       FileStream fileStream(mVfilename, std::ios_base::in | std::ios_base::binary, false);
       BufferUtils::ActivityHeader header = BufferUtils::readActivityHeader(fileStream);
       int fileType                       = header.fileType;
-      if (header.fileType == PVP_NONSPIKING_ACT_FILE_TYPE) {
+      if (fileType == PVP_NONSPIKING_ACT_FILE_TYPE) {
          readDenseActivityPvp(V, loc, fileStream, header);
       }
       else { // TODO: Handle sparse activity pvp files.
          if (getMPIBlock()->getRank() == 0) {
             ErrorLog() << "InitVFromFile: filename \"" << mVfilename << "\" has fileType "
-                       << header.fileType << ", which is not supported for InitVFromFile.\n";
+                       << fileType << ", which is not supported for InitVFromFile.\n";
          }
          MPI_Barrier(getMPIBlock()->getComm());
          MPI_Finalize();

--- a/src/io/Configuration.cpp
+++ b/src/io/Configuration.cpp
@@ -166,7 +166,6 @@ Configuration::printIntOptionalArgument(std::string const &name, IntOptional con
 std::string Configuration::printArgument(std::string const &name) const {
    ConfigurationType type = getType(name);
    std::string returnString;
-   bool status; // Used to verify the result of calling the get*Argument method.
    switch (type) {
       case CONFIG_UNRECOGNIZED: break;
       case CONFIG_BOOL: returnString = printBooleanArgument(name, getBooleanArgument(name)); break;
@@ -192,7 +191,6 @@ std::string Configuration::printConfig() const {
 }
 
 bool Configuration::setArgumentUsingString(std::string const &name, std::string const &value) {
-   bool found;
    switch (getType(name)) {
       case CONFIG_UNRECOGNIZED: return false; break;
       case CONFIG_BOOL: setBooleanArgument(name, parseBoolean(value)); break;

--- a/src/io/PVParams.cpp
+++ b/src/io/PVParams.cpp
@@ -1704,7 +1704,6 @@ void PVParams::handleUnnecessaryParameter(const char *group_name, const char *pa
 }
 
 void PVParams::handleUnnecessaryStringParameter(const char *group_name, const char *param_name) {
-   int status             = PV_SUCCESS;
    const char *class_name = groupKeywordFromName(group_name);
    if (stringPresent(group_name, param_name)) {
       if (worldRank == 0) {
@@ -1715,7 +1714,7 @@ void PVParams::handleUnnecessaryStringParameter(const char *group_name, const ch
                group_name,
                param_name);
       }
-      const char *params_value = stringValue(group_name, param_name, false /*warnIfAbsent*/);
+      stringValue(group_name, param_name, false /*warnIfAbsent*/);
       // marks param as read so that presentAndNotBeenRead doesn't trip up
    }
 }

--- a/src/io/WeightsFileIO.cpp
+++ b/src/io/WeightsFileIO.cpp
@@ -377,14 +377,6 @@ void WeightsFileIO::writeNonsharedWeights(double timestamp, bool compress) {
                long lineStartFile = arborStartFile + (long)startFile * (long)patchSizePvpFormat;
                mFileStream->setOutPos(lineStartFile, true /*from beginning of file*/);
 
-               int const startPatchLocal = kIndex(
-                     startPatchX,
-                     y + startPatchY,
-                     0,
-                     mWeights->getNumDataPatchesX(),
-                     mWeights->getNumDataPatchesY(),
-                     mWeights->getNumDataPatchesF());
-
                for (int k = startPatchK; k < endPatchK; k++) {
                   int patchIndexLocal = kIndex(
                         k, y + startPatchY, 0, numDataPatchesK, mWeights->getNumDataPatchesY(), 1);

--- a/src/io/fileio.cpp
+++ b/src/io/fileio.cpp
@@ -249,11 +249,9 @@ int PV_fseek(PV_Stream *pvstream, long offset, int whence) {
 size_t
 PV_fwrite(const void *RESTRICT ptr, size_t size, size_t nitems, PV_Stream *RESTRICT pvstream) {
    assert(ferror(pvstream->fp) == 0);
-   int fwritecounts            = 0;
-   size_t writesize            = nitems * size;
-   size_t charswritten         = (size_t)0;
-   const char *RESTRICT curptr = (const char *RESTRICT)ptr;
-   long int fpos               = pvstream->filepos;
+   size_t writesize    = nitems * size;
+   size_t charswritten = (size_t)0;
+   long int fpos       = pvstream->filepos;
    if (fpos < 0) {
       Fatal().printf(
             "PV_fwrite error: unable to determine file position of \"%s\".  Fatal error\n",
@@ -488,10 +486,8 @@ int checkDirExists(MPIBlock const *mpiBlock, const char *dirname, struct stat *p
    if (rank != 0) {
       return 0;
    }
-   int status;
-   int errorcode;
    char *expandedDirName = strdup(expandLeadingTilde(dirname).c_str());
-   status                = stat(dirname, pathstat);
+   int status            = stat(dirname, pathstat);
    free(expandedDirName);
    return status ? errno : 0;
 }

--- a/src/io/randomstateio.cpp
+++ b/src/io/randomstateio.cpp
@@ -19,7 +19,6 @@ double readRandState(
       nyGlobal += loc->halo.dn + loc->halo.up;
    }
    int const nf          = loc->nf;
-   int const numGlobal   = nxGlobal * nyGlobal * nf;
    int const rootProcess = 0; // process that does the I/O.
 
    Buffer<taus_uint4> buffer{nxGlobal, nyGlobal, nf};

--- a/src/io/randomstateio.cpp
+++ b/src/io/randomstateio.cpp
@@ -81,11 +81,18 @@ void writeRandState(
    for (int m = 0; m < mpiBlock->getBatchDimension(); m++) {
       for (int b = 0; b < loc->nbatch; b++) {
          auto localData = &randState[b * numLocal];
-         Buffer<taus_uint4> localBuffer{randState, nxLocal, nyLocal, nf};
+         Buffer<taus_uint4> localBuffer{localData, nxLocal, nyLocal, nf};
          Buffer<taus_uint4> globalBuffer =
                BufferUtils::gather(mpiBlock, localBuffer, loc->nx, loc->ny, m, 0);
          if (mpiBlock->getRank() == 0) {
-            BufferUtils::writeToPvp<taus_uint4>(path.c_str(), &globalBuffer, simTime, verifyWrites);
+            if (b == 0) {
+               BufferUtils::writeToPvp<taus_uint4>(
+                     path.c_str(), &globalBuffer, simTime, verifyWrites);
+            }
+            else {
+               BufferUtils::appendToPvp<taus_uint4>(
+                     path.c_str(), &globalBuffer, b, simTime, verifyWrites);
+            }
          }
       }
    }

--- a/src/layers/FilenameParsingGroundTruthLayer.hpp
+++ b/src/layers/FilenameParsingGroundTruthLayer.hpp
@@ -25,7 +25,7 @@ class FilenameParsingGroundTruthLayer : public HyPerLayer {
 
   protected:
    virtual void createComponentTable(char const *description) override;
-   virtual LayerUpdateController *createLayerUpdateController();
+   virtual LayerUpdateController *createLayerUpdateController() override;
    virtual LayerInputBuffer *createLayerInput() override;
    virtual ActivityComponent *createActivityComponent() override;
    virtual InputLayerNameParam *createInputLayerNameParam();

--- a/src/layers/HyPerLayer.cpp
+++ b/src/layers/HyPerLayer.cpp
@@ -289,7 +289,10 @@ HyPerLayer::respondLayerWriteParams(std::shared_ptr<LayerWriteParamsMessage cons
 #ifdef PV_USE_CUDA
 Response::Status HyPerLayer::setCudaDevice(std::shared_ptr<SetCudaDeviceMessage const> message) {
    Response::Status status = ComponentBasedObject::setCudaDevice(message);
-   return notify(message, mCommunicator->globalCommRank() == 0 /*printFlag*/);
+   if (Response::completed(status)) {
+      status = notify(message, mCommunicator->globalCommRank() == 0 /*printFlag*/);
+   }
+   return status;
 }
 #endif // PV_USE_CUDA
 
@@ -417,10 +420,10 @@ Response::Status
 HyPerLayer::respondLayerUpdateState(std::shared_ptr<LayerUpdateStateMessage const> message) {
    Response::Status status = Response::SUCCESS;
    if (mLayerUpdateController) {
-      mLayerUpdateController->respond(message);
+      status = mLayerUpdateController->respond(message);
    }
    checkUpdateState(message->mTime, message->mDeltaT);
-   return Response::SUCCESS;
+   return status;
 }
 
 Response::Status HyPerLayer::checkUpdateState(double simTime, double deltaTime) {

--- a/src/layers/HyPerLayer.hpp
+++ b/src/layers/HyPerLayer.hpp
@@ -121,7 +121,8 @@ class HyPerLayer : public ComponentBasedObject {
    Response::Status respondLayerWriteParams(std::shared_ptr<LayerWriteParamsMessage const> message);
 
 #ifdef PV_USE_CUDA
-   virtual Response::Status setCudaDevice(std::shared_ptr<SetCudaDeviceMessage const> message);
+   virtual Response::Status
+   setCudaDevice(std::shared_ptr<SetCudaDeviceMessage const> message) override;
 #endif // PV_USE_CUDA
 
    virtual Response::Status allocateDataStructures() override;

--- a/src/layers/InputRegionLayer.hpp
+++ b/src/layers/InputRegionLayer.hpp
@@ -27,7 +27,7 @@ class InputRegionLayer : public HyPerLayer {
   protected:
    InputRegionLayer();
    void initialize(const char *name, PVParams *params, Communicator const *comm);
-   void createComponentTable(char const *description);
+   virtual void createComponentTable(char const *description) override;
    virtual PhaseParam *createPhaseParam() override;
    virtual BoundaryConditions *createBoundaryConditions() override;
    virtual LayerUpdateController *createLayerUpdateController() override;

--- a/src/layers/PoolingIndexLayer.hpp
+++ b/src/layers/PoolingIndexLayer.hpp
@@ -22,7 +22,7 @@ class PoolingIndexLayer : public HyPerLayer {
    void initialize(const char *name, PVParams *params, Communicator const *comm);
    virtual int ioParamsFillGroup(enum ParamsIOFlag ioFlag) override;
    LayerInputBuffer *createLayerInput() override;
-   virtual ActivityComponent *createActivityComponent();
+   virtual ActivityComponent *createActivityComponent() override;
 }; // end of class PoolingIndexLayer
 
 } // end namespace PV

--- a/src/normalizers/NormalizeL2.cpp
+++ b/src/normalizers/NormalizeL2.cpp
@@ -105,8 +105,6 @@ int NormalizeL2::normalizeWeights() {
                int nxp               = weights->getPatchSizeX();
                int nyp               = weights->getPatchSizeY();
                int nfp               = weights->getPatchSizeF();
-               int xPatchStride      = weights->getPatchStrideX();
-               int yPatchStride      = weights->getPatchStrideY();
                int weightsPerPatch   = nxp * nyp * nfp;
                float *dataStartPatch = weights->getData(arborID) + patchindex * weightsPerPatch;
                accumulateSumSquared(dataStartPatch, weightsPerPatch, &sumsq);

--- a/src/observerpattern/Response.hpp
+++ b/src/observerpattern/Response.hpp
@@ -46,7 +46,7 @@ Status operator+(Status const &a, Status const &b);
  * A convenience method to test if a status is either SUCCESS or NO_ACTION. In either
  * case, the message that generated this status would not need to be resent.
  */
-static bool completed(Status &a) { return a == SUCCESS or a == NO_ACTION; }
+inline static bool completed(Status &a) { return a == SUCCESS or a == NO_ACTION; }
 
 } // namespace PV
 

--- a/src/observerpattern/Subject.cpp
+++ b/src/observerpattern/Subject.cpp
@@ -34,7 +34,7 @@ Subject::notify(std::vector<std::shared_ptr<BaseMessage const>> messages, bool p
    Response::Status returnStatus = Response::NO_ACTION;
    std::vector<int> numPostponed(messages.size());
    for (auto *obj : *mTable) {
-      for (int msgIdx = 0; msgIdx < messages.size(); msgIdx++) {
+      for (std::size_t msgIdx = 0; msgIdx < messages.size(); msgIdx++) {
          auto &msg               = messages[msgIdx];
          Response::Status status = obj->respond(msg);
          returnStatus            = returnStatus + status;
@@ -55,7 +55,7 @@ Subject::notify(std::vector<std::shared_ptr<BaseMessage const>> messages, bool p
       }
    }
    if (printFlag) {
-      for (int msgIdx = 0; msgIdx < messages.size(); msgIdx++) {
+      for (std::size_t msgIdx = 0; msgIdx < messages.size(); msgIdx++) {
          int numPostponedThisMsg = numPostponed.at(msgIdx);
          if (numPostponedThisMsg > 0) {
             InfoLog().printf(

--- a/src/probes/AdaptiveTimeScaleProbe.cpp
+++ b/src/probes/AdaptiveTimeScaleProbe.cpp
@@ -194,8 +194,8 @@ void AdaptiveTimeScaleProbe::calcValues(double timeValue) {
    else {
       mTargetProbe->getValues(timeValue, &rawProbeValues);
    }
-   pvAssert(rawProbeValues.size() == getNumValues()); // In allocateDataStructures, we checked that
-   // mTargetProbe has a compatible size.
+   pvAssert(rawProbeValues.size() == (std::size_t)getNumValues());
+   // In allocateDataStructures, we checked that mTargetProbe has a compatible size.
    std::vector<double> timeSteps =
          mAdaptiveTimeScaleController->calcTimesteps(timeValue, rawProbeValues);
    memcpy(getValuesBuffer(), timeSteps.data(), sizeof(double) * getNumValues());

--- a/src/probes/BaseConnectionProbe.cpp
+++ b/src/probes/BaseConnectionProbe.cpp
@@ -98,7 +98,6 @@ Response::Status BaseConnectionProbe::registerData(
 }
 
 void BaseConnectionProbe::initOutputStreams(const char *filename, Checkpointer *checkpointer) {
-   MPIBlock const *mpiBlock = checkpointer->getMPIBlock();
    if (getMPIBlock()->getRank() == 0) {
       char const *probeOutputFilename = getProbeOutputFilename();
       if (probeOutputFilename) {

--- a/src/probes/ColumnEnergyProbe.cpp
+++ b/src/probes/ColumnEnergyProbe.cpp
@@ -137,7 +137,7 @@ int ColumnEnergyProbe::addTerm(BaseProbe *probe) {
    terms           = newTermsArray;
    terms[numTerms] = probe;
    numTerms        = newNumTerms;
-   return PV_SUCCESS;
+   return status;
 } // end ColumnEnergyProbe::addTerm(BaseProbe *, double)
 
 bool ColumnEnergyProbe::needRecalc(double timevalue) { return true; }

--- a/src/probes/ColumnEnergyProbe.cpp
+++ b/src/probes/ColumnEnergyProbe.cpp
@@ -173,7 +173,6 @@ Response::Status ColumnEnergyProbe::outputState(double simTime, double deltaTime
    double *valuesBuffer = getValuesBuffer();
    int nbatch           = this->getNumValues();
    pvAssert(nbatch == (int)mOutputStreams.size());
-   char const *probeOutputFilename = getProbeOutputFilename();
    for (int b = 0; b < nbatch; b++) {
       auto stream = *mOutputStreams[b];
       if (!isWritingToFile()) {

--- a/src/probes/ColumnEnergyProbe.cpp
+++ b/src/probes/ColumnEnergyProbe.cpp
@@ -111,7 +111,7 @@ int ColumnEnergyProbe::addTerm(BaseProbe *probe) {
       }
    }
    assert(probe->getNumValues() == getNumValues());
-   int newNumTerms = numTerms + (size_t)1;
+   auto newNumTerms = numTerms + (std::size_t)1;
    if (newNumTerms <= numTerms) {
       if (this->mCommunicator->commRank() == 0) {
          ErrorLog().printf(
@@ -154,7 +154,7 @@ void ColumnEnergyProbe::calcValues(double timevalue) {
    int numValues        = this->getNumValues();
    memset(valuesBuffer, 0, numValues * sizeof(*valuesBuffer));
    double energy1[numValues];
-   for (int n = 0; n < numTerms; n++) {
+   for (std::size_t n = 0; n < numTerms; n++) {
       BaseProbe *p = terms[n];
       p->getValues(timevalue, energy1);
       double coeff = p->getCoefficient();

--- a/src/probes/ColumnEnergyProbe.hpp
+++ b/src/probes/ColumnEnergyProbe.hpp
@@ -99,7 +99,7 @@ class ColumnEnergyProbe : public ColProbe {
    virtual int ioParamsFillGroup(enum ParamsIOFlag ioFlag) override;
    virtual void ioParam_reductionInterval(enum ParamsIOFlag ioFlag);
 
-   size_t numTerms;
+   std::size_t numTerms;
    BaseProbe **terms;
 
   private:

--- a/src/probes/KernelProbe.cpp
+++ b/src/probes/KernelProbe.cpp
@@ -184,11 +184,10 @@ Response::Status KernelProbe::outputState(double simTime, double deltaTime) {
    if (mOutputStreams.empty()) {
       return Response::NO_ACTION;
    }
-   const int rank = mCommunicator->commRank();
-   int nxp        = getPatchSize()->getPatchSizeX();
-   int nyp        = getPatchSize()->getPatchSizeY();
-   int nfp        = getPatchSize()->getPatchSizeF();
-   int patchSize  = nxp * nyp * nfp;
+   int nxp       = getPatchSize()->getPatchSizeX();
+   int nyp       = getPatchSize()->getPatchSizeY();
+   int nfp       = getPatchSize()->getPatchSizeF();
+   int patchSize = nxp * nyp * nfp;
 
    const float *wdata  = mWeightData + patchSize * kernelIndex;
    const float *dwdata = outputPlasticIncr ? mDeltaWeightData + patchSize * kernelIndex : nullptr;

--- a/src/probes/L2ConnProbe.cpp
+++ b/src/probes/L2ConnProbe.cpp
@@ -21,13 +21,11 @@ Response::Status L2ConnProbe::outputState(double simTime, double deltaTime) {
       return Response::NO_ACTION;
    }
    pvAssert(getTargetConn() != nullptr);
-   const int rank = mCommunicator->commRank();
-   int nxp        = getPatchSize()->getPatchSizeX();
-   int nyp        = getPatchSize()->getPatchSizeY();
-   int nfp        = getPatchSize()->getPatchSizeF();
-   int patchSize  = nxp * nyp * nfp;
+   int nxp       = getPatchSize()->getPatchSizeX();
+   int nyp       = getPatchSize()->getPatchSizeY();
+   int nfp       = getPatchSize()->getPatchSizeF();
+   int patchSize = nxp * nyp * nfp;
 
-   int arborID = getArbor();
    int numKern = getWeights()->getNumDataPatches();
 
    if (numKern != getWeights()->getGeometry()->getPreLoc().nf) {

--- a/src/probes/PointLIFProbe.cpp
+++ b/src/probes/PointLIFProbe.cpp
@@ -52,7 +52,7 @@ void PointLIFProbe::initNumValues() { setNumValues(NUMBER_OF_VALUES); }
 Response::Status
 PointLIFProbe::communicateInitInfo(std::shared_ptr<CommunicateInitInfoMessage const> message) {
    auto status = PointProbe::communicateInitInfo(message);
-   if (!Response::completed) {
+   if (!Response::completed(status)) {
       return status;
    }
 

--- a/src/probes/PointProbe.cpp
+++ b/src/probes/PointProbe.cpp
@@ -240,7 +240,6 @@ void PointProbe::calcValues(double timevalue) {
 
 void PointProbe::writeState(double timevalue) {
    if (!mOutputStreams.empty()) {
-      double *valuesBuffer = this->getValuesBuffer();
       output(0).printf("%s t=%.1f V=%6.5f a=%.5f", getMessage(), timevalue, getV(), getA());
       output(0) << std::endl;
    }

--- a/src/probes/StatsProbe.cpp
+++ b/src/probes/StatsProbe.cpp
@@ -283,15 +283,14 @@ Response::Status StatsProbe::outputState(double simTime, double deltaTime) {
 
 #ifdef PV_USE_MPI
    mpitimer->start();
-   int ierr;
 
    // In place reduction to prevent allocating a temp recv buffer
-   ierr = MPI_Allreduce(MPI_IN_PLACE, sum, nbatch, MPI_DOUBLE, MPI_SUM, comm);
-   ierr = MPI_Allreduce(MPI_IN_PLACE, sum2, nbatch, MPI_DOUBLE, MPI_SUM, comm);
-   ierr = MPI_Allreduce(MPI_IN_PLACE, nnz, nbatch, MPI_INT, MPI_SUM, comm);
-   ierr = MPI_Allreduce(MPI_IN_PLACE, fMin, nbatch, MPI_FLOAT, MPI_MIN, comm);
-   ierr = MPI_Allreduce(MPI_IN_PLACE, fMax, nbatch, MPI_FLOAT, MPI_MAX, comm);
-   ierr = MPI_Allreduce(MPI_IN_PLACE, &nk, 1, MPI_INT, MPI_SUM, comm);
+   MPI_Allreduce(MPI_IN_PLACE, sum, nbatch, MPI_DOUBLE, MPI_SUM, comm);
+   MPI_Allreduce(MPI_IN_PLACE, sum2, nbatch, MPI_DOUBLE, MPI_SUM, comm);
+   MPI_Allreduce(MPI_IN_PLACE, nnz, nbatch, MPI_INT, MPI_SUM, comm);
+   MPI_Allreduce(MPI_IN_PLACE, fMin, nbatch, MPI_FLOAT, MPI_MIN, comm);
+   MPI_Allreduce(MPI_IN_PLACE, fMax, nbatch, MPI_FLOAT, MPI_MAX, comm);
+   MPI_Allreduce(MPI_IN_PLACE, &nk, 1, MPI_INT, MPI_SUM, comm);
 
    mpitimer->stop();
    if (rank != rcvProc) {

--- a/src/structures/Buffer.tpp
+++ b/src/structures/Buffer.tpp
@@ -52,7 +52,7 @@ void Buffer<T>::set(int k, T value) {
 template <class T>
 void Buffer<T>::set(const std::vector<T> &vector, int width, int height, int features) {
    FatalIf(
-         vector.size() != width * height * features,
+         (int)vector.size() != width * height * features,
          "Invalid vector size: Expected %d elements, vector contained %d elements.\n",
          width * height * features,
          vector.size());

--- a/src/structures/SparseList.hpp
+++ b/src/structures/SparseList.hpp
@@ -4,6 +4,7 @@
 #include "Buffer.hpp"
 #include "utils/PVLog.hpp"
 
+#include <cinttypes>
 #include <vector>
 
 using std::vector;
@@ -38,12 +39,12 @@ class SparseList {
    }
 
    void toBuffer(Buffer<T> &dest, T zeroVal) {
-      int numElements = dest.getTotalElements();
+      uint32_t numElements = dest.getTotalElements();
       vector<T> newData(numElements, zeroVal);
       for (auto entry : mList) {
          FatalIf(
                entry.index > numElements,
-               "Buffer is not large enough to hold index %d / %d\n",
+               "Buffer is not large enough to hold index %" PRIu32 " / %" PRIu32 "\n",
                entry.index,
                numElements);
          newData.at(entry.index) = entry.value;

--- a/src/utils/BorderExchange.cpp
+++ b/src/utils/BorderExchange.cpp
@@ -175,12 +175,11 @@ int BorderExchange::wait(std::vector<MPI_Request> &req) {
  * If there is no neighbor, returns a negative value
  */
 int BorderExchange::neighborIndex(int commId, int direction) {
-   int batchDimension = mMPIBlock->getBatchDimension();
-   int numRows        = mMPIBlock->getNumRows();
-   int numColumns     = mMPIBlock->getNumColumns();
-   int rankRowColumn  = commId % (numRows * numColumns);
-   int row            = rowFromRank(rankRowColumn, numRows, numColumns);
-   int column         = columnFromRank(rankRowColumn, numRows, numColumns);
+   int numRows       = mMPIBlock->getNumRows();
+   int numColumns    = mMPIBlock->getNumColumns();
+   int rankRowColumn = commId % (numRows * numColumns);
+   int row           = rowFromRank(rankRowColumn, numRows, numColumns);
+   int column        = columnFromRank(rankRowColumn, numRows, numColumns);
    int neighborRank;
    switch (direction) {
       case LOCAL: return commId;
@@ -326,13 +325,12 @@ int BorderExchange::reverseDirection(int commId, int direction) {
    if (neighbor == commId) {
       return LOCAL;
    }
-   int revdir         = 9 - direction; // Correct unless at an edge of the MPI quilt
-   int batchDimension = mMPIBlock->getBatchDimension();
-   int numRows        = mMPIBlock->getNumRows();
-   int numCols        = mMPIBlock->getNumColumns();
-   int rankRowColumn  = commId % (numRows * numCols);
-   int row            = rowFromRank(rankRowColumn, numRows, numCols);
-   int col            = columnFromRank(rankRowColumn, numRows, numCols);
+   int revdir        = 9 - direction; // Correct unless at an edge of the MPI quilt
+   int numRows       = mMPIBlock->getNumRows();
+   int numCols       = mMPIBlock->getNumColumns();
+   int rankRowColumn = commId % (numRows * numCols);
+   int row           = rowFromRank(rankRowColumn, numRows, numCols);
+   int col           = columnFromRank(rankRowColumn, numRows, numCols);
    switch (direction) {
       case LOCAL:
          pvAssert(0); // Should have neighbor==commId, so should have already returned

--- a/src/utils/BorderExchange.cpp
+++ b/src/utils/BorderExchange.cpp
@@ -191,7 +191,10 @@ int BorderExchange::neighborIndex(int commId, int direction) {
       case SOUTHWEST: neighborRank = southwest(row, column, numRows, numColumns); break;
       case SOUTH: neighborRank     = south(row, column, numRows, numColumns); break;
       case SOUTHEAST: neighborRank = southeast(row, column, numRows, numColumns); break;
-      default: pvAssert(0); break;
+      default:
+         neighborRank = -1;
+         pvAssert(0);
+         break;
    }
    if (neighborRank >= 0) {
       int rankBatchStart = commId - rankRowColumn;
@@ -416,6 +419,7 @@ std::size_t BorderExchange::recvOffset(int direction) {
       case SOUTH: offset     = sx * leftBorder + sy * (topBorder + ny); break;
       case SOUTHEAST: offset = sx * leftBorder + sx * nx + sy * (topBorder + ny); break;
       default:
+         offset = -1; // Suppresses g++ maybe-uninitialized warning
          pvAssert(0); /* All allowable directions handled in above cases */
          break;
    }
@@ -466,6 +470,7 @@ std::size_t BorderExchange::sendOffset(int direction) {
                 + sy * (ny + !hasSouthNeighbor * topBorder);
          break;
       default:
+         offset = -1; // Suppresses g++ maybe-uninitialized warning
          pvAssert(0); /* All allowable directions handled in above cases */
          break;
    }

--- a/src/utils/BufferUtilsMPI.tpp
+++ b/src/utils/BufferUtilsMPI.tpp
@@ -214,7 +214,6 @@ gatherSparse(MPIBlock const *mpiBlock, SparseList<T> list, int mpiBatchIndex, in
    else if (mpiBlock->getBatchIndex() == mpiBatchIndex) {
       vector<struct SparseList<T>::Entry> toSend = list.getContents();
       uint32_t numToSend                         = toSend.size();
-      int batchElementRoot = mpiBlock->calcRankFromRowColBatch(0, 0, mpiBlock->getBatchIndex());
       MPI_Send(&numToSend, 1, MPI_INT, destProcess, 33, mpiBlock->getComm());
       if (numToSend > 0) {
          MPI_Send(

--- a/src/utils/BufferUtilsPvp.cpp
+++ b/src/utils/BufferUtilsPvp.cpp
@@ -33,8 +33,7 @@ WeightHeader buildWeightHeader(
    baseHeader.numRecords = numArbors;
    baseHeader.recordSize = 0;
 
-   int numPatches    = preLayerNxExt * preLayerNyExt * preLayerNf;
-   int numPatchItems = nxp * nyp * nfp;
+   int numPatches = preLayerNxExt * preLayerNyExt * preLayerNf;
    if (compress) {
       baseHeader.dataSize = (int)sizeof(unsigned char);
       baseHeader.dataType = returnDataType<unsigned char>();
@@ -164,9 +163,6 @@ void calcNumberOfPatches(
       int &numPatchesF,
       int &numPatchesXExt,
       int &numPatchesYExt) {
-   int nxPreRestricted = preLayerLoc->nx * numColumnProcesses;
-   int nyPreRestricted = preLayerLoc->ny * numRowProcesses;
-
    numPatchesX = preLayerLoc->nx * numColumnProcesses;
    numPatchesY = preLayerLoc->ny * numRowProcesses;
 

--- a/src/utils/BufferUtilsPvp.tpp
+++ b/src/utils/BufferUtilsPvp.tpp
@@ -317,7 +317,7 @@ double readSparseBinaryFrame(FileStream &fStream, SparseList<T> *list, T oneValu
    if (numElements > 0) {
       fStream.read(indices.data(), numElements * sizeof(int));
    }
-   for (int i = 0; i < indices.size(); ++i) {
+   for (std::size_t i = 0; i < indices.size(); ++i) {
       contents.at(i).index = indices.at(i);
       contents.at(i).value = oneValue;
    }

--- a/src/utils/BufferUtilsRescale.cpp
+++ b/src/utils/BufferUtilsRescale.cpp
@@ -69,27 +69,23 @@ void bicubicInterp(
 
    // Interpolation using bicubic convolution with a = -1
    // (following Octave image toolbox's imremap function - change this?)
-   float xinterp[widthOut];
    int xinteger[widthOut];
    float xfrac[widthOut];
    float dx = (float)(widthIn - 1) / (float)(widthOut - 1);
 
    for (int kx = 0; kx < widthOut; kx++) {
       float x      = dx * (float)kx;
-      xinterp[kx]  = x;
       float xfloor = floorf(x);
       xinteger[kx] = (int)xfloor;
       xfrac[kx]    = x - xfloor;
    }
 
-   float yinterp[heightOut];
    int yinteger[heightOut];
    float yfrac[heightOut];
    float dy = (float)(heightIn - 1) / (float)(heightOut - 1);
 
    for (int ky = 0; ky < heightOut; ky++) {
       float y      = dy * (float)ky;
-      yinterp[ky]  = y;
       float yfloor = floorf(y);
       yinteger[ky] = (int)yfloor;
       yfrac[ky]    = y - yfloor;

--- a/src/utils/TransposeWeights.cpp
+++ b/src/utils/TransposeWeights.cpp
@@ -54,14 +54,11 @@ void TransposeWeights::transpose(
 }
 
 void TransposeWeights::transposeShared(Weights *preWeights, Weights *postWeights, int arbor) {
-   int const numPatchesXPre = preWeights->getNumDataPatchesX();
-   int const numPatchesYPre = preWeights->getNumDataPatchesY();
-   int const numPatchesFPre = preWeights->getNumDataPatchesF();
-   int const numPatchesPre  = preWeights->getNumDataPatches();
-   int const patchSizeXPre  = preWeights->getPatchSizeX();
-   int const patchSizeYPre  = preWeights->getPatchSizeY();
-   int const patchSizeFPre  = preWeights->getPatchSizeF();
-   int const patchSizePre   = patchSizeXPre * patchSizeYPre * patchSizeFPre;
+   int const numPatchesPre = preWeights->getNumDataPatches();
+   int const patchSizeXPre = preWeights->getPatchSizeX();
+   int const patchSizeYPre = preWeights->getPatchSizeY();
+   int const patchSizeFPre = preWeights->getPatchSizeF();
+   int const patchSizePre  = patchSizeXPre * patchSizeYPre * patchSizeFPre;
 
    int const numPatchesXPost = postWeights->getNumDataPatchesX();
    int const numPatchesYPost = postWeights->getNumDataPatchesY();
@@ -72,12 +69,6 @@ void TransposeWeights::transposeShared(Weights *preWeights, Weights *postWeights
 #endif
    for (int patchIndexPre = 0; patchIndexPre < numPatchesPre; patchIndexPre++) {
       for (int itemInPatchPre = 0; itemInPatchPre < patchSizePre; itemInPatchPre++) {
-         int const patchIndexXPre =
-               kxPos(patchIndexPre, numPatchesXPre, numPatchesYPre, numPatchesFPre);
-         int const patchIndexYPre =
-               kyPos(patchIndexPre, numPatchesXPre, numPatchesYPre, numPatchesFPre);
-         int const patchIndexFPre =
-               featureIndex(patchIndexPre, numPatchesXPre, numPatchesYPre, numPatchesFPre);
 
          int itemInPatchPost =
                preWeights->getGeometry()->getTransposeItemIndex(patchIndexPre, itemInPatchPre);
@@ -145,15 +136,7 @@ void TransposeWeights::transposeNonshared(
    PVLayerLoc const &preLoc  = preWeights->getGeometry()->getPreLoc();
    PVLayerLoc const &postLoc = postWeights->getGeometry()->getPreLoc();
 
-   int const nxPre            = preLoc.nx;
-   int const nyPre            = preLoc.ny;
-   int const nfPre            = preLoc.nf;
-   int const numRestrictedPre = nxPre * nyPre * nfPre;
-
-   int const nxPost            = postLoc.nx;
-   int const nyPost            = postLoc.ny;
-   int const nfPost            = postLoc.nf;
-   int const numRestrictedPost = nxPost * nyPost * nfPost;
+   int const nfPost = postLoc.nf;
 
    int const numKernelsXPre = preWeights->getGeometry()->getNumKernelsX();
    int const numKernelsYPre = preWeights->getGeometry()->getNumKernelsY();

--- a/src/utils/conversions.h
+++ b/src/utils/conversions.h
@@ -595,8 +595,8 @@ static inline int
 extendedIndexInBorderRegion(int extK, int nx, int ny, int nf, int lt, int rt, int dn, int up) {
    int x = kxPos(extK, nx + lt + rt, ny + dn + up, nf);
    int y = kyPos(extK, nx + lt + rt, ny + dn + up, nf);
-   return x < lt | x >= nx + lt | y < up
-          | y >= ny + up; // Which is better: bitwise-or or logical-or?
+   return (x < lt) | (x >= nx + lt) | (y < up) | (y >= ny + up);
+   // Which is better: bitwise-or or logical-or?
 }
 
 // Converts a local ext index into a global res index

--- a/src/weightinit/InitSpreadOverArborsWeights.cpp
+++ b/src/weightinit/InitSpreadOverArborsWeights.cpp
@@ -74,18 +74,6 @@ int InitSpreadOverArborsWeights::spreadOverArborsWeights(float *dataStart, int a
             }
             else {
                float theta2pi = atan2f(yp, xp) / (2 * PI);
-               unsigned int xpraw, ypraw, atanraw;
-               union u {
-                  float f;
-                  unsigned int i;
-               };
-               union u f2u;
-               f2u.f   = xp;
-               xpraw   = f2u.i;
-               f2u.f   = yp;
-               ypraw   = f2u.i;
-               f2u.f   = theta2pi;
-               atanraw = f2u.i;
                if (theta2pi < 0) {
                   theta2pi += 1;
                }

--- a/src/weightupdaters/HebbianUpdater.cpp
+++ b/src/weightupdaters/HebbianUpdater.cpp
@@ -37,7 +37,7 @@ int HebbianUpdater::ioParamsFillGroup(enum ParamsIOFlag ioFlag) {
    ioParam_normalizeDw(ioFlag);
    ioParam_useMask(ioFlag);
    ioParam_combine_dW_with_W_flag(ioFlag);
-   return PV_SUCCESS;
+   return status;
 }
 
 void HebbianUpdater::ioParam_triggerLayerName(enum ParamsIOFlag ioFlag) {

--- a/src/weightupdaters/HebbianUpdater.cpp
+++ b/src/weightupdaters/HebbianUpdater.cpp
@@ -581,7 +581,6 @@ void HebbianUpdater::updateInd_dW(
    HyPerLayer *post          = mConnectionData->getPost();
    const PVLayerLoc *postLoc = post->getLayerLoc();
 
-   const float *maskactbuf = NULL;
    const float *preactbuf  = preLayerData + batchID * pre->getNumExtended();
    const float *postactbuf = postLayerData + batchID * post->getNumExtended();
 
@@ -602,8 +601,7 @@ void HebbianUpdater::updateInd_dW(
    size_t offset           = mWeights->getGeometry()->getAPostOffset(kExt);
    const float *postactRef = &postactbuf[offset];
 
-   int sym                 = 0;
-   const float *maskactRef = NULL;
+   int sym = 0;
 
    float *dwdata =
          mDeltaWeights->getDataFromPatchIndex(arborID, kExt) + mDeltaWeights->getPatch(kExt).offset;

--- a/src/weightupdaters/MomentumUpdater.cpp
+++ b/src/weightupdaters/MomentumUpdater.cpp
@@ -101,6 +101,7 @@ void MomentumUpdater::checkTimeConstantTau() {
                getDescription_c(),
                (double)mTimeConstantTau);
          break;
+      default: Fatal().printf("Unrecognized momentumMethod\n"); break;
    }
 }
 

--- a/tests/AdjustAxonalArborsTest/src/main.cpp
+++ b/tests/AdjustAxonalArborsTest/src/main.cpp
@@ -32,8 +32,7 @@ int checkoutput(HyPerCol *hc, int argc, char **argv) {
    pvAssert(
          inLoc->halo.lt == 1 and inLoc->halo.rt == 1 and inLoc->halo.dn == 1
          and inLoc->halo.up == 1);
-   int const numGlobalExtended = 16;
-   int const numExtended       = inLayerData->getNumExtended();
+   int const numExtended = inLayerData->getNumExtended();
    FatalIf(numExtended != (inLoc->nx + 1 + 1) * (inLoc->ny + 1 + 1) * inLoc->nf, "Test failed.\n");
 
    InfoLog().flush();

--- a/tests/AvgPoolTest/src/AvgPoolTestInputBuffer.cpp
+++ b/tests/AvgPoolTest/src/AvgPoolTestInputBuffer.cpp
@@ -19,8 +19,6 @@ void AvgPoolTestInputBuffer::updateBufferCPU(double timef, double dt) {
    int nf                = loc->nf;
    int nxGlobal          = loc->nxGlobal;
    int nyGlobal          = loc->nyGlobal;
-   int kx0               = loc->kx0;
-   int ky0               = loc->ky0;
 
    for (int b = 0; b < loc->nbatch; b++) {
       float *A = mBufferData.data() + b * getBufferSize();

--- a/tests/AvgPoolTest/src/GateAvgPoolTestBuffer.cpp
+++ b/tests/AvgPoolTest/src/GateAvgPoolTestBuffer.cpp
@@ -22,11 +22,7 @@ void GateAvgPoolTestBuffer::updateBufferCPU(double simTime, double deltaTime) {
    const PVLayerLoc *loc = getLayerLoc();
    int nx                = loc->nx;
    int ny                = loc->ny;
-   int nxGlobal          = loc->nxGlobal;
-   int nyGlobal          = loc->nyGlobal;
    int nf                = loc->nf;
-   int kx0               = loc->kx0;
-   int ky0               = loc->ky0;
 
    bool isCorrect = true;
    // Grab the activity layer of current layer
@@ -46,10 +42,10 @@ void GateAvgPoolTestBuffer::updateBufferCPU(double simTime, double deltaTime) {
 
                float actualvalue = A[ext_idx];
 
-               int xval = (iX + kx0 - loc->halo.lt) / 2;
-               int yval = (iY + ky0 - loc->halo.up) / 2;
-               FatalIf(!(xval >= 0 && xval < loc->nxGlobal), "Test failed.\n");
-               FatalIf(!(yval >= 0 && yval < loc->nxGlobal), "Test failed.\n");
+               int xval = (iX + loc->kx0 - loc->halo.lt) / 2;
+               int yval = (iY + loc->ky0 - loc->halo.up) / 2;
+               FatalIf(xval < 0 or xval >= loc->nxGlobal, "Test failed.\n");
+               FatalIf(yval < 0 or yval >= loc->nyGlobal, "Test failed.\n");
 
                float expectedvalue;
                expectedvalue = iFeature * 64 + yval * 16 + xval * 2 + 4.5;

--- a/tests/BackgroundLayerTest/src/ComparisonLayer.cpp
+++ b/tests/BackgroundLayerTest/src/ComparisonLayer.cpp
@@ -7,15 +7,6 @@ ComparisonLayer::ComparisonLayer(const char *name, PVParams *params, Communicato
 }
 
 Response::Status ComparisonLayer::checkUpdateState(double timef, double dt) {
-
-   // Grab layer size
-   const PVLayerLoc *loc = getLayerLoc();
-   int nx                = loc->nx;
-   int ny                = loc->ny;
-   int nf                = loc->nf;
-   int kx0               = loc->kx0;
-   int ky0               = loc->ky0;
-
    float const *GSynExt = mLayerInput->getChannelData(CHANNEL_EXC); // gated
    float const *GSynInh = mLayerInput->getChannelData(CHANNEL_INH); // gt
 
@@ -32,7 +23,7 @@ Response::Status ComparisonLayer::checkUpdateState(double timef, double dt) {
    }
 
    if (!isCorrect) {
-      exit(-1);
+      exit(EXIT_FAILURE);
    }
    return Response::SUCCESS;
 }

--- a/tests/BatchCheckpointSystemTest/src/main.cpp
+++ b/tests/BatchCheckpointSystemTest/src/main.cpp
@@ -93,9 +93,6 @@ int main(int argc, char *argv[]) {
 int customexit(HyPerCol *hc, int argc, char *argv[]) {
    // Rank of the checkpointing MPI communicator does is not publicly accessible, so recreate it.
    Arguments const *arguments = hc->getPV_InitObj()->getArguments();
-   int cellNumRows            = arguments->getIntegerArgument("CheckpointCellNumRows");
-   int cellNumColumns         = arguments->getIntegerArgument("CheckpointCellNumColumns");
-   int cellBatchDimension     = arguments->getIntegerArgument("CheckpointCellBatchDimension");
    MPIBlock mpiBlock(
          hc->getCommunicator()->globalCommunicator(),
          arguments->getIntegerArgument("NumRows"),

--- a/tests/BatchMPICheckpointSystemTest/src/main.cpp
+++ b/tests/BatchMPICheckpointSystemTest/src/main.cpp
@@ -120,9 +120,6 @@ int diffDirs(const char *cpdir1, const char *cpdir2, int index) {
 int customexit(HyPerCol *hc, int argc, char *argv[]) {
    // Rank of the checkpointing MPI communicator does is not publicly accessible, so recreate it.
    Arguments const *arguments = hc->getPV_InitObj()->getArguments();
-   int cellNumRows            = arguments->getIntegerArgument("CheckpointCellNumRows");
-   int cellNumColumns         = arguments->getIntegerArgument("CheckpointCellNumColumns");
-   int cellBatchDimension     = arguments->getIntegerArgument("CheckpointCellBatchDimension");
    MPIBlock mpiBlock(
          hc->getCommunicator()->globalCommunicator(),
          arguments->getIntegerArgument("NumRows"),

--- a/tests/BatchMethodTest/src/FixedImageSequence.cpp
+++ b/tests/BatchMethodTest/src/FixedImageSequence.cpp
@@ -36,7 +36,6 @@ PV::Response::Status FixedImageSequence::checkUpdateState(double simTime, double
          "FixedImageSequence::checkUpdateState() requires the time argument be an integer.\n");
    PVLayerLoc const *loc = getLayerLoc();
    int timestampInt      = (int)timestampRounded;
-   int globalBatchSize   = getMPIBlock()->getGlobalBatchDimension() * loc->nbatch;
    int localNBatch       = loc->nbatch;
 
    for (int m = 0; m < getMPIBlock()->getBatchDimension(); m++) {

--- a/tests/BatchMethodTest/src/FixedImageSequence.hpp
+++ b/tests/BatchMethodTest/src/FixedImageSequence.hpp
@@ -25,7 +25,8 @@ class FixedImageSequence : public PV::HyPerLayer {
     * the pure virtual method defineImageSequence to set the
     * mIndexStart and mIndexSkip data members.
     */
-   PV::Response::Status initializeState(std::shared_ptr<PV::InitializeStateMessage const> message);
+   PV::Response::Status
+   initializeState(std::shared_ptr<PV::InitializeStateMessage const> message) override;
 
    /**
     * A pure virtual method where derived classes should set the data members

--- a/tests/BinningLayerTest/src/BinningTestProbe.cpp
+++ b/tests/BinningLayerTest/src/BinningTestProbe.cpp
@@ -65,10 +65,9 @@ Response::Status BinningTestProbe::outputState(double simTime, double deltaTime)
    for (int iY = loc->halo.up; iY < ny + loc->halo.up; iY++) {
       for (int iX = loc->halo.up; iX < nx + loc->halo.lt; iX++) {
          for (int iF = 0; iF < nf; iF++) {
-            int origIndexGlobal    = kIndex(iX + kx0, iY + ky0, 0, nxGlobalExt, nyGlobalExt, 1);
-            int binningIndexGlobal = kIndex(iX + kx0, iY + ky0, iF, nxGlobalExt, nyGlobalExt, nf);
-            int binningIndexLocal  = kIndex(iX, iY, iF, nxExt, nyExt, nf);
-            float observedValue    = A[binningIndexLocal];
+            int origIndexGlobal   = kIndex(iX + kx0, iY + ky0, 0, nxGlobalExt, nyGlobalExt, 1);
+            int binningIndexLocal = kIndex(iX, iY, iF, nxExt, nyExt, nf);
+            float observedValue   = A[binningIndexLocal];
             if (binSigma == 0) {
                // Based on the input image, F index should be floor(origIndex/255*32), except
                // that if origIndex==255, F index should be 31.

--- a/tests/BinningLayerTest/src/BinningTestProbe.hpp
+++ b/tests/BinningLayerTest/src/BinningTestProbe.hpp
@@ -16,7 +16,7 @@ namespace PV {
 class BinningTestProbe : public PV::LayerProbe {
   public:
    BinningTestProbe(const char *name, PVParams *params, Communicator const *comm);
-   virtual void calcValues(double timeValue) {}
+   virtual void calcValues(double timeValue) override {}
 
   protected:
    virtual Response::Status

--- a/tests/BufferTest/src/main.cpp
+++ b/tests/BufferTest/src/main.cpp
@@ -67,7 +67,7 @@ void testAsVector() {
          testVector.size(),
          comparison.size());
 
-   for (int i = 0; i < testVector.size(); ++i) {
+   for (std::size_t i = 0; i < testVector.size(); ++i) {
       FatalIf(
             testVector.at(i) != comparison.at(i),
             "Failed: Expected %f, found %f at index %d.\n",
@@ -168,7 +168,7 @@ void testCrop() {
       testBuffer.set(bufferContents, 4, 4, 1);
       testBuffer.crop(4, 4, anchor);
       std::vector<float> contents = testBuffer.asVector();
-      for (int i = 0; i < contents.size(); ++i) {
+      for (std::size_t i = 0; i < contents.size(); ++i) {
          FatalIf(contents.at(i) != bufferContents.at(i), "Failed (same size crop).");
       }
    }
@@ -298,7 +298,7 @@ void testRescale() {
          "Failed (Size). Expected %d elements, found %d.\n",
          answerNearest.size(),
          nearest.size());
-   for (int i = 0; i < nearest.size(); ++i) {
+   for (std::size_t i = 0; i < nearest.size(); ++i) {
       FatalIf(
             nearest.at(i) != answerNearest.at(i),
             "Failed (Nearest). Expected %f at index %d, found %f.\n",
@@ -317,7 +317,7 @@ void testRescale() {
          "Failed (Size). Expected %d elements, found %d.\n",
          answerCrop.size(),
          cropped.size());
-   for (int i = 0; i < cropped.size(); ++i) {
+   for (std::size_t i = 0; i < cropped.size(); ++i) {
       FatalIf(
             cropped.at(i) != answerCrop.at(i),
             "Failed (Crop). Expected %f at index %d, found %f.\n",
@@ -336,7 +336,7 @@ void testRescale() {
          "Failed (Size). Expected %d elements, found %d.\n",
          answerPad.size(),
          padded.size());
-   for (int i = 0; i < padded.size(); ++i) {
+   for (std::size_t i = 0; i < padded.size(); ++i) {
       FatalIf(
             padded.at(i) != answerPad.at(i),
             "Failed (Pad). Expected %f at index %d, found %f.\n",

--- a/tests/BufferUtilsPvpTest/src/main.cpp
+++ b/tests/BufferUtilsPvpTest/src/main.cpp
@@ -172,7 +172,7 @@ void testSparseFile(const char *fName) {
 
       int frameOffset = f * 5 * 5;
 
-      for (int i = 0; i < values.size(); ++i) {
+      for (std::size_t i = 0; i < values.size(); ++i) {
          FatalIf(
                values.at(i) != expected.at(i + frameOffset),
                "Failed on frame %d. Expected value %d at index %d, found %d.\n",

--- a/tests/CheckpointSystemTest/src/main.cpp
+++ b/tests/CheckpointSystemTest/src/main.cpp
@@ -94,9 +94,6 @@ int main(int argc, char *argv[]) {
 int customexit(HyPerCol *hc, int argc, char *argv[]) {
    // Rank of the checkpointing MPI communicator does is not publicly accessible, so recreate it.
    Arguments const *arguments = hc->getPV_InitObj()->getArguments();
-   int cellNumRows            = arguments->getIntegerArgument("CheckpointCellNumRows");
-   int cellNumColumns         = arguments->getIntegerArgument("CheckpointCellNumColumns");
-   int cellBatchDimension     = arguments->getIntegerArgument("CheckpointCellBatchDimension");
    MPIBlock mpiBlock(
          hc->getCommunicator()->globalCommunicator(),
          arguments->getIntegerArgument("NumRows"),

--- a/tests/CheckpointWeightTest/src/CheckpointWeightTest.cpp
+++ b/tests/CheckpointWeightTest/src/CheckpointWeightTest.cpp
@@ -121,7 +121,6 @@ void verifyCheckpointing(PV::Weights &weights, PV::MPIBlock const mpiBlock) {
    // values inside a shrunken patch on another.
    if (!shared) {
       for (int a = 0; a < numArbors; a++) {
-         float *arborDataStart = weights.getData(a);
          for (int p = 0; p < numDataPatches; p++) {
             PV::Patch const &patch = weights.getPatch(p);
             float *w               = weights.getDataFromDataIndex(a, p);

--- a/tests/CheckpointWeightTest/src/CheckpointWeightTest.cpp
+++ b/tests/CheckpointWeightTest/src/CheckpointWeightTest.cpp
@@ -177,7 +177,7 @@ void verifyCheckpointing(PV::Weights &weights, PV::MPIBlock const mpiBlock) {
    for (int a = 0; a < numArbors; a++) {
       float *w            = weights.getData(a);
       int const arborSize = weights.getNumDataPatches() * numItemsInPatch;
-      for (std::size_t d = 0; d < arborSize; d++) {
+      for (int d = 0; d < arborSize; d++) {
          w[d] = std::numeric_limits<float>::infinity();
       }
    }

--- a/tests/CopyConnTest/src/main.cpp
+++ b/tests/CopyConnTest/src/main.cpp
@@ -11,7 +11,6 @@
 int runparamsfile(PV_Init *initObj, char const *paramsfile);
 
 int main(int argc, char *argv[]) {
-   int rank         = 0;
    PV_Init *initObj = new PV_Init(&argc, &argv, false /*allowUnrecognizedArguments*/);
    if (initObj->getParams()) {
       if (initObj->getWorldRank() == 0) {

--- a/tests/DatastoreDelayTest/src/DatastoreDelayTestLayer.hpp
+++ b/tests/DatastoreDelayTest/src/DatastoreDelayTestLayer.hpp
@@ -21,7 +21,7 @@ class DatastoreDelayTestLayer : public HyPerLayer {
   protected:
    void initialize(const char *name, PVParams *params, Communicator const *comm);
 
-   virtual LayerInputBuffer *createLayerInput();
+   virtual LayerInputBuffer *createLayerInput() override;
 
    virtual ActivityComponent *createActivityComponent() override;
 

--- a/tests/FilenameParsingTest/src/FilenameParsingProbe.cpp
+++ b/tests/FilenameParsingTest/src/FilenameParsingProbe.cpp
@@ -81,9 +81,8 @@ PV::Response::Status FilenameParsingProbe::outputState(double simTime, double de
    for (int b = 0; b < localBatchWidth; b++) {
       float const *activity = publisherComponent->getLayerData(0) + b * numExtended;
       int globalBatchIndex  = localBatchStart + b;
-      int imageIndex        = (globalBatchIndex + displayNumber * globalBatchWidth);
-      imageIndex %= (int)mCategories.size();
-      int expectedCategory = mCategories[imageIndex];
+      int imageIndex        = (globalBatchIndex + displayNumber * globalBatchWidth) % numCategories;
+      int expectedCategory  = mCategories[imageIndex];
 
       for (int k = 0; k < numExtended; k++) {
          int f               = featureIndex(k, nxExt, nyExt, loc->nf);

--- a/tests/GPUSystemTest/src/GPUSystemTestProbe.cpp
+++ b/tests/GPUSystemTest/src/GPUSystemTestProbe.cpp
@@ -34,9 +34,6 @@ Response::Status GPUSystemTestProbe::outputState(double simTime, double deltaTim
    }
    auto *targetPublisher = getTargetLayer()->getComponentByType<BasePublisherComponent>();
    PVLayerLoc const *loc = targetPublisher->getLayerLoc();
-   int numExtNeurons     = targetPublisher->getNumExtended() * loc->nbatch;
-   const float *A        = targetPublisher->getLayerData();
-   float sumsq           = 0;
    float tolSigma        = 5e-5;
    for (int b = 0; b < loc->nbatch; b++) {
       // For max std of 5.0fe-5

--- a/tests/GroupNormalizationTest/src/AllConstantValueProbe.cpp
+++ b/tests/GroupNormalizationTest/src/AllConstantValueProbe.cpp
@@ -54,10 +54,7 @@ Response::Status AllConstantValueProbe::outputState(double simTime, double delta
             nbatch != (int)mOutputStreams.size(),
             "Number of output streams for %s does not agree with local batch width.\n",
             getDescription_c());
-      int globalBatchOffset =
-            nbatch * (getMPIBlock()->getStartBatch() + getMPIBlock()->getBatchIndex());
       for (int b = 0; b < nbatch; b++) {
-         int globalBatchIndex = globalBatchOffset + b;
          if (fMin[b] < correctValue - nnzThreshold or fMax[b] > correctValue + nnzThreshold) {
             output(b).printf(
                   "     Values outside of tolerance nnzThreshold=%f\n", (double)nnzThreshold);

--- a/tests/IdentConnTest/src/IdentConnTest.cpp
+++ b/tests/IdentConnTest/src/IdentConnTest.cpp
@@ -35,10 +35,6 @@ int main(int argc, char *argv[]) {
    PV::HyPerLayer *preLayerInh0 = findLayer(hc, std::string("PreLayerInh0"));
    PV::HyPerLayer *preLayerInh1 = findLayer(hc, std::string("PreLayerInh1"));
    PV::HyPerLayer *postLayer    = findLayer(hc, std::string("PostLayer"));
-   PV::IdentConn *exc0          = findIdentConn(hc, std::string("Exc0"));
-   PV::IdentConn *exc1          = findIdentConn(hc, std::string("Exc1"));
-   PV::IdentConn *inh0          = findIdentConn(hc, std::string("Inh0"));
-   PV::IdentConn *inh1          = findIdentConn(hc, std::string("Inh1"));
 
    // Give the pre-layers margins, to test converting from extended to restricted indices as needed
    int xMargin = 3;
@@ -47,7 +43,6 @@ int main(int argc, char *argv[]) {
    setMargins(preLayerExc1, xMargin, yMargin);
    setMargins(preLayerInh0, xMargin, yMargin);
    setMargins(preLayerInh1, xMargin, yMargin);
-   int marginResult;
 
    // IdentConn should check that pre and post have the same # of neurons, but let's make sure.
    int const numNeurons = postLayer->getNumNeurons();
@@ -211,7 +206,6 @@ PV::IdentConn *findIdentConn(PV::HyPerCol &hc, std::string const &connName) {
 void setMargins(PV::HyPerLayer *layer, int const xMargin, int const yMargin) {
    auto *geometry = layer->getComponentByType<PV::LayerGeometry>();
    pvAssert(geometry);
-   int marginResult;
    geometry->requireMarginWidth(xMargin, 'x');
    geometry->requireMarginWidth(yMargin, 'y');
    PVLayerLoc const *loc = geometry->getLayerLoc();

--- a/tests/InitWeightsTest/src/NonsharedConnDebugInitWeights.cpp
+++ b/tests/InitWeightsTest/src/NonsharedConnDebugInitWeights.cpp
@@ -362,19 +362,21 @@ void NonsharedConnDebugInitWeights::cocircCalcWeights(
       int iThPost     = kfPost % noPost;
       float thetaPost = th0Post + iThPost * dThPost;
 
-      int iKvPost        = kfPost % nKurvePost;
-      bool iPosKurvePost = false;
-      bool iSaddlePost   = false;
-      float radKurvPost  = delta_radius_curvature + iKvPost * delta_radius_curvature;
-      float kurvePost    = (radKurvPost != 0.0f) ? 1 / radKurvPost : 1.0f;
-      int iKvPostAdj     = iKvPost;
+      int iKvPost = kfPost % nKurvePost;
+      // InitCocircWeights calculates IPosKurvePost and ISaddlePost as data members,
+      // but this test does not check their values. Possible TODO: add these checks?
+      // bool iPosKurvePost = false;
+      // bool iSaddlePost   = false;
+      float radKurvPost = delta_radius_curvature + iKvPost * delta_radius_curvature;
+      float kurvePost   = (radKurvPost != 0.0f) ? 1 / radKurvPost : 1.0f;
+      int iKvPostAdj    = iKvPost;
       if (POS_KURVE_FLAG) {
          FatalIf(!(nKurvePost >= 2), "Test failed.\n");
-         iPosKurvePost = iKvPost >= (int)(nKurvePost / 2);
+         // iPosKurvePost = iKvPost >= (int)(nKurvePost / 2);
          if (SADDLE_FLAG) {
             FatalIf(!(nKurvePost >= 4), "Test failed.\n");
-            iSaddlePost = (iKvPost % 2 == 0) ? 0 : 1;
-            iKvPostAdj  = ((iKvPost % (nKurvePost / 2)) / 2);
+            // iSaddlePost = (iKvPost % 2 == 0) ? 0 : 1;
+            iKvPostAdj = ((iKvPost % (nKurvePost / 2)) / 2);
          }
          else { // SADDLE_FLAG
             iKvPostAdj = (iKvPost % (nKurvePost / 2));

--- a/tests/InitWeightsTest/src/SharedConnDebugInitWeights.cpp
+++ b/tests/InitWeightsTest/src/SharedConnDebugInitWeights.cpp
@@ -353,19 +353,21 @@ void SharedConnDebugInitWeights::cocircCalcWeights(
       int iThPost     = kfPost % noPost;
       float thetaPost = th0Post + iThPost * dThPost;
 
-      int iKvPost        = kfPost % nKurvePost;
-      bool iPosKurvePost = false;
-      bool iSaddlePost   = false;
-      float radKurvPost  = delta_radius_curvature + iKvPost * delta_radius_curvature;
-      float kurvePost    = (radKurvPost != 0.0f) ? 1 / radKurvPost : 1.0f;
-      int iKvPostAdj     = iKvPost;
+      int iKvPost = kfPost % nKurvePost;
+      // InitCocircWeights calculates IPosKurvePost and ISaddlePost as data members,
+      // but this test does not check their values. Possible TODO: add these checks?
+      // bool iPosKurvePost = false;
+      // bool iSaddlePost   = false;
+      float radKurvPost = delta_radius_curvature + iKvPost * delta_radius_curvature;
+      float kurvePost   = (radKurvPost != 0.0f) ? 1 / radKurvPost : 1.0f;
+      int iKvPostAdj    = iKvPost;
       if (POS_KURVE_FLAG) {
          FatalIf(!(nKurvePost >= 2), "Test failed.\n");
-         iPosKurvePost = iKvPost >= (int)(nKurvePost / 2);
+         // iPosKurvePost = iKvPost >= (int)(nKurvePost / 2);
          if (SADDLE_FLAG) {
             FatalIf(!(nKurvePost >= 4), "Test failed.\n");
-            iSaddlePost = (iKvPost % 2 == 0) ? 0 : 1;
-            iKvPostAdj  = ((iKvPost % (nKurvePost / 2)) / 2);
+            // iSaddlePost = (iKvPost % 2 == 0) ? 0 : 1;
+            iKvPostAdj = ((iKvPost % (nKurvePost / 2)) / 2);
          }
          else { // SADDLE_FLAG
             iKvPostAdj = (iKvPost % (nKurvePost / 2));

--- a/tests/InitWeightsTest/src/SharedConnDebugInitWeights.cpp
+++ b/tests/InitWeightsTest/src/SharedConnDebugInitWeights.cpp
@@ -84,7 +84,6 @@ SharedConnDebugInitWeights::initializeState(std::shared_ptr<InitializeStateMessa
 
 void SharedConnDebugInitWeights::initializeSmartWeights(float *dataStart, int numPatches) {
    auto *weightsPair    = getComponentByType<WeightsPair>();
-   Weights *preWeights  = weightsPair->getPreWeights();
    int overallPatchSize = weightsPair->getPreWeights()->getPatchSizeOverall();
    for (int k = 0; k < numPatches; k++) {
       smartWeights(&dataStart[k * overallPatchSize], dataIndexToUnitCellIndex(k));

--- a/tests/InputLayerNormalizeOffsetTest/src/InputLayerNormalizeOffsetTest.cpp
+++ b/tests/InputLayerNormalizeOffsetTest/src/InputLayerNormalizeOffsetTest.cpp
@@ -252,7 +252,7 @@ void verifyActivity(
                                 false /*no warning if absent*/)
                           != 0;
    FatalIf(
-         !normalizeLuminance,
+         !normalizeStdDev,
          "%s has normalizeStdDev set to false. This test requires it to be true.\n",
          inputName.c_str());
    double stddev = 0.0;

--- a/tests/MPIBlockTest/src/MPIBlockTest.cpp
+++ b/tests/MPIBlockTest/src/MPIBlockTest.cpp
@@ -54,14 +54,25 @@ void run(std::string configString) {
    PV::Arguments arguments{configStream, false /* do not allow unrecognized arguments */};
    PV::Communicator pvCommunicator{&arguments};
 
-   int const numRows            = arguments.getIntegerArgument("NumRows");
-   int const numColumns         = arguments.getIntegerArgument("NumColumns");
-   int const batchWidth         = arguments.getIntegerArgument("BatchWidth");
-   int const numNeededProcesses = numRows * numColumns * batchWidth;
+   int const numRows    = arguments.getIntegerArgument("NumRows");
+   int const numColumns = arguments.getIntegerArgument("NumColumns");
+   int const batchWidth = arguments.getIntegerArgument("BatchWidth");
 
    int const cellNumRows        = arguments.getIntegerArgument("CheckpointCellNumRows");
    int const cellNumColumns     = arguments.getIntegerArgument("CheckpointCellNumColumns");
    int const cellBatchDimension = arguments.getIntegerArgument("CheckpointCellBatchDimension");
+
+   int globalRank;
+   MPI_Comm_rank(pvCommunicator.globalCommunicator(), &globalRank);
+
+   int const globalRowIndex    = pvCommunicator.commRow();
+   int const globalColumnIndex = pvCommunicator.commColumn();
+   int const globalBatchIndex  = pvCommunicator.commBatch();
+
+   int const blockNumRows        = cellNumRows > 0 ? cellNumRows : 1;
+   int const blockNumColumns     = cellNumColumns > 0 ? cellNumColumns : 1;
+   int const blockBatchDimension = cellBatchDimension > 0 ? cellBatchDimension : 1;
+   int const blockSize           = cellNumRows * cellNumColumns * blockBatchDimension;
 
    PV::MPIBlock mpiBlock{pvCommunicator.globalCommunicator(),
                          pvCommunicator.numCommRows(),
@@ -71,15 +82,17 @@ void run(std::string configString) {
                          cellNumColumns,
                          cellBatchDimension};
 
-   int globalRank;
-   MPI_Comm_rank(pvCommunicator.globalCommunicator(), &globalRank);
+   FatalIf(
+         pvCommunicator.globalCommunicator() != mpiBlock.getGlobalComm(),
+         "MPIBlock's global communicator incorrect on global process %d\n",
+         globalRank);
 
-   int const globalRowIndex      = pvCommunicator.commRow();
-   int const globalColumnIndex   = pvCommunicator.commColumn();
-   int const globalBatchIndex    = pvCommunicator.commBatch();
-   int const blockNumRows        = cellNumRows > 0 ? cellNumRows : 1;
-   int const blockNumColumns     = cellNumColumns > 0 ? cellNumColumns : 1;
-   int const blockBatchDimension = cellBatchDimension > 0 ? cellBatchDimension : 1;
+   // Verify global rank
+   FatalIf(
+         mpiBlock.getGlobalRank() != globalRank,
+         "Global process %d returned GlobalRank %d\n",
+         globalRank,
+         mpiBlock.getGlobalRank());
 
    // Verify MPIBlock rank
    int const blockRowIndex    = globalRowIndex % blockNumRows;
@@ -89,19 +102,39 @@ void run(std::string configString) {
          (blockBatchIndex * blockNumRows + blockRowIndex) * blockNumColumns + blockColumnIndex;
    FatalIf(mpiBlock.getRank() != blockRank, "Rank incorrect on global process %d\n", globalRank);
 
-   // Verify SizeRow, SizeColumn, SizeBatch
+   // Verify global dimensions
+   FatalIf(
+         mpiBlock.getGlobalNumRows() != numRows,
+         "GlobalNumRows incorrect on global process %d\n",
+         globalRank);
+   FatalIf(
+         mpiBlock.getGlobalNumColumns() != numColumns,
+         "GlobalNumColumns incorrect on global process %d\n",
+         globalRank);
+   FatalIf(
+         mpiBlock.getGlobalBatchDimension() != batchWidth,
+         "GlobalBatchDimension incorrect on global process %d\n",
+         globalRank);
+
+   // Verify NumRows, NumColumns, BatchDimension
    FatalIf(
          mpiBlock.getNumRows() != blockNumRows,
-         "SizeRow incorrect on global process %d\n",
+         "NumRows incorrect on global process %d\n",
          globalRank);
    FatalIf(
          mpiBlock.getNumColumns() != blockNumColumns,
-         "SizeColumn incorrect on global process %d\n",
+         "NumColumns incorrect on global process %d\n",
          globalRank);
    FatalIf(
          mpiBlock.getBatchDimension() != blockBatchDimension,
-         "SizeBatch incorrect on global process %d\n",
+         "BatchDimension incorrect on global process %d\n",
          globalRank);
+   FatalIf(
+         mpiBlock.getSize() != blockSize,
+         "BatchDimension incorrect on global process %d: %d versus %d\n",
+         globalRank,
+         mpiBlock.getSize(),
+         blockSize);
 
    // Verify RowIndex, ColumnIndex, BatchIndex
    FatalIf(

--- a/tests/MPITest/src/MPITestLayer.hpp
+++ b/tests/MPITest/src/MPITestLayer.hpp
@@ -18,7 +18,7 @@ class MPITestLayer : public PV::HyPerLayer {
 
   protected:
    void initialize(const char *name, PVParams *params, Communicator const *comm);
-   virtual ActivityComponent *createActivityComponent();
+   virtual ActivityComponent *createActivityComponent() override;
 };
 
 } /* namespace PV */

--- a/tests/MaskLayerTest/src/MaskTestInputLayer.cpp
+++ b/tests/MaskLayerTest/src/MaskTestInputLayer.cpp
@@ -28,8 +28,6 @@ Response::Status MaskTestInputLayer::checkUpdateState(double timef, double dt) {
    int nf                = loc->nf;
    int nxGlobal          = loc->nxGlobal;
    int nyGlobal          = loc->nyGlobal;
-   int kx0               = loc->kx0;
-   int ky0               = loc->ky0;
 
    float *A = mActivityComponent->getComponentByType<ActivityBuffer>()->getReadWritePointer();
    // looping over ext

--- a/tests/MaskLayerTest/src/MaskTestLayer.cpp
+++ b/tests/MaskLayerTest/src/MaskTestLayer.cpp
@@ -46,8 +46,6 @@ Response::Status MaskTestLayer::checkUpdateState(double timef, double dt) {
    int nx                = loc->nx;
    int ny                = loc->ny;
    int nf                = loc->nf;
-   int kx0               = loc->kx0;
-   int ky0               = loc->ky0;
 
    bool isCorrect = true;
    for (int b = 0; b < loc->nbatch; b++) {

--- a/tests/MaxPoolTest/src/GateMaxPoolTestBuffer.cpp
+++ b/tests/MaxPoolTest/src/GateMaxPoolTestBuffer.cpp
@@ -22,15 +22,10 @@ void GateMaxPoolTestBuffer::updateBufferCPU(double simTime, double deltaTime) {
    }
 
    // Grab layer size
-   const PVLayerLoc *loc = getLayerLoc();
-   int nx                = loc->nx;
-   int ny                = loc->ny;
-   int nf                = loc->nf;
-   int kx0               = loc->kx0;
-   int ky0               = loc->ky0;
+   const int nbatch = getLayerLoc()->nbatch;
 
    bool isCorrect = true;
-   for (int b = 0; b < loc->nbatch; b++) {
+   for (int b = 0; b < nbatch; b++) {
       float const *GSynExt = mLayerInput->getBufferData(b, CHANNEL_EXC); // gated
       float const *GSynInh = mLayerInput->getBufferData(b, CHANNEL_INH); // gt
 

--- a/tests/MomentumConnSimpleCheckpointerTest/src/MomentumConnSimpleCheckpointerTestProbe.cpp
+++ b/tests/MomentumConnSimpleCheckpointerTest/src/MomentumConnSimpleCheckpointerTestProbe.cpp
@@ -204,10 +204,9 @@ MomentumConnSimpleCheckpointerTestProbe::readStateFromCheckpoint(PV::Checkpointe
    return PV::Response::SUCCESS;
 }
 
-void MomentumConnSimpleCheckpointerTestProbe::initializeCorrectValues(double timevalue) {
-   int const updateNumber = mStartingTimestamp + timevalue;
-   auto *momentumUpdater  = mConnection->getComponentByType<PV::MomentumUpdater>();
-   float const tau        = momentumUpdater->getTimeConstantTau();
+void MomentumConnSimpleCheckpointerTestProbe::initializeCorrectValues() {
+   auto *momentumUpdater = mConnection->getComponentByType<PV::MomentumUpdater>();
+   float const tau       = momentumUpdater->getTimeConstantTau();
    mCorrectState =
          new CorrectState(tau, 1.0f /*weight*/, 0.0f /*dw*/, 1.0f /*input*/, 1.0f /*output*/);
 }
@@ -215,7 +214,7 @@ void MomentumConnSimpleCheckpointerTestProbe::initializeCorrectValues(double tim
 PV::Response::Status
 MomentumConnSimpleCheckpointerTestProbe::outputState(double simTime, double deltaTime) {
    if (!mValuesSet) {
-      initializeCorrectValues(simTime);
+      initializeCorrectValues();
       mValuesSet = true;
    }
    int const updateNumber = mStartingTimestamp + simTime;

--- a/tests/MomentumConnSimpleCheckpointerTest/src/MomentumConnSimpleCheckpointerTestProbe.hpp
+++ b/tests/MomentumConnSimpleCheckpointerTest/src/MomentumConnSimpleCheckpointerTestProbe.hpp
@@ -78,7 +78,7 @@ class MomentumConnSimpleCheckpointerTestProbe : public PV::ColProbe {
     */
    PV::Response::Status checkCommunicatedFlag(PV::BaseObject *dependencyObject);
 
-   void initializeCorrectValues(double timevalue);
+   void initializeCorrectValues();
 
    bool verifyConnection(
          PV::ComponentBasedObject *connection,

--- a/tests/MomentumConnViscosityCheckpointerTest/src/MomentumConnViscosityCheckpointerTestProbe.cpp
+++ b/tests/MomentumConnViscosityCheckpointerTest/src/MomentumConnViscosityCheckpointerTestProbe.cpp
@@ -201,11 +201,10 @@ PV::Response::Status MomentumConnViscosityCheckpointerTestProbe::readStateFromCh
    return PV::Response::SUCCESS;
 }
 
-void MomentumConnViscosityCheckpointerTestProbe::initializeCorrectValues(double timevalue) {
-   int const updateNumber = mStartingTimestamp + timevalue;
-   auto *momentumUpdater  = mConnection->getComponentByType<PV::MomentumUpdater>();
-   float const tau        = momentumUpdater->getTimeConstantTau();
-   float const tau_exp    = std::exp(-1.0f / tau);
+void MomentumConnViscosityCheckpointerTestProbe::initializeCorrectValues() {
+   auto *momentumUpdater = mConnection->getComponentByType<PV::MomentumUpdater>();
+   float const tau       = momentumUpdater->getTimeConstantTau();
+   float const tau_exp   = std::exp(-1.0f / tau);
    mCorrectState =
          new CorrectState(tau_exp, 1.0f /*weight*/, 0.0f /*dw*/, 1.0f /*input*/, 1.0f /*output*/);
 }
@@ -213,7 +212,7 @@ void MomentumConnViscosityCheckpointerTestProbe::initializeCorrectValues(double 
 PV::Response::Status
 MomentumConnViscosityCheckpointerTestProbe::outputState(double simTime, double deltaTime) {
    if (!mValuesSet) {
-      initializeCorrectValues(simTime);
+      initializeCorrectValues();
       mValuesSet = true;
    }
    int const updateNumber = mStartingTimestamp + simTime;

--- a/tests/MomentumConnViscosityCheckpointerTest/src/MomentumConnViscosityCheckpointerTestProbe.hpp
+++ b/tests/MomentumConnViscosityCheckpointerTest/src/MomentumConnViscosityCheckpointerTestProbe.hpp
@@ -78,7 +78,7 @@ class MomentumConnViscosityCheckpointerTestProbe : public PV::ColProbe {
     */
    PV::Response::Status checkCommunicatedFlag(PV::BaseObject *dependencyObject);
 
-   void initializeCorrectValues(double timevalue);
+   void initializeCorrectValues();
 
    bool verifyConnection(
          PV::ComponentBasedObject *connection,

--- a/tests/MomentumTest/src/MomentumConnTestProbe.cpp
+++ b/tests/MomentumTest/src/MomentumConnTestProbe.cpp
@@ -55,7 +55,6 @@ Response::Status MomentumConnTestProbe::outputState(double simTime, double delta
             getKernelIndex(),
             getArbor());
    }
-   float const *dw = getDeltaWeightData() + getKernelIndex() * patchSize;
 
    int status = PV_SUCCESS;
    for (int k = 0; k < patchSize; k++) {
@@ -71,12 +70,14 @@ Response::Status MomentumConnTestProbe::outputState(double simTime, double delta
       }
 
       if (fabs(((double)(wObserved - wCorrect)) / simTime) > 1e-6) {
-         int y = kyPos(k, nxp, nyp, nfp);
-         int f = featureIndex(k, nxp, nyp, nfp);
+         // int x = kxPos(k, nxp, nyp, nfp);
+         // int y = kyPos(k, nxp, nyp, nfp);
+         // int f = featureIndex(k, nxp, nyp, nfp);
          output(0).printf("        w = %f, should be %f\n", (double)wObserved, (double)wCorrect);
-         exit(EXIT_FAILURE);
+         status = PV_FAILURE;
       }
    }
+   FatalIf(status != PV_SUCCESS, "%s found incorrect weights.\n", getDescription_c());
 
    return Response::SUCCESS;
 }

--- a/tests/MtoNOutputStateTest/src/IndexInternalState.cpp
+++ b/tests/MtoNOutputStateTest/src/IndexInternalState.cpp
@@ -41,7 +41,6 @@ IndexInternalState::initializeState(std::shared_ptr<InitializeStateMessage const
 
 void IndexInternalState::updateBufferCPU(double simTime, double deltaTime) {
    PVLayerLoc const *loc = getLayerLoc();
-   PVHalo const &halo    = loc->halo;
    int const numNeurons  = loc->nx * loc->ny * loc->nf;
    pvAssert(numNeurons == getBufferSize());
    int const numGlobalNeurons = loc->nxGlobal * loc->nyGlobal * loc->nf;

--- a/tests/NormalizeSubclassSystemTest/src/NormalizeL3.cpp
+++ b/tests/NormalizeSubclassSystemTest/src/NormalizeL3.cpp
@@ -69,8 +69,6 @@ int NormalizeL3::normalizeWeights() {
                int nxp               = weights->getPatchSizeX();
                int nyp               = weights->getPatchSizeY();
                int nfp               = weights->getPatchSizeF();
-               int xPatchStride      = weights->getPatchStrideX();
-               int yPatchStride      = weights->getPatchStrideY();
                int weights_per_patch = nxp * nyp * nfp;
                float *dataStartPatch = weights->getData(arborID) + patchindex * weights_per_patch;
                for (int k = 0; k < weights_per_patch; k++) {
@@ -108,8 +106,6 @@ int NormalizeL3::normalizeWeights() {
                int nxp               = weights->getPatchSizeX();
                int nyp               = weights->getPatchSizeY();
                int nfp               = weights->getPatchSizeF();
-               int xPatchStride      = weights->getPatchStrideX();
-               int yPatchStride      = weights->getPatchStrideY();
                int weights_per_patch = nxp * nyp * nfp;
                float *dataStartPatch = weights->getData(arborID) + patchindex * weights_per_patch;
                for (int k = 0; k < weights_per_patch; k++) {

--- a/tests/PatchGeometryTest/src/PatchGeometryTest.cpp
+++ b/tests/PatchGeometryTest/src/PatchGeometryTest.cpp
@@ -107,8 +107,7 @@ void testOneToOneExtended() {
    patchGeometry.allocateDataStructures();
 
    int numPatches         = patchGeometry.getNumPatches();
-   int expectedNumPatches = (preLoc.nx + preLoc.halo.lt + preLoc.halo.rt)
-                            * (preLoc.ny + preLoc.halo.dn + preLoc.halo.up) * preLoc.nf;
+   int expectedNumPatches = nxExt * nyExt * preLoc.nf;
    FatalIf(
          numPatches != expectedNumPatches,
          "%s: expected %d patches; there were %d.\n",
@@ -125,7 +124,6 @@ void testOneToOneExtended() {
       int numPatchesF = patchGeometry.getNumPatchesF();
       int xIndex      = kxPos(p, numPatchesX, numPatchesY, numPatchesF);
       int yIndex      = kyPos(p, numPatchesX, numPatchesY, numPatchesF);
-      int fIndex      = featureIndex(p, numPatchesX, numPatchesY, numPatchesF);
 
       auto &patch = patchGeometry.getPatch(p);
 
@@ -262,10 +260,10 @@ void testOneToManyExtended() {
    postLoc.nx      = preLoc.nx * tstride;
    postLoc.ny      = preLoc.ny * tstride;
    postLoc.nf      = 10;
-   postLoc.halo.lt = preMargin * tstride;
-   postLoc.halo.rt = preMargin * tstride;
-   postLoc.halo.dn = preMargin * tstride;
-   postLoc.halo.up = preMargin * tstride;
+   postLoc.halo.lt = postMargin;
+   postLoc.halo.rt = postMargin;
+   postLoc.halo.dn = postMargin;
+   postLoc.halo.up = postMargin;
    // Other fields of preLoc, postLoc are not used.
 
    int nxp = (2 * preMargin + 1) * tstride;
@@ -279,8 +277,7 @@ void testOneToManyExtended() {
    patchGeometry.allocateDataStructures();
 
    int numPatches         = patchGeometry.getNumPatches();
-   int expectedNumPatches = (preLoc.nx + preLoc.halo.lt + preLoc.halo.rt)
-                            * (preLoc.ny + preLoc.halo.dn + preLoc.halo.up) * preLoc.nf;
+   int expectedNumPatches = nxExt * nyExt * preLoc.nf;
    FatalIf(
          numPatches != expectedNumPatches,
          "%s: expected %d patches; there were %d.\n",
@@ -301,11 +298,6 @@ void testOneToManyExtended() {
                   patchGeometry.getNumPatchesX(),
                   patchGeometry.getNumPatchesY(),
                   patchGeometry.getNumPatchesF());
-      int fIndex = featureIndex(
-            p,
-            patchGeometry.getNumPatchesX(),
-            patchGeometry.getNumPatchesY(),
-            patchGeometry.getNumPatchesF());
 
       auto &patch = patchGeometry.getPatch(p);
 
@@ -457,9 +449,6 @@ void testManyToOneExtended() {
    int nyp = 2 * postMargin + 1;
    int nfp = 10;
 
-   int xStride = preLoc.nx / postLoc.nx;
-   int yStride = preLoc.ny / postLoc.ny;
-
    int nxExt = preLoc.nx + preLoc.halo.lt + preLoc.halo.rt;
    int nyExt = preLoc.ny + preLoc.halo.dn + preLoc.halo.up;
 
@@ -467,8 +456,7 @@ void testManyToOneExtended() {
    patchGeometry.allocateDataStructures();
 
    int numPatches         = patchGeometry.getNumPatches();
-   int expectedNumPatches = (preLoc.nx + preLoc.halo.lt + preLoc.halo.rt)
-                            * (preLoc.ny + preLoc.halo.dn + preLoc.halo.up) * preLoc.nf;
+   int expectedNumPatches = nxExt * nyExt * preLoc.nf;
    FatalIf(
          numPatches != expectedNumPatches,
          "%s: expected %d patches; there were %d.\n",
@@ -497,11 +485,6 @@ void testManyToOneExtended() {
                   patchGeometry.getNumPatchesX(),
                   patchGeometry.getNumPatchesY(),
                   patchGeometry.getNumPatchesF());
-      int fIndex = featureIndex(
-            p,
-            patchGeometry.getNumPatchesX(),
-            patchGeometry.getNumPatchesY(),
-            patchGeometry.getNumPatchesF());
 
       auto &patch = patchGeometry.getPatch(p);
 

--- a/tests/PatchGeometryTest/src/PatchGeometryTest.cpp
+++ b/tests/PatchGeometryTest/src/PatchGeometryTest.cpp
@@ -2,6 +2,7 @@
  * PatchGeometryTest.cpp
  */
 
+#include <cinttypes>
 #include <components/PatchGeometry.hpp>
 #include <string.h>
 #include <utils/PVLog.hpp>
@@ -115,7 +116,8 @@ void testOneToOneExtended() {
          preLoc.nx * preLoc.ny * preLoc.nf,
          numPatches);
 
-   std::vector<int> const correctSizes{1, 2, 3, 4, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 4, 3, 2, 1};
+   std::vector<uint16_t> const correctSizes{1, 2, 3, 4, 5, 5, 5, 5, 5, 5,
+                                            5, 5, 5, 5, 5, 5, 4, 3, 2, 1};
    std::vector<int> const correctStarts{4, 3, 2, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0};
    for (int p = 0; p < numPatches; p++) {
       int numPatchesX = patchGeometry.getNumPatchesX();
@@ -130,13 +132,13 @@ void testOneToOneExtended() {
       int correctNx = correctSizes[xIndex];
       int correctNy = correctSizes[yIndex];
 
-      int correctStartX = correctStarts[xIndex];
-      int correctStartY = correctStarts[yIndex];
-      int correctOffset = kIndex(correctStartX, correctStartY, 0, nxp, nyp, nfp);
+      uint16_t correctStartX = correctStarts[xIndex];
+      uint16_t correctStartY = correctStarts[yIndex];
+      auto correctOffset     = (uint32_t)kIndex(correctStartX, correctStartY, 0, nxp, nyp, nfp);
       FatalIf(
             patch.nx != correctNx or patch.ny != correctNy or patch.offset != correctOffset,
-            "%s: patch %d is (nx=%d, ny=%d, offset=%d) instead of "
-            "expected (nx=%d, ny=%d, offset=%d).\n",
+            "%s: patch %d is (nx=%" PRIu16 ", ny=%" PRIu16 ", offset=%" PRIu32 ") instead of "
+            "expected (nx=%" PRIu16 ", ny=%" PRIu16 ", offset=%" PRIu32 ").\n",
             name.c_str(),
             p,
             patch.nx,
@@ -286,7 +288,7 @@ void testOneToManyExtended() {
          expectedNumPatches,
          numPatches);
 
-   std::vector<int> const correctSizes{4, 8, 12, 12, 8, 4};
+   std::vector<uint16_t> const correctSizes{4, 8, 12, 12, 8, 4};
    std::vector<int> const correctStarts{8, 4, 0, 0, 0, 0};
    for (int p = 0; p < numPatches; p++) {
       int xIndex =
@@ -307,16 +309,16 @@ void testOneToManyExtended() {
 
       auto &patch = patchGeometry.getPatch(p);
 
-      int correctNx = correctSizes[xIndex];
-      int correctNy = correctSizes[yIndex];
+      uint16_t correctNx = correctSizes[xIndex];
+      uint16_t correctNy = correctSizes[yIndex];
 
-      int correctStartX = correctStarts[xIndex];
-      int correctStartY = correctStarts[yIndex];
-      int correctOffset = kIndex(correctStartX, correctStartY, 0, nxp, nyp, nfp);
+      int correctStartX  = correctStarts[xIndex];
+      int correctStartY  = correctStarts[yIndex];
+      auto correctOffset = (uint32_t)kIndex(correctStartX, correctStartY, 0, nxp, nyp, nfp);
       FatalIf(
             patch.nx != correctNx or patch.ny != correctNy or patch.offset != correctOffset,
-            "%s: patch %d is (nx=%d, ny=%d, offset=%d) instead of "
-            "expected (nx=%d, ny=%d, offset=%d).\n",
+            "%s: patch %d is (nx=%" PRIu16 ", ny=%" PRIu16 ", offset=%" PRIu32 ") instead of "
+            "expected (nx=%" PRIu16 ", ny=%" PRIu16 ", offset=%" PRIu32 ").\n",
             name.c_str(),
             p,
             patch.nx,
@@ -474,7 +476,7 @@ void testManyToOneExtended() {
          expectedNumPatches,
          numPatches);
 
-   std::vector<int> correctSizes(nxExt, nxp);
+   std::vector<uint16_t> correctSizes(nxExt, nxp);
    std::vector<int> correctStarts(nxExt, 0);
    for (int k = 0; k < 4; k++) {
       correctSizes[k]      = 1;
@@ -503,16 +505,16 @@ void testManyToOneExtended() {
 
       auto &patch = patchGeometry.getPatch(p);
 
-      int correctNx = correctSizes[xIndex];
-      int correctNy = correctSizes[yIndex];
+      uint16_t correctNx = correctSizes[xIndex];
+      uint16_t correctNy = correctSizes[yIndex];
 
-      int correctStartX = correctStarts[xIndex];
-      int correctStartY = correctStarts[yIndex];
-      int correctOffset = kIndex(correctStartX, correctStartY, 0, nxp, nyp, nfp);
+      int correctStartX  = correctStarts[xIndex];
+      int correctStartY  = correctStarts[yIndex];
+      auto correctOffset = (uint32_t)kIndex(correctStartX, correctStartY, 0, nxp, nyp, nfp);
       FatalIf(
             patch.nx != correctNx or patch.ny != correctNy or patch.offset != correctOffset,
-            "%s: patch %d is (nx=%d, ny=%d, offset=%d) instead of "
-            "expected (nx=%d, ny=%d, offset=%d).\n",
+            "%s: patch %d is (nx=%" PRIu16 ", ny=%" PRIu16 ", offset=%" PRIu32 ") instead of "
+            "expected (nx=%" PRIu16 ", ny=%" PRIu16 ", offset=%" PRIu32 ").\n",
             name.c_str(),
             p,
             patch.nx,

--- a/tests/PlasticCloneConnTest/src/WeightComparisonProbe.cpp
+++ b/tests/PlasticCloneConnTest/src/WeightComparisonProbe.cpp
@@ -68,6 +68,10 @@ Response::Status WeightComparisonProbe::allocateDataStructures() {
       int const numArbors = c->getComponentByType<ArborList>()->getNumAxonalArbors();
       auto *preWeights    = c->getComponentByType<WeightsPair>()->getPreWeights();
       auto *patchSize     = c->getComponentByType<PatchSize>();
+      numPatches          = preWeights->getNumDataPatches();
+      nxp                 = patchSize->getPatchSizeX();
+      nyp                 = patchSize->getPatchSizeY();
+      nfp                 = patchSize->getPatchSizeF();
       if (initialized) {
          FatalIf(
                numArbors != mNumArbors,
@@ -75,8 +79,8 @@ Response::Status WeightComparisonProbe::allocateDataStructures() {
                firstConn.c_str(),
                c->getDescription_c());
          FatalIf(
-               numPatches != preWeights->getNumDataPatches(),
-               "%s and %s have different numbers of data patches.\n",
+               mNumWeightsInArbor != nxp * nyp * nfp * numPatches,
+               "%s and %s have different numbers of data weights.\n",
                firstConn.c_str(),
                c->getDescription_c());
          auto *patchSize = c->getComponentByType<PatchSize>();
@@ -99,11 +103,7 @@ Response::Status WeightComparisonProbe::allocateDataStructures() {
       else {
          firstConn          = c->getDescription();
          mNumArbors         = numArbors;
-         numPatches         = preWeights->getNumDataPatches();
-         nxp                = patchSize->getPatchSizeX();
-         nyp                = patchSize->getPatchSizeY();
-         nfp                = patchSize->getPatchSizeF();
-         mNumWeightsInArbor = (std::size_t)(nxp * nyp * nfp * numPatches);
+         mNumWeightsInArbor = nxp * nyp * nfp * numPatches;
          initialized        = true;
       }
    }
@@ -117,7 +117,7 @@ Response::Status WeightComparisonProbe::outputState(double simTime, double delta
       for (int a = 0; a < mNumArbors; a++) {
          float *firstConnWeightData = firstConnWeights->getData(a);
          float *thisConnWeightData  = thisConnWeights->getData(a);
-         std::size_t memsize        = sizeof(float) * mNumWeightsInArbor;
+         std::size_t memsize        = sizeof(float) * (std::size_t)mNumWeightsInArbor;
          FatalIf(
                memcmp(firstConnWeightData, thisConnWeightData, memsize) != 0,
                "%s and %s do not have the same weights.\n",

--- a/tests/PlasticCloneConnTest/src/WeightComparisonProbe.hpp
+++ b/tests/PlasticCloneConnTest/src/WeightComparisonProbe.hpp
@@ -65,7 +65,7 @@ class WeightComparisonProbe : public PV::ColProbe {
   private:
    std::vector<PV::ComponentBasedObject *> mConnectionList;
    int mNumArbors;
-   std::size_t mNumWeightsInArbor;
+   int mNumWeightsInArbor;
 }; // end class WeightComparisonProbe
 } // end namespace PV
 

--- a/tests/PlasticConnTest/src/PlasticConnTestLayer.hpp
+++ b/tests/PlasticConnTest/src/PlasticConnTestLayer.hpp
@@ -18,7 +18,7 @@ class PlasticConnTestLayer : public PV::HyPerLayer {
 
   protected:
    void initialize(const char *name, PVParams *params, Communicator const *comm);
-   virtual ActivityComponent *createActivityComponent();
+   virtual ActivityComponent *createActivityComponent() override;
 }; // end class PlasticConnTestLayer
 
 } // end namespace PV

--- a/tests/PoolingConnCheckpointerTest/src/PoolingConnCheckpointerTestProbe.cpp
+++ b/tests/PoolingConnCheckpointerTest/src/PoolingConnCheckpointerTestProbe.cpp
@@ -254,7 +254,7 @@ bool PoolingConnCheckpointerTestProbe::verifyLayer(
          int *recvBuffer = &badIndicesGlobal.at(r * numNeurons);
          MPI_Irecv(recvBuffer, numNeurons, MPI_INT, r, 211, comm->communicator(), &requests[r - 1]);
       }
-      int status = MPI_Waitall(requests.size(), requests.data(), MPI_STATUSES_IGNORE);
+      MPI_Waitall(requests.size(), requests.data(), MPI_STATUSES_IGNORE);
       badIndicesGlobal.erase(
             std::remove_if(
                   badIndicesGlobal.begin(), badIndicesGlobal.end(), [](int j) { return j < 0; }),

--- a/tests/ReceiveFromPostTest/src/ReceiveFromPostProbe.cpp
+++ b/tests/ReceiveFromPostTest/src/ReceiveFromPostProbe.cpp
@@ -49,31 +49,10 @@ Response::Status ReceiveFromPostProbe::outputState(double simTime, double deltaT
       return status;
    }
    auto *publisherComponent = getTargetLayer()->getComponentByType<BasePublisherComponent>();
-   const PVLayerLoc *loc    = publisherComponent->getLayerLoc();
-   int numExtNeurons        = publisherComponent->getNumExtended();
-   const float *A           = publisherComponent->getLayerData();
-   bool failed              = false;
+   int numExtNeurons = publisherComponent->getNumExtended();
+   const float *A    = publisherComponent->getLayerData();
+   bool failed       = false;
    for (int i = 0; i < numExtNeurons; i++) {
-      if (fabsf(A[i]) != 0) {
-         int xpos =
-               kxPos(i,
-                     loc->nx + loc->halo.lt + loc->halo.rt,
-                     loc->ny + loc->halo.dn + loc->halo.up,
-                     loc->nf);
-         int ypos =
-               kyPos(i,
-                     loc->nx + loc->halo.lt + loc->halo.rt,
-                     loc->ny + loc->halo.dn + loc->halo.up,
-                     loc->nf);
-         int fpos = featureIndex(
-               i,
-               loc->nx + loc->halo.lt + loc->halo.rt,
-               loc->ny + loc->halo.dn + loc->halo.up,
-               loc->nf);
-         // InfoLog() << "[" << xpos << "," << ypos << "," << fpos << "] = " << std::fixed << A[i]
-         // <<
-         // "\n";
-      }
       // For roundoff errors
       if (fabsf(A[i]) >= tolerance) {
          ErrorLog().printf(

--- a/tests/ReduceAcrossBatchTest/src/main.cpp
+++ b/tests/ReduceAcrossBatchTest/src/main.cpp
@@ -74,5 +74,5 @@ int checkWeights(HyPerCol *hc, int argc, char *argv[]) {
                     << weights[k] << "\n";
       }
    }
-   return PV_SUCCESS;
+   return status;
 }

--- a/tests/ResetStateOnTriggerTest/src/ResetStateOnTriggerTestProbe.cpp
+++ b/tests/ResetStateOnTriggerTest/src/ResetStateOnTriggerTestProbe.cpp
@@ -22,7 +22,6 @@ void ResetStateOnTriggerTestProbe::initialize(
       char const *name,
       PV::PVParams *params,
       PV::Communicator const *comm) {
-   int status = PV_SUCCESS;
    PV::LayerProbe::initialize(name, params, comm);
 }
 
@@ -89,7 +88,6 @@ PV::Response::Status ResetStateOnTriggerTestProbe::outputState(double simTime, d
    if (probeStatus != 0) {
       int nBatch = getNumValues();
       pvAssert((std::size_t)nBatch == mOutputStreams.size());
-      int batchOffset = nBatch * (getMPIBlock()->getStartBatch() + getMPIBlock()->getBatchIndex());
       int globalBatchSize = nBatch * getMPIBlock()->getGlobalBatchDimension();
       for (int localBatchIndex = 0; localBatchIndex < nBatch; localBatchIndex++) {
          int nnz = (int)nearbyint(getValuesBuffer()[localBatchIndex]);
@@ -104,7 +102,6 @@ PV::Response::Status ResetStateOnTriggerTestProbe::outputState(double simTime, d
                         nnz == 1 ? " has" : "s have");
          }
          else {
-            int globalBatchIndex = localBatchIndex + batchOffset;
             output(localBatchIndex)
                   .printf(
                         "%s t=%f, batch element %d, %d neuron%s the wrong value.\n",

--- a/tests/ResetStateOnTriggerTest/src/ResetStateOnTriggerTestProbe.cpp
+++ b/tests/ResetStateOnTriggerTest/src/ResetStateOnTriggerTestProbe.cpp
@@ -88,7 +88,7 @@ PV::Response::Status ResetStateOnTriggerTestProbe::outputState(double simTime, d
    }
    if (probeStatus != 0) {
       int nBatch = getNumValues();
-      pvAssert(nBatch == mOutputStreams.size());
+      pvAssert((std::size_t)nBatch == mOutputStreams.size());
       int batchOffset = nBatch * (getMPIBlock()->getStartBatch() + getMPIBlock()->getBatchIndex());
       int globalBatchSize = nBatch * getMPIBlock()->getGlobalBatchDimension();
       for (int localBatchIndex = 0; localBatchIndex < nBatch; localBatchIndex++) {

--- a/tests/SegmentTest/src/AssertZerosProbe.cpp
+++ b/tests/SegmentTest/src/AssertZerosProbe.cpp
@@ -40,7 +40,6 @@ Response::Status AssertZerosProbe::outputState(double simTime, double deltaTime)
    const float *GSyn_I          = targetLayerInputBuffer->getChannelData(CHANNEL_INH);
 
    // getOutputStream().precision(15);
-   float sumsq = 0;
    for (int i = 0; i < numExtNeurons; i++) {
       FatalIf(fabsf(A[i]) >= 5e-4f, "Test failed.\n");
    }

--- a/tests/SegmentTest/src/SegmentifyTest.cpp
+++ b/tests/SegmentTest/src/SegmentifyTest.cpp
@@ -67,25 +67,9 @@ int SegmentifyTest::checkOutputVals(int yi, int xi, int fi, float targetVal, flo
    char const *outputMethod = mSegmentifyBuffer->getOutputMethod();
 
    if (strcmp(outputMethod, "centroid") == 0) {
-      int centX, centY;
-      if (newXi == 0) {
-         centX = 1;
-      }
-      else if (newXi == 1) {
-         centX = 4;
-      }
-      else if (newXi == 2) {
-         centX = 6;
-      }
-      if (newYi == 0) {
-         centY = 1;
-      }
-      else if (newYi == 1) {
-         centY = 4;
-      }
-      else if (newYi == 2) {
-         centY = 6;
-      }
+      int centX = newXi == 0 ? 1 : newXi == 1 ? 4 : newXi == 2 ? 6 : -1;
+      int centY = newYi == 0 ? 1 : newYi == 1 ? 4 : newYi == 2 ? 6 : -1;
+      FatalIf(centX < 0 or centY < 0, "Test failed.\n");
 
       if (xi == centX && yi == centY) {
          FatalIf(!(actualVal == targetVal), "Test failed.\n");

--- a/tests/SegmentTest/src/SegmentifyTest.cpp
+++ b/tests/SegmentTest/src/SegmentifyTest.cpp
@@ -32,7 +32,6 @@ void SegmentifyTest::createComponentTable(char const *description) {
  * 7 7 7 8 8 8 9 9
  */
 float SegmentifyTest::getTargetVal(int yi, int xi, int fi) {
-   const PVLayerLoc *loc = getLayerLoc();
    // We can convert yi and xi to an index between 0 and 2
    int newYi               = yi / 3;
    int newXi               = xi / 3;
@@ -62,11 +61,9 @@ float SegmentifyTest::getTargetVal(int yi, int xi, int fi) {
 }
 
 int SegmentifyTest::checkOutputVals(int yi, int xi, int fi, float targetVal, float actualVal) {
-   const PVLayerLoc *loc = getLayerLoc();
    // We can convert yi and xi to an index between 0 and 2
    int newYi                = yi / 3;
    int newXi                = xi / 3;
-   int segmentLabel         = newYi * 3 + newXi + 1;
    char const *outputMethod = mSegmentifyBuffer->getOutputMethod();
 
    if (strcmp(outputMethod, "centroid") == 0) {

--- a/tests/Shared/ColumnArchive.cpp
+++ b/tests/Shared/ColumnArchive.cpp
@@ -115,7 +115,6 @@ bool ColumnArchive::operator==(ColumnArchive const &comparison) const {
 
    areEqual &= compareFields(
          "The columns", "numbers of connections", m_conndata.size(), comparison.m_conndata.size());
-   int const nc = m_conndata.size();
    for (auto const &conn1 : m_conndata) {
       bool found = false;
       for (auto const &conn2 : comparison.m_conndata) {

--- a/tests/Shared/ColumnArchive.cpp
+++ b/tests/Shared/ColumnArchive.cpp
@@ -45,7 +45,7 @@ bool LayerArchive::operator==(LayerArchive const &comparison) const {
                int const f = featureIndex(n, nx, ny, nf);
                std::stringstream fieldstream("");
                fieldstream << "values in batch element " << b << " at x=" << x << ",y=" << y
-                           << ",f=";
+                           << ",f=" << f;
                compareFields("Activities", fieldstream.str().c_str(), dat1[nExt1], dat2[nExt2]);
                areEqual = false;
             }
@@ -80,7 +80,7 @@ bool ConnArchive::operator==(ConnArchive const &comparison) const {
                   int const f = featureIndex(widx, nxp, nyp, nfp);
                   std::stringstream fieldstream("");
                   fieldstream << "values in data patch " << patchIdx << " at x=" << x << ",y=" << y
-                              << ",f=";
+                              << ",f=" << f;
                   compareFields(
                         "Weights", fieldstream.str().c_str(), patchdata1[widx], patchdata2[widx]);
                   areEqual = false;

--- a/tests/Shared/ColumnArchive.cpp
+++ b/tests/Shared/ColumnArchive.cpp
@@ -73,7 +73,7 @@ bool ConnArchive::operator==(ConnArchive const &comparison) const {
          for (int patchIdx = 0; patchIdx < numDataPatches; patchIdx++) {
             float const *patchdata1 = &arbor1.data()[patchIdx * patchSize];
             float const *patchdata2 = &arbor2.data()[patchIdx * patchSize];
-            for (int widx; widx < patchSize; widx++) {
+            for (int widx = 0; widx < patchSize; widx++) {
                if (std::fabs(patchdata1[widx] - patchdata2[widx]) > tolerance) {
                   int const x = kxPos(widx, nxp, nyp, nfp);
                   int const y = kyPos(widx, nxp, nyp, nfp);

--- a/tests/Shared/IncrementingWeightUpdater.cpp
+++ b/tests/Shared/IncrementingWeightUpdater.cpp
@@ -30,7 +30,9 @@ int IncrementingWeightUpdater::updateWeights(int arborId) {
       float *Wdata  = mWeights->getDataFromDataIndex(arborId, patchIndex);
       float *dWdata = mDeltaWeights->getDataFromDataIndex(arborId, patchIndex);
       for (int k = 0; k < nPatch; k++) {
-         Wdata[k] += 1.0f;
+         float const dw = 1.0f;
+         dWdata[k]      = dw;
+         Wdata[k] += dw;
       }
    }
    return PV_SUCCESS;

--- a/tests/Shared/IncrementingWeightUpdater.hpp
+++ b/tests/Shared/IncrementingWeightUpdater.hpp
@@ -24,7 +24,7 @@ class IncrementingWeightUpdater : public HebbianUpdater {
 
    void initialize(char const *name, PVParams *params, Communicator const *comm);
 
-   virtual int updateWeights(int arborId);
+   virtual int updateWeights(int arborId) override;
 };
 
 } // namespace PV

--- a/tests/ShrunkenPatchTest/src/ShrunkenPatchTestLayer.hpp
+++ b/tests/ShrunkenPatchTest/src/ShrunkenPatchTestLayer.hpp
@@ -18,7 +18,7 @@ class ShrunkenPatchTestLayer : public PV::HyPerLayer {
 
   protected:
    void initialize(const char *name, PVParams *params, Communicator const *comm);
-   virtual ActivityComponent *createActivityComponent();
+   virtual ActivityComponent *createActivityComponent() override;
 };
 
 } /* namespace PV */

--- a/tests/SumPoolTest/src/GateSumPoolTestBuffer.cpp
+++ b/tests/SumPoolTest/src/GateSumPoolTestBuffer.cpp
@@ -20,11 +20,7 @@ void GateSumPoolTestBuffer::updateBufferCPU(double simTime, double deltaTime) {
    const PVLayerLoc *loc = getLayerLoc();
    int nx                = loc->nx;
    int ny                = loc->ny;
-   int nxGlobal          = loc->nxGlobal;
-   int nyGlobal          = loc->nyGlobal;
    int nf                = loc->nf;
-   int kx0               = loc->kx0;
-   int ky0               = loc->ky0;
 
    bool isCorrect = true;
    // Grab the activity layer of current layer
@@ -44,10 +40,10 @@ void GateSumPoolTestBuffer::updateBufferCPU(double simTime, double deltaTime) {
 
                float actualvalue = A[ext_idx];
 
-               int xval = (iX + kx0 - loc->halo.lt) / 2;
-               int yval = (iY + ky0 - loc->halo.up) / 2;
-               FatalIf(!(xval >= 0 && xval < loc->nxGlobal), "Test failed.\n");
-               FatalIf(!(yval >= 0 && yval < loc->nxGlobal), "Test failed.\n");
+               int xval = (iX + loc->kx0 - loc->halo.lt) / 2;
+               int yval = (iY + loc->ky0 - loc->halo.up) / 2;
+               FatalIf(xval < 0 or xval >= loc->nxGlobal, "Test failed.\n");
+               FatalIf(yval < 0 or yval >= loc->nyGlobal, "Test failed.\n");
 
                float expectedvalue;
                expectedvalue = iFeature * 64 + yval * 16 + xval * 2 + 4.5;

--- a/tests/SumPoolTest/src/SumPoolTestInputBuffer.cpp
+++ b/tests/SumPoolTest/src/SumPoolTestInputBuffer.cpp
@@ -19,8 +19,6 @@ void SumPoolTestInputBuffer::updateBufferCPU(double simTime, double deltaTime) {
    int nf                = loc->nf;
    int nxGlobal          = loc->nxGlobal;
    int nyGlobal          = loc->nyGlobal;
-   int kx0               = loc->kx0;
-   int ky0               = loc->ky0;
 
    for (int b = 0; b < loc->nbatch; b++) {
       float *A = mBufferData.data() + b * getBufferSize();

--- a/tests/TransposeWeightsTest/src/TestNonshared.cpp
+++ b/tests/TransposeWeightsTest/src/TestNonshared.cpp
@@ -89,10 +89,6 @@ int TestNonshared(
          patchSizeYPre,
          comm);
 
-   int const patchSizeFPre    = originalWeights.getPatchSizeF();
-   int const numPatchItemsPre = originalWeights.getPatchSizeOverall();
-   int const numKernelsPre    = originalWeights.getGeometry()->getNumKernels();
-
    std::string transposeWeightsName("Transpose");
    PV::Weights transposeWeights(
          transposeWeightsName,

--- a/tests/TransposeWeightsTest/src/TestShared.cpp
+++ b/tests/TransposeWeightsTest/src/TestShared.cpp
@@ -78,9 +78,7 @@ int TestShared(
    PV::Weights originalWeights = createOriginalWeights(
          shared, nxPre, nyPre, nfPre, nxPost, nyPost, nfPost, patchSizeXPre, patchSizeYPre, comm);
 
-   int const patchSizeFPre    = originalWeights.getPatchSizeF();
-   int const numPatchItemsPre = originalWeights.getPatchSizeOverall();
-   int const numKernelsPre    = originalWeights.getGeometry()->getNumKernels();
+   int const patchSizeFPre = originalWeights.getPatchSizeF();
 
    std::string transposeWeightsName("Transpose");
    PV::Weights transposeWeights(

--- a/tests/WeightsClassTest/src/WeightsClassTest.cpp
+++ b/tests/WeightsClassTest/src/WeightsClassTest.cpp
@@ -309,9 +309,6 @@ void testManyToOneNonshared() {
    int nyp = 3;
    int nfp = 10;
 
-   int xStride = preLoc.nx / postLoc.nx;
-   int yStride = preLoc.ny / postLoc.ny;
-
    PV::Weights weightsObject(name, nxp, nyp, nfp, &preLoc, &postLoc, 1, false, 0.0);
 
    int nxExt = preLoc.nx + preLoc.halo.lt + preLoc.halo.rt;

--- a/tests/WeightsFileIOTest/src/WeightsFileIOTest.cpp
+++ b/tests/WeightsFileIOTest/src/WeightsFileIOTest.cpp
@@ -38,9 +38,6 @@ PV::Weights makeWeights(PV::PV_Init &pv_init, std::string const &name, bool shar
    int nfp       = 10;
    int numArbors = 4;
 
-   int xStride = preLoc.nx / postLoc.nx;
-   int yStride = preLoc.ny / postLoc.ny;
-
    PV::Weights weightsObject(name, nxp, nyp, nfp, &preLoc, &postLoc, numArbors, sharedFlag, 0.0);
    weightsObject.allocateDataStructures();
    return weightsObject;

--- a/tests/WriteActivitySparseTest/src/WriteActivitySparseTest.cpp
+++ b/tests/WriteActivitySparseTest/src/WriteActivitySparseTest.cpp
@@ -15,8 +15,6 @@ int main(int argc, char *argv[]) {
    MPI_Comm_rank(MPI_COMM_WORLD, &rank);
    char const *paramFile1 = "input/GenerateOutput.params";
    char const *paramFile2 = "input/TestOutput.params";
-   char const *outputDir1 = "outputGenerate";
-   char const *outputDir2 = "outputTest";
    int status             = PV_SUCCESS;
    if (initObj.getParams() != NULL) {
       if (rank == 0) {

--- a/tests/test_constant_input/src/TestImageActivityComponent.hpp
+++ b/tests/test_constant_input/src/TestImageActivityComponent.hpp
@@ -27,7 +27,7 @@ class TestImageActivityComponent : public ActivityComponent {
 
    void initialize(char const *name, PVParams *params, Communicator const *comm);
 
-   virtual void setObjectType();
+   virtual void setObjectType() override;
 
    virtual ActivityBuffer *createActivity() override;
 };

--- a/tests/test_constant_input/src/test_constant_input.cpp
+++ b/tests/test_constant_input/src/test_constant_input.cpp
@@ -194,7 +194,6 @@ int checkLoc(HyPerCol *hc, const PVLayerLoc *loc) {
 
    const int cols = hc->numCommColumns();
    const int rows = hc->numCommRows();
-   const int rank = hc->columnId();
 
    if (loc->nxGlobal != loc->nx * cols) {
       status = PV_FAILURE;

--- a/tests/test_datatypes/src/test_datatypes.cpp
+++ b/tests/test_datatypes/src/test_datatypes.cpp
@@ -124,9 +124,8 @@ static int check_borders(float *image, PV::BorderExchange *borderExchanger, PVLa
    int const numRows     = mpiBlock->getNumRows();
    int const numColumns  = mpiBlock->getNumColumns();
 
-   int k0   = columnIndex * nx + rowIndex * ny * loc.nxGlobal;
-   int sy   = nx + halo->lt + halo->rt;
-   int rank = mpiBlock->getRank();
+   int k0 = columnIndex * nx + rowIndex * ny * loc.nxGlobal;
+   int sy = nx + halo->lt + halo->rt;
 
    // northwest
    // Note that if this MPI process is on the northern edge of the MPI quilt,


### PR DESCRIPTION
This pull request eliminates compiler warnings generated by g++ when using the -Wall, -Wextra, and -Wsuggest-override options. These warnings revealed several bugs, which have been fixed.