### PR TITLE
Randomize ParameterGroups

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -38,6 +38,7 @@ pv_config_project()
 add_subdirectory(${PV_DIR})
 
 if (${PV_BUILD_TEST})
+  enable_testing()
   add_subdirectory(${PV_TEST_DIR})
 else()
    message(STATUS "Only building the OpenPV library. Set PV_BUILD_TEST=On to build the OpenPV test suite.")

--- a/cmake/PVAddTest.cmake
+++ b/cmake/PVAddTest.cmake
@@ -48,8 +48,9 @@
 # MAX_MPI_COPIES - maximum number of MPI copies. Test cases are incremented by powers of two,
 #  First case is 2, next is 4, and so on, until MAX_MPI_COPIES is reached. Default is 4
 #
-# FLAGS - by default, the flags are "-t ${PV_SYSTEM_TEST_THREADS}". Setting FLAGS appends
-#  to this
+# FLAGS - by default, the flags are "-t ${PV_SYSTEM_TEST_THREADS}" or
+#  "-t ${PV_SYSTEM_TEST_THREADS} -shuffle ${PV_SYSTEM_TEST_SHUFFLE}".
+#  Setting FLAGS appends to this
 #
 # BASE_NAME - by default, this is the last component of the path ${CMAKE_CURRENT_SOURCE_DIR}.
 #  Set BASE_NAME to override
@@ -93,9 +94,12 @@ macro(pv_add_test)
 
   # Set the TEST_FLAGS
   set(TEST_FLAGS "-t;${PV_SYSTEM_TEST_THREADS}")
+  if (PV_SYSTEM_TEST_SHUFFLE)
+    set(TEST_FLAGS "${TEST_FLAGS};-shuffle;${PV_SYSTEM_TEST_SHUFFLE}")
+  endif()
   if (PARSED_ARGS_FLAGS)
     string(REPLACE " " ";" FLAG_LIST ${PARSED_ARGS_FLAGS})
-    set(TEST_FLAGS ${TEST_FLAGS};${FLAG_LIST})
+    set(TEST_FLAGS "${TEST_FLAGS};${FLAG_LIST}")
   endif()
 
   # Set the list of params files, if needed

