### PR TITLE
PoolingDelivery verifies that pre->nf == post->nf

### DIFF
--- a/src/delivery/PoolingDelivery.cpp
+++ b/src/delivery/PoolingDelivery.cpp
@@ -199,14 +199,6 @@ Response::Status PoolingDelivery::allocateDataStructures() {
    }
    pvAssert(mPreData and mPreData->getLayerLoc());
    pvAssert(mPostGSyn and mPostGSyn->getLayerLoc());
-   if (preLoc->nf != postLoc->nf) {
-      ErrorLog().printf(
-            "%s requires pre and post nf be equal (%d versus %d).\n",
-            getDescription_c(),
-            preLoc->nf,
-            postLoc->nf);
-      status = PV_FAILURE;
-   }
    FatalIf(
          mPreData->getLayerLoc()->nf != mPostGSyn->getLayerLoc()->nf,
          "%s requires pre layer \"%s\" and post layer \"%s\" have equal nf (%d versus %d).\n",

--- a/src/delivery/PoolingDelivery.cpp
+++ b/src/delivery/PoolingDelivery.cpp
@@ -197,6 +197,17 @@ Response::Status PoolingDelivery::allocateDataStructures() {
    if (!Response::completed(status)) {
       return status;
    }
+   pvAssert(mPreData and mPreData->getLayerLoc());
+   pvAssert(mPostGSyn and mPostGSyn->getLayerLoc());
+   FatalIf(
+         mPreData->getLayerLoc()->nf != mPostGSyn->getLayerLoc()->nf,
+         "%s pre layer \"%s\" has %d features but post layer \"%s\" has %d features. "
+         "The numbers of features must be equal.\n",
+         getDescription_c(),
+         mPreData->getName(),
+         mPreData->getLayerLoc()->nf,
+         mPostGSyn->getName(),
+         mPostGSyn->getLayerLoc()->nf);
 #ifdef PV_USE_CUDA
    if (mReceiveGpu) {
       if (!mPreData->getDataStructuresAllocatedFlag()) {

--- a/src/delivery/PoolingDelivery.cpp
+++ b/src/delivery/PoolingDelivery.cpp
@@ -199,14 +199,21 @@ Response::Status PoolingDelivery::allocateDataStructures() {
    }
    pvAssert(mPreData and mPreData->getLayerLoc());
    pvAssert(mPostGSyn and mPostGSyn->getLayerLoc());
+   if (preLoc->nf != postLoc->nf) {
+      ErrorLog().printf(
+            "%s requires pre and post nf be equal (%d versus %d).\n",
+            getDescription_c(),
+            preLoc->nf,
+            postLoc->nf);
+      status = PV_FAILURE;
+   }
    FatalIf(
          mPreData->getLayerLoc()->nf != mPostGSyn->getLayerLoc()->nf,
-         "%s pre layer \"%s\" has %d features but post layer \"%s\" has %d features. "
-         "The numbers of features must be equal.\n",
+         "%s requires pre layer \"%s\" and post layer \"%s\" have equal nf (%d versus %d).\n",
          getDescription_c(),
          mPreData->getName(),
-         mPreData->getLayerLoc()->nf,
          mPostGSyn->getName(),
+         mPreData->getLayerLoc()->nf,
          mPostGSyn->getLayerLoc()->nf);
 #ifdef PV_USE_CUDA
    if (mReceiveGpu) {

--- a/src/delivery/TransposePoolingDelivery.cpp
+++ b/src/delivery/TransposePoolingDelivery.cpp
@@ -191,6 +191,17 @@ Response::Status TransposePoolingDelivery::allocateDataStructures() {
    if (!Response::completed(status)) {
       return status;
    }
+   pvAssert(mPreData and mPreData->getLayerLoc());
+   pvAssert(mPostGSyn and mPostGSyn->getLayerLoc());
+   FatalIf(
+         mPreData->getLayerLoc()->nf != mPostGSyn->getLayerLoc()->nf,
+         "%s pre layer \"%s\" has %d features but post layer \"%s\" has %d features. "
+         "The numbers of features must be equal.\n",
+         getDescription_c(),
+         mPreData->getName(),
+         mPreData->getLayerLoc()->nf,
+         mPostGSyn->getName(),
+         mPostGSyn->getLayerLoc()->nf);
 #ifdef PV_USE_CUDA
    if (mReceiveGpu) {
       if (!mPreData->getDataStructuresAllocatedFlag()) {


### PR DESCRIPTION
This pull request adds a check to PoolingDelivery and TransposePoolingDelivery, to ensure that the pre and post layers have the same number of features.