### PR TITLE
CloneV fix

### DIFF
--- a/src/components/CloneInternalStateBuffer.cpp
+++ b/src/components/CloneInternalStateBuffer.cpp
@@ -72,6 +72,15 @@ Response::Status CloneInternalStateBuffer::communicateInitInfo(
    return Response::SUCCESS;
 }
 
+Response::Status CloneInternalStateBuffer::allocateDataStructures() {
+   if (!mOriginalBuffer->getDataStructuresAllocatedFlag()) {
+      return Response::POSTPONE;
+   }
+   else {
+      return InternalStateBuffer::allocateDataStructures();
+   }
+}
+
 void CloneInternalStateBuffer::setReadOnlyPointer() {
    pvAssert(mBufferData.empty()); // nothing else should have allocated this
    pvAssert(mOriginalBuffer); // set in communicateInitInfo

--- a/src/components/CloneInternalStateBuffer.hpp
+++ b/src/components/CloneInternalStateBuffer.hpp
@@ -47,6 +47,8 @@ class CloneInternalStateBuffer : public InternalStateBuffer {
    virtual Response::Status
    communicateInitInfo(std::shared_ptr<CommunicateInitInfoMessage const> message) override;
 
+   virtual Response::Status allocateDataStructures() override;
+
    /**
     * Sets the read-only pointer to the original layer's read-only pointer.
     */

--- a/src/components/HyPerActivityBuffer.cpp
+++ b/src/components/HyPerActivityBuffer.cpp
@@ -43,22 +43,14 @@ void HyPerActivityBuffer::updateBufferCPU(double simTime, double deltaTime) {
    PVHalo const *halo = &getLayerLoc()->halo;
 
    int const numNeuronsAcrossBatch = mInternalState->getBufferSizeAcrossBatch();
-   if (V != nullptr) {
+   pvAssert(V != nullptr);
 #ifdef PV_USE_OPENMP_THREADS
 #pragma omp parallel for schedule(static)
 #endif
-      for (int k = 0; k < numNeuronsAcrossBatch; k++) {
-         int kExt = kIndexExtendedBatch(k, nbatch, nx, ny, nf, halo->lt, halo->rt, halo->dn, halo->up);
-         A[kExt]  = V[k];
-      }
+   for (int k = 0; k < numNeuronsAcrossBatch; k++) {
+      int kExt = kIndexExtendedBatch(k, nbatch, nx, ny, nf, halo->lt, halo->rt, halo->dn, halo->up);
+      A[kExt]  = V[k];
    }
-   else {
-      for (int k = 0; k < numNeuronsAcrossBatch; k++) {
-         int kExt = kIndexExtendedBatch(k, nbatch, nx, ny, nf, halo->lt, halo->rt, halo->dn, halo->up);
-         A[kExt]  = 0.0f;
-      }
-   }
-
 }
 
 } // namespace PV


### PR DESCRIPTION
This pull request address more fully the issue addressed in <https://github.com/PetaVision/OpenPV/pull/281>. In the AllocateDataStructures stage, CloneInternalStateBuffer was not properly checking that the original layer had allocated before setting its data pointer to the original layer's data pointer.

This pull request does the following:
- has CloneInternalStateBuffer override the allocateDataStructures() method to check whether the original InternalStateBuffer has allocated, and return POSTPONE if it hasn't.
- replaces the "if (V != nullptr)" in Austin's patch with a pvAssert(V != nullptr) statement, since the V pointer should never be null at this point in the code.