--- a/src/columns/CommandLineArguments.cpp
+++ b/src/columns/CommandLineArguments.cpp
@@ -38,21 +38,22 @@ void CommandLineArguments::resetState(
       char const *const *argv,
       bool allowUnrecognizedArguments) {
    bool paramUsage[argc];
-   bool requireReturn        = false;
-   char *outputPath          = nullptr;
-   char *paramsFile          = nullptr;
-   char *logFile             = nullptr;
-   char *gpuDevices          = nullptr;
-   unsigned int randomSeed   = 0U;
-   char *workingDir          = nullptr;
-   int restart               = 0;
-   char *checkpointReadDir   = nullptr;
-   bool useDefaultNumThreads = false;
-   int numThreads            = 0;
-   int numRows               = 0;
-   int numColumns            = 0;
-   int batchWidth            = 0;
-   int dryRun                = 0;
+   bool requireReturn              = false;
+   char *outputPath                = nullptr;
+   char *paramsFile                = nullptr;
+   char *logFile                   = nullptr;
+   char *gpuDevices                = nullptr;
+   unsigned int randomSeed         = 0U;
+   char *workingDir                = nullptr;
+   int restart                     = 0;
+   char *checkpointReadDir         = nullptr;
+   bool useDefaultNumThreads       = false;
+   int numThreads                  = 0;
+   int numRows                     = 0;
+   int numColumns                  = 0;
+   int batchWidth                  = 0;
+   int dryRun                      = 0;
+   unsigned int shuffleParamGroups = 0U;
    parse_options(
          argc,
          argv,
@@ -71,7 +72,8 @@ void CommandLineArguments::resetState(
          &numRows,
          &numColumns,
          &batchWidth,
-         &dryRun);
+         &dryRun,
+         &shuffleParamGroups);
    if (!allowUnrecognizedArguments) {
       bool allrecognized = true;
       for (int argi = 0; argi < argc; argi++) {
@@ -102,7 +104,8 @@ void CommandLineArguments::resetState(
          numRows,
          numColumns,
          batchWidth,
-         (bool)dryRun);
+         (bool)dryRun,
+         shuffleParamGroups);
    std::istringstream configStream{configString};
    Arguments::resetState(configStream, allowUnrecognizedArguments);
    free(outputPath);

--- a/src/columns/PV_Init.cpp
+++ b/src/columns/PV_Init.cpp
@@ -193,6 +193,10 @@ int PV_Init::createParams() {
             paramsFile.c_str(),
             2 * (INITIAL_LAYER_ARRAY_SIZE + INITIAL_CONNECTION_ARRAY_SIZE),
             mCommunicator);
+      unsigned int shuffleSeed = arguments->getUnsignedIntArgument("ShuffleParamGroups");
+      if (shuffleSeed) {
+         params->shuffleGroups(shuffleSeed);
+      }
       return PV_SUCCESS;
    }
    else {

--- a/src/delivery/PoolingDelivery.cpp
+++ b/src/delivery/PoolingDelivery.cpp
@@ -207,13 +207,13 @@ Response::Status PoolingDelivery::allocateDataStructures() {
 #ifdef PV_USE_CUDA
    if (mReceiveGpu) {
       if (!mPreData->getDataStructuresAllocatedFlag()) {
-         return Response::POSTPONE;
+         return status + Response::POSTPONE;
       }
       if (!mPostGSyn->getDataStructuresAllocatedFlag()) {
-         return Response::POSTPONE;
+         return status + Response::POSTPONE;
       }
       if (!mWeightsPair->getDataStructuresAllocatedFlag()) {
-         return Response::POSTPONE;
+         return status + Response::POSTPONE;
       }
       initializeDeliverKernelArgs();
    }
@@ -261,8 +261,13 @@ void PoolingDelivery::allocateThreadGateIdxBuffer() {
       mThreadGateIdxBuffer.resize(numThreads);
       // mThreadGateIdxBuffer is only a buffer for one batch element. We're threading over
       // presynaptic neuron index, not batch element; so batch elements will be processed serially.
+
+      PVLayerLoc const *postLoc = mPostGSyn->getLayerLoc();
+      // We could use mPostGSyn->getBufferSize(), but this requires
+      // checking mPostGSyn->getDataStructuresAllocatedFlag().
+      int const numNeurons = postLoc->nx * postLoc->ny * postLoc->nf;
       for (int th = 0; th < numThreads; th++) {
-         mThreadGateIdxBuffer[th].resize(mPostGSyn->getBufferSize());
+         mThreadGateIdxBuffer[th].resize(numNeurons);
       }
    }
 }

--- a/src/io/ConfigParser.cpp
+++ b/src/io/ConfigParser.cpp
@@ -107,7 +107,8 @@ std::string ConfigParser::createString(
       int numRows,
       int numColumns,
       int batchWidth,
-      bool dryRunFlag) {
+      bool dryRunFlag,
+      unsigned int shuffleParamGroups) {
    std::string configString;
    FatalIf(
          restartFlag && !checkpointReadDir.empty(),
@@ -156,6 +157,10 @@ std::string ConfigParser::createString(
    }
    if (dryRunFlag) {
       configString.append("DryRun:true\n");
+   }
+   if (shuffleParamGroups) {
+      auto argString = std::to_string(shuffleParamGroups);
+      configString.append("ShuffleParamGroups:").append(argString).append("\n");
    }
    return configString;
 }

--- a/src/io/ConfigParser.hpp
+++ b/src/io/ConfigParser.hpp
@@ -107,7 +107,8 @@ class ConfigParser {
          int numRows,
          int numColumns,
          int batchWidth,
-         bool dryRunFlag);
+         bool dryRunFlag,
+         unsigned int shuffleParamGroups);
 
    /**
     * Returns a constant reference to the underlying Configuration object.

--- a/src/io/Configuration.cpp
+++ b/src/io/Configuration.cpp
@@ -22,6 +22,7 @@ Configuration::Configuration() {
    registerIntegerArgument("CheckpointCellNumColumns");
    registerIntegerArgument("CheckpointCellBatchDimension");
    registerBooleanArgument("DryRun");
+   registerUnsignedIntArgument("ShuffleParamGroups");
 }
 
 void Configuration::registerArgument(std::string const &name, ConfigurationType type) {

--- a/src/io/PVParams.cpp
+++ b/src/io/PVParams.cpp
@@ -8,10 +8,12 @@
 #include "PVParams.hpp"
 #include "include/pv_common.h"
 #include "utils/PVAlloc.hpp"
+#include <algorithm> // shuffle, used in shuffleGroups()
 #include <assert.h>
 #include <climits> // INT_MIN
 #include <cmath> // nearbyint()
 #include <iostream>
+#include <random> // mt19937, used in shuffleGroups()
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
@@ -1769,6 +1771,13 @@ void PVParams::handleUnnecessaryStringParameter(
    if (status != PV_SUCCESS) {
       MPI_Barrier(icComm->globalCommunicator());
       exit(EXIT_FAILURE);
+   }
+}
+
+void PVParams::shuffleGroups(unsigned int seed) {
+   if (seed and numberOfGroups() > 1) {
+      std::mt19937 shuffleRNG(seed);
+      std::shuffle(mGroups.begin() + 1, mGroups.end(), shuffleRNG);
    }
 }
 

--- a/src/io/PVParams.hpp
+++ b/src/io/PVParams.hpp
@@ -375,7 +375,7 @@ class PVParams {
    void action_parameter_sweep_values_string(const char *stringval);
    void action_parameter_sweep_values_filename(const char *stringval);
 
-   int numberOfGroups() { return numGroups; }
+   int numberOfGroups() { return (int)mGroups.size(); }
    int numberOfParameterSweeps() { return numParamSweeps; }
    int getParameterSweepSize() { return parameterSweepSize; }
    FileStream *getPrintParamsStream() { return mPrintParamsStream; }
@@ -383,9 +383,7 @@ class PVParams {
 
   private:
    int parseStatus;
-   int numGroups;
-   size_t groupArraySize;
-   ParameterGroup **groups;
+   std::vector<ParameterGroup *> mGroups;
    ParameterStack *stack;
    ParameterArrayStack *arrayStack;
    ParameterStringStack *stringStack;

--- a/src/io/PVParams.hpp
+++ b/src/io/PVParams.hpp
@@ -355,6 +355,15 @@ class PVParams {
    }
    int setParameterSweepValues(int n);
 
+   /**
+    * Randomly shuffles the vector of pointers to the ParameterGroup objects.
+    * Used for debugging purposes, to help identify cases where behavior depends
+    * on the order of objects in the params file during debugging.
+    * The shuffling here has no effect on the RNGs managed by the HyPerCol and used
+    * by layers or connections.
+    */
+   void shuffleGroups(unsigned int seed);
+
    void action_pvparams_directive(char *id, double val);
    void action_parameter_group_name(char *keyword, char *name);
    void action_parameter_group();

--- a/src/io/io.cpp
+++ b/src/io/io.cpp
@@ -55,7 +55,8 @@ int parse_options(
       int *num_rows,
       int *num_columns,
       int *batch_width,
-      int *dry_run) {
+      int *dry_run,
+      unsigned int *shuffleParamGroups) {
    paramusage[0] = true;
    int arg;
    for (arg = 1; arg < argc; arg++) {
@@ -82,6 +83,7 @@ int parse_options(
    if (pv_getopt(argc, argv, "-n", paramusage) == 0) {
       *dry_run = 1;
    }
+   pv_getopt_unsigned(argc, argv, "-shuffle", shuffleParamGroups, paramusage);
 
    return 0;
 }

--- a/src/io/io.hpp
+++ b/src/io/io.hpp
@@ -56,7 +56,8 @@ int parse_options(
       int *numRows,
       int *numColumns,
       int *batch_width,
-      int *dryrun);
+      int *dryrun,
+      unsigned int *shuffleParamGroups);
 
 } // end namespace PV
 

--- a/src/probes/LayerProbe.cpp
+++ b/src/probes/LayerProbe.cpp
@@ -79,8 +79,7 @@ LayerProbe::communicateInitInfo(std::shared_ptr<CommunicateInitInfoMessage const
          "%s targetLayer \"%s\" is not a layer in the column.\n",
          getDescription_c(),
          targetName);
-
-   return Response::SUCCESS;
+   return targetLayer->getInitInfoCommunicatedFlag() ? Response::SUCCESS : Response::POSTPONE;
 }
 
 Response::Status

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -14,14 +14,21 @@ set(TESTS_SHARED_DIR "${CMAKE_CURRENT_SOURCE_DIR}/Shared")
 
 set(PV_SYSTEM_TEST_THREADS "" CACHE STRING "Defines the number of threads to use for system tests (empty string for max)")
 set(PV_SYSTEM_TEST_COMMAND "" CACHE STRING "Defines the program that should invoke the test (if empty, ctest calls the test directly)")
+set(PV_SYSTEM_TEST_SHUFFLE "" CACHE STRING "Defines whether to shuffle the order of param groups before running (empty string or \"0\" for no shuffling)")
 
-# Make sure that PV_SYSTEM_TEST_THREADS is a number
-if("${PV_SYSTEM_TEST_THREADS}" MATCHES "^([0-9]+|)$")
+# Make sure that PV_SYSTEM_TEST_THREADS is a either a positive integer or the empty string
+if("${PV_SYSTEM_TEST_THREADS}" MATCHES "^([1-9][0-9]*|)$")
    #Do nothing, correct
-else("${PV_SYSTEM_TEST_THREADS}" MATCHES "^([0-9]+|)$")
+else("${PV_SYSTEM_TEST_THREADS}" MATCHES "^([1-9][0-9]*|)$")
    message(FATAL_ERROR "PV_SYSTEM_TEST_THREADS must be either a positive integer or the empty string")
-endif("${PV_SYSTEM_TEST_THREADS}" MATCHES "^([0-9]+|)$")
+endif("${PV_SYSTEM_TEST_THREADS}" MATCHES "^([1-9][0-9]*|)$")
 
+# Make sure that PV_SYSTEM_TEST_SHUFFLE is either a nonnegative integer or the empty string
+if("${PV_SYSTEM_TEST_SHUFFLE}" MATCHES "^(0|[1-9][0-9]*|)$")
+   #Do nothing, correct
+else("${PV_SYSTEM_TEST_SHUFFLE}" MATCHES "^(0|[1-9][0-9]*|)$")
+   message(FATAL_ERROR "PV_SYSTEM_TEST_SHUFFLE must be either a positive integer or the empty string")
+endif("${PV_SYSTEM_TEST_SHUFFLE}" MATCHES "^(0|[1-9][0-9]*|)$")
 
 # Unit tests for individual classes happen first. If these fail, the rest of the results are unreliable.
 add_subdirectory(BatchIndexerTest)


### PR DESCRIPTION
This pull request adds an option to shuffle the order of the parameter groups once the params have been read in.

On the command line, add the option `-shuffle <seed>` where `<seed>` is a positive integer, used as the random seed for the shuffle. Adding `-shuffle 0` specifies no shuffling; this is the default. If `-shuffle` appears on the command line, it must be followed by a number.

If you're using a config file to specify the params file etc., add the line `ShuffleParamGroups:<seed>' to the config file.

This option can be added to the system tests, by using the PV_SYSTEM_TEST_SHUFFLE variable in cmake.

Some bugs in PoolingDelivery and PointProbe were uncovered with this option. This pull request includes fixes for them as well.