### PR TITLE
More efficient loading of sparse activity files with python

### DIFF
--- a/python/pvtools/pvpFile.py
+++ b/python/pvtools/pvpFile.py
@@ -91,6 +91,7 @@ class pvpOpen(object):
         outFramePos = np.zeros((self.numFrames)).astype(np.int64)
 
         print("Building frame lookup for sparse pvp file")
+        self.activeCount = 0
         for frame in range(self.numFrames):
             #if(frame % 100 == 0):
             #    print "Frame " + str(frame) + " out of " + str(self.numFrames)
@@ -98,6 +99,8 @@ class pvpOpen(object):
             outFramePos[frame] = self.pvpFile.tell()
             numActive = np.fromfile(self.pvpFile, np.uint32,3)[-1]
             self.pvpFile.seek(entryPattern.itemsize * numActive, os.SEEK_CUR)
+
+            self.activeCount += numActive
         print("Done")
 
         #Restore file position

--- a/python/pvtools/pvpFile.py
+++ b/python/pvtools/pvpFile.py
@@ -213,30 +213,38 @@ class pvpOpen(object):
         elif self.header['filetype'] == 6:
             entryPattern = np.dtype([('index', np.int32),
                                      ('activation', np.float32)])
-            valuesList = []
-            framesList = []
-            idxList = []
-            timeList = []
 
+            rows     = np.empty(self.activeCount, dtype=np.uint32)
+            cols     = np.empty(self.activeCount, dtype=np.uint32)
+            vals     = np.empty(self.activeCount, dtype=np.float32)
+            timeList = np.empty(len(frameRange),  dtype=np.float64)
+
+            curOffset = 0
             for (frameNum, frame) in enumerate(frameRange):
                 self.pvpFile.seek(self.framePos[frame], os.SEEK_SET)
-                time = np.fromfile(self.pvpFile,np.float64,1)[0]
-                timeList.append(time)
-                numActive = np.fromfile(self.pvpFile,np.uint32,1).item()
-                currentData = np.fromfile(self.pvpFile,entryPattern,numActive)
+
+                time = np.fromfile(self.pvpFile, np.float64, 1)[0]
+                timeList[frameNum] = time
+
+                numActive = np.fromfile(self.pvpFile, np.uint32, 1)[0]
+                currentData = np.fromfile(self.pvpFile, entryPattern, numActive)
+
                 dataIdx = currentData['index']
                 dataValues = currentData['activation']
-                idxList.extend(dataIdx)
-                valuesList.extend(dataValues)
-                framesList.extend(np.ones((len(dataIdx)))*frameNum)
 
+                rows[curOffset:curOffset + numActive] = frameNum
+                cols[curOffset:curOffset + numActive] = dataIdx
+                vals[curOffset:curOffset + numActive] = dataValues
+
+                curOffset += numActive
+    
                 if progress:
                     if frameNum % progress == 0:
                         print("File "+self.filename+": frame "+str(frame)+" of "+str(frameRange[-1]))
 
             #Make csrsparsematrix
-            data["time"] = np.array(timeList)
-            data["values"] = sp.csr_matrix((valuesList, (framesList, idxList)), shape=(len(frameRange), self.header["nx"]*self.header["ny"]*self.header["nf"]))
+            data["time"] = timeList
+            data["values"] = sp.csr_matrix( (vals, (rows, cols)) )
 
         return data
 


### PR DESCRIPTION
Significantly speeds up loading of sparse activity files in python (**~25x** from an SSD). Memory usage when loading in the PVP is also significantly reduced (maybe up to **4x** or more? hard to figure out, massif is lying to me about memory usage). Haven't been able to do extensive performance/whether-or-not-it-works-properly testing because I'm using a laptop.

When building the frame lookup for a sparse pvp file, I save the number of active neurons in each frame. When loading it in I then allocate 3 arrays:
 
- A row array to store row indices for active neurons (row values will be duplicated, 1 index per active neuron in that row). 
- A col array to store col indices for active neurons
- A value array to store the activation such that `matrix[row[i], [col[i]] = value[i]`
