### PR TITLE
Fixes format-truncation warnings

### DIFF
--- a/src/io/PrintStream.hpp
+++ b/src/io/PrintStream.hpp
@@ -22,8 +22,7 @@ class PrintStream {
       va_list args1, args2;
       va_start(args1, fmt);
       va_copy(args2, args1);
-      char c;
-      int chars_needed = vsnprintf(&c, 1, fmt, args1) + 1; // +1 for null terminator
+      int chars_needed = vsnprintf(nullptr, 0, fmt, args1) + 1; // +1 for null terminator
       char output_string[chars_needed];
 #ifdef NDEBUG
       vsnprintf(output_string, chars_needed, fmt, args2);

--- a/src/utils/PVLog.hpp
+++ b/src/utils/PVLog.hpp
@@ -401,8 +401,7 @@ struct Log {
          va_list args1, args2;
          va_start(args1, fmt);
          va_copy(args2, args1);
-         char c;
-         int chars_needed = vsnprintf(&c, 1, fmt, args1);
+         int chars_needed = vsnprintf(nullptr, 0, fmt, args1);
          chars_needed++;
          char output_string[chars_needed];
          chars_printed = vsnprintf(output_string, chars_needed, fmt, args2);

--- a/src/utils/Timer.cpp
+++ b/src/utils/Timer.cpp
@@ -68,9 +68,8 @@ Timer::Timer(const char *timermessage, double init_time) {
 Timer::Timer(const char *objname, const char *objtype, const char *timertype, double init_time) {
    rank = 0;
    reset(init_time);
-   char dummy;
    int charsneeded =
-         snprintf(&dummy, 1, "%32s: total time in %6s %10s: ", objname, objtype, timertype) + 1;
+         snprintf(nullptr, 0, "%32s: total time in %6s %10s: ", objname, objtype, timertype) + 1;
    message = (char *)malloc(charsneeded);
    FatalIf(
          message == nullptr,


### PR DESCRIPTION
This pull request improves the way that snprintf is used to determine the length a formatted string will be before allocating space for the string. The older method generated format-truncation warnings on some compilers.