### PR TITLE
Ifdef'ed CUDA calls

### DIFF
--- a/src/columns/HyPerCol.cpp
+++ b/src/columns/HyPerCol.cpp
@@ -754,9 +754,11 @@ int HyPerCol::advanceTime(double sim_time) {
 
    notifyLoop(std::make_shared<ColProbeOutputStateMessage>(mSimTime, mDeltaTime));
 
+#ifdef PV_USE_CUDA
    if (getDevice() != nullptr) {
       getDevice()->syncDevice();
    }
+#endif
 
    mRunTimer->stop();
 

--- a/src/components/BasePublisherComponent.cpp
+++ b/src/components/BasePublisherComponent.cpp
@@ -95,7 +95,10 @@ Response::Status BasePublisherComponent::allocateDataStructures() {
          mActivity->getLayerLoc(),
          getNumDelayLevels(),
          mSparseLayer);
+#ifdef PV_USE_CUDA
    allocateCudaBuffers();
+#endif
+
    return Response::SUCCESS;
 }
 


### PR DESCRIPTION
Calls to CUDA specific functions not #ifdef'ed so they are called even if PV_USE_CUDA is set to false. This pull request adds the necessary #ifdef's