### PR TITLE
Gpu delivery tweaks

### DIFF
--- a/src/delivery/HyPerDelivery.cpp
+++ b/src/delivery/HyPerDelivery.cpp
@@ -24,7 +24,20 @@ void HyPerDelivery::initialize(char const *name, PVParams *params, Communicator 
 void HyPerDelivery::setObjectType() { mObjectType = "HyPerDelivery"; }
 
 void HyPerDelivery::ioParam_receiveGpu(enum ParamsIOFlag ioFlag) {
-   parameters()->handleUnnecessaryParameter(name, "receiveGpu");
+   // Don't call handleUnnecessaryParameter here because that will generate a warning.
+   // HyPerDeliver-derived classes don't need this parameter, but in the usual situation,
+   // the parameter is read by HyPerDeliverCreator, which does need the parameter.
+   // Hence a warning generated here would be misleading.
+   if (ioFlag == PARAMS_IO_READ) {
+      bool receiveGpu = parameters()->value(
+            name, "receiveGpu", mCorrectReceiveGpu, false /*don't warn if absent*/);
+      FatalIf(
+            receiveGpu != mCorrectReceiveGpu,
+            "%s has receiveGpu set to %s in params, but requires %s to be %s.\n",
+            getDescription(),
+            receiveGpu ? "true" : "false",
+            mCorrectReceiveGpu ? "true" : "false");
+   }
 }
 
 Response::Status

--- a/src/delivery/HyPerDelivery.hpp
+++ b/src/delivery/HyPerDelivery.hpp
@@ -24,7 +24,9 @@ class HyPerDelivery : public BaseDelivery {
    /**
     * The HyPerDeliveryCreator object reads this parameter and creates the appropriate
     * HyPerDelivery-derived object based on its value; hence the derived class knows
-    * the value of receiveGpu just from having been instantiated.
+    * the value of receiveGpu just from having been instantiated. Instead of setting
+    * receiveGpu here, this class checks that if the value is present it agrees with
+    * the correct value for the derived class (based on the value of mCorrectReceiveGpu).
     */
    void ioParam_receiveGpu(enum ParamsIOFlag ioFlag) override;
 
@@ -54,6 +56,10 @@ class HyPerDelivery : public BaseDelivery {
    float mDeltaTimeFactor    = 1.0f;
    WeightsPair *mWeightsPair = nullptr;
    ArborList *mArborList     = nullptr;
+
+   // subclasses that use GPU (e.g. PresynapticPerspectiveGPUDelivery) must set this flag to
+   // true in initialize() before ioParam_receiveGpu gets called.
+   bool mCorrectReceiveGpu = false;
 
 }; // end class HyPerDelivery
 

--- a/src/delivery/PostsynapticPerspectiveGPUDelivery.cpp
+++ b/src/delivery/PostsynapticPerspectiveGPUDelivery.cpp
@@ -13,10 +13,13 @@ PostsynapticPerspectiveGPUDelivery::PostsynapticPerspectiveGPUDelivery(
       char const *name,
       PVParams *params,
       Communicator const *comm) {
+   mCorrectReceiveGpu = true;
    initialize(name, params, comm);
 }
 
-PostsynapticPerspectiveGPUDelivery::PostsynapticPerspectiveGPUDelivery() {}
+PostsynapticPerspectiveGPUDelivery::PostsynapticPerspectiveGPUDelivery() {
+   mCorrectReceiveGpu = true;
+}
 
 PostsynapticPerspectiveGPUDelivery::~PostsynapticPerspectiveGPUDelivery() {
    delete mRecvKernel;

--- a/src/delivery/PresynapticPerspectiveGPUDelivery.cpp
+++ b/src/delivery/PresynapticPerspectiveGPUDelivery.cpp
@@ -13,10 +13,13 @@ PresynapticPerspectiveGPUDelivery::PresynapticPerspectiveGPUDelivery(
       char const *name,
       PVParams *params,
       Communicator const *comm) {
+   mCorrectReceiveGpu = true;
    initialize(name, params, comm);
 }
 
-PresynapticPerspectiveGPUDelivery::PresynapticPerspectiveGPUDelivery() {}
+PresynapticPerspectiveGPUDelivery::PresynapticPerspectiveGPUDelivery() {
+   mCorrectReceiveGpu = true;
+}
 
 PresynapticPerspectiveGPUDelivery::~PresynapticPerspectiveGPUDelivery() {}
 

--- a/tests/GPUSystemTest/input/postTestNoTranspose.params
+++ b/tests/GPUSystemTest/input/postTestNoTranspose.params
@@ -1,11 +1,11 @@
 debugParsing = false;
 
 HyPerCol "column" = {
-    nx = 64; //1242;  // KITTI synced value
-    ny = 64;  //218;
+    nx = 64;
+    ny = 64;
     dt = 1.0;
     randomSeed = 1234567890;  // Must be at least 8 digits long.  // if not set here,  clock time is used to generate seed
-    stopTime = 30.0;       // Depends on number of VINE video frames
+    stopTime = 30.0;
     progressInterval = 1.0;
     //Change this
     outputPath = "output/postTestNoTranspose/";
@@ -16,7 +16,6 @@ HyPerCol "column" = {
 };
 
 ConstantLayer "input" = {
-    restart = 0;
     nxScale = 1;
     nyScale = 1;
     nf = 3;
@@ -33,7 +32,6 @@ ConstantLayer "input" = {
 };
 
 ANNLayer "outputRecv" = {
-    restart = 0;
     nxScale = .5;
     nyScale = .5;
     nf = 64;
@@ -53,7 +51,6 @@ ANNLayer "outputRecv" = {
 };
 
 ANNLayer "outputRecvGpu" = {
-    restart = 0;
     nxScale = .5;
     nyScale = .5;
     nf = 64;
@@ -73,7 +70,6 @@ ANNLayer "outputRecvGpu" = {
 };
 
 ANNLayer "outputTest" = {
-    restart = 0;
     nxScale = .5;
     nyScale = .5;
     nf = 64;
@@ -104,19 +100,10 @@ HyPerConn "cpuConn" = {
     initialWriteTime = 0.0;
     writeCompressedWeights = false;
     
-//    weightInitType = "UniformRandomWeight";
-//    wMinInit = -1;
-//    wMaxInit = 1;
-//    sparseFraction = 0;
-//
     weightInitType = "UniformWeight";
     weightInit = 1;
         
     normalizeMethod                     = "none";
-    //strength                            = 1;
-    //rMinX                               = 1.5;
-    //rMinY                               = 1.5;
-    //normalize_cutoff                    = 0;
 
     normalizeArborsIndividually = false;
     normalizeFromPostPerspective = false;
@@ -147,19 +134,10 @@ HyPerConn "gpuConn" = {
     initialWriteTime = 0.0;
     writeCompressedWeights = false;
     
-//    weightInitType = "UniformRandomWeight";
-//    wMinInit = -1;
-//    wMaxInit = 1;
-//    sparseFraction = 0;
-//
     weightInitType = "UniformWeight";
     weightInit = 1;
         
     normalizeMethod                     = "none";
-    //strength                            = 1;
-    //rMinX                               = 1.5;
-    //rMinY                               = 1.5;
-    //normalize_cutoff                    = 0;
 
     normalizeArborsIndividually = false;
     normalizeFromPostPerspective = false;
@@ -171,11 +149,9 @@ HyPerConn "gpuConn" = {
     pvpatchAccumulateType = "convolve";
      
     delay = 0;
-     
 
     updateGSynFromPostPerspective = true;
-    receiveGpu = false;
-
+    receiveGpu = true;
 };
 
 IdentConn "RecvPostTest" = {


### PR DESCRIPTION
This pull request fixes a bug in GPUSystemTest_postTestNoTranspose, where gpuConn had receiveGpu set to false when it should be true.

It also rewords HyPerDelivery::ioParam_receiveGpu to eliminate an unnecessary warning.