### PR TITLE
Adds ccmake toggle to build tools to avoid build order issue

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -15,14 +15,17 @@ set(PV_TOOLS_DIR "${CMAKE_CURRENT_SOURCE_DIR}/tools")
 
 # Defaults
 set(PV_BUILD_DEMOS_DEFAULT OFF)
+set(PV_BUILD_TOOLS_DEFAULT OFF)
 
 # Help strings
 set(PV_BUILD_DEMOS_HELP "Build OpenPV demos")
+set(PV_BUILD_DEMOS_HELP "Build OpenPV tools")
 
 # Set CMAKE_MODULE_PATH
 set(CMAKE_MODULE_PATH "${PROJECT_SOURCE_DIR}/cmake")
 
 set(PV_BUILD_DEMOS ${PV_BUILD_DEMOS_DEFAULT} CACHE BOOL "${PV_BUILD_DEMOS_HELP}")
+set(PV_BUILD_TOOLS ${PV_BUILD_TOOLS_DEFAULT} CACHE BOOL "${PV_BUILD_TOOLS_HELP}")
 
 include(PVConfigProject)
 pv_config_project()
@@ -44,4 +47,6 @@ if (${PV_BUILD_DEMOS})
    add_subdirectory(${PV_DEMOS_DIR})
 endif()
 
-add_subdirectory(${PV_TOOLS_DIR})
+if (${PV_BUILD_TOOLS})
+   add_subdirectory(${PV_TOOLS_DIR})
+endif()


### PR DESCRIPTION
This pull request disables building the tools directory by default. After building OpenPV successfully without tools enabled, the flag can be enabled and tools will build without issue.