### PR TITLE
Initializing from checkpoint with different nbatch

### DIFF
--- a/src/checkpointing/CheckpointEntryPvp.tpp
+++ b/src/checkpointing/CheckpointEntryPvp.tpp
@@ -112,13 +112,22 @@ void CheckpointEntryPvp<T>::read(std::string const &checkpointDirectory, double 
       path = generatePath(checkpointDirectory, "pvp");
       FileStream fileStream(path.c_str(), std::ios_base::in, false);
       struct BufferUtils::ActivityHeader header = BufferUtils::readActivityHeader(fileStream);
-      FatalIf(
-            header.nBands != numFrames,
-            "CheckpointEntryDataStore::read error reading \"%s\": delays*batchwidth in file is %d, "
-            "but delays*batchwidth in layer is %d\n",
-            path.c_str(),
-            header.nBands,
-            numFrames);
+      if (numFrames < header.nBands) {
+         WarnLog().printf(
+               "CheckpointEntryPvp reading \"%s\" expects %d bands, but the file has %d bands. "
+               "Extra bands will be ignored.\n",
+               path.c_str(),
+               numFrames,
+               header.nBands);
+      }
+      else if (numFrames > header.nBands) {
+         WarnLog().printf(
+               "CheckpointEntryPvp reading \"%s\" expects %d bands, but the file only has "
+               "%d bands. Bands will be repeated cyclically.\n",
+               path.c_str(),
+               numFrames,
+               header.nBands);
+      }
    }
    Buffer<T> pvpBuffer;
    std::vector<double> frameTimestamps;

--- a/src/components/ActivityComponent.cpp
+++ b/src/components/ActivityComponent.cpp
@@ -114,15 +114,6 @@ ActivityComponent::initializeState(std::shared_ptr<InitializeStateMessage const>
    return mActivity->respond(message);
 }
 
-Response::Status ActivityComponent::readStateFromCheckpoint(Checkpointer *checkpointer) {
-   Response::Status status = ComponentBasedObject::readStateFromCheckpoint(checkpointer);
-   if (!Response::completed(status)) {
-      return status;
-   }
-   auto message = std::make_shared<ReadStateFromCheckpointMessage<Checkpointer>>(checkpointer);
-   return notify(message, mCommunicator->globalCommRank() == 0 /*printFlag*/);
-}
-
 #ifdef PV_USE_CUDA
 Response::Status
 ActivityComponent::setCudaDevice(std::shared_ptr<SetCudaDeviceMessage const> message) {

--- a/src/components/ActivityComponent.hpp
+++ b/src/components/ActivityComponent.hpp
@@ -82,8 +82,6 @@ class ActivityComponent : public ComponentBasedObject {
    virtual Response::Status
    initializeState(std::shared_ptr<InitializeStateMessage const> message) override;
 
-   Response::Status readStateFromCheckpoint(Checkpointer *checkpointer) override;
-
 #ifdef PV_USE_CUDA
    virtual Response::Status
    setCudaDevice(std::shared_ptr<SetCudaDeviceMessage const> message) override;

--- a/tests/InitializeFromCheckpointDirTest/input/BaseRun.params
+++ b/tests/InitializeFromCheckpointDirTest/input/BaseRun.params
@@ -17,90 +17,90 @@
 debugParsing = false;    // Debug the reading of this parameter file.
 
 HyPerCol "column" = {
-   nx = 8;
-   ny = 8;
-   nbatch = 4;
-   dt = 1.0;
-   randomSeed = 1234567890;
-   stopTime = 10.0;  
-   errorOnNotANumber = true;
-   progressInterval = 10.0;
-   writeProgressToErr = false;
-   verifyWrites = false;
-   outputPath = "output-BaseRun/";
-   printParamsFilename = "pv.params";
-   initializeFromCheckpointDir = "";
-   checkpointWrite = true;
-   checkpointWriteDir = "output-BaseRun/checkpoints";
-   checkpointIndexWidth = -1;
-   suppressNonplasticCheckpoints = true;
-   deleteOlderCheckpoints = false;
-   checkpointWriteTriggerMode = "step";
-   checkpointWriteStepInterval = 1;
+    dt                                  = 1;
+    stopTime                            = 10;
+    progressInterval                    = 10;
+    writeProgressToErr                  = false;
+    printParamsFilename                 = "pv.params";
+    randomSeed                          = 1234567890;
+    nx                                  = 8;
+    ny                                  = 8;
+    nbatch                              = 4;
+    errorOnNotANumber                   = true;
+    outputPath                          = "output-BaseRun/";
+    verifyWrites                        = false;
+    checkpointWrite                     = true;
+    checkpointWriteDir                  = "output-BaseRun/checkpoints";
+    checkpointWriteTriggerMode          = "step";
+    checkpointWriteStepInterval         = 1;
+    checkpointIndexWidth                = -1;
+    suppressNonplasticCheckpoints       = true;
+    deleteOlderCheckpoints              = false;
+    initializeFromCheckpointDir         = "";
 };
 
-//
-// layers
-//
-
 PvpLayer "Input" = {
-    nxScale = 1;
-    nyScale = 1;
-    	      	
-    inputPath = "input/input.pvp";
-    nf = 1;
-    phase = 0;
-    writeStep = 1.0;
-    initialiWriteTime = 0.0;
-    sparseLayer = false;
-    mirrorBCflag = false;
-    valueBC = 0.0;
-    useInputBCflag = false;
-    updateGpu = false;
-    inverseFlag = false; 
-    normalizeLuminanceFlag = false;
-    autoResizeFlag = false;
-    offsetAnchor = "tl";
-    offsetX = 0;
-    offsetY = 0;
-    padValue = false;
-    displayPeriod = 100;
-    batchMethod = "bySpecified";
-    start_frame_index = [0, 1, 2, 3];
-    skip_frame_index = [1, 1, 1, 1];
-    writeFrameToTimestamp = true;
-    resetToStartOnLoop = false;
+    initializeFromCheckpointFlag        = false;
+    nxScale                             = 1;
+    nyScale                             = 1;
+    nf                                  = 1;
+    phase                               = 0;
+    mirrorBCflag                        = false;
+    valueBC                             = 0;
+    displayPeriod                       = 100;
+    inputPath                           = "input/input.pvp";
+    offsetAnchor                        = "tl";
+    offsetX                             = 0;
+    offsetY                             = 0;
+    maxShiftX                           = 0;
+    maxShiftY                           = 0;
+    xFlipEnabled                        = false;
+    yFlipEnabled                        = false;
+    xFlipToggle                         = false;
+    yFlipToggle                         = false;
+    jitterChangeInterval                = 1;
+    autoResizeFlag                      = false;
+    inverseFlag                         = false;
+    normalizeLuminanceFlag              = false;
+    useInputBCflag                      = false;
+    padValue                            = 0;
+    batchMethod                         = "bySpecified";
+    randomSeed                          = 123456789;
+    start_frame_index                   = [0, 1, 2, 3];
+    skip_frame_index                    = [1, 1, 1, 1];
+    resetToStartOnLoop                  = false;
+    writeFrameToTimestamp               = true;
+    updateGpu                           = false;
+    sparseLayer                         = false;
+    writeStep                           = 1;
+    initialWriteTime                    = 0;
 };
 
 LeakyIntegrator "Output" = {
-    nxScale = 1; 
-    nyScale = 1;
-    nf = 1;
-    phase = 1;
-    triggerLayerName = NULL;
-    writeStep = 1.0;
-    initialWriteTime = 0.0;
-    mirrorBCflag = 1;
-    sparseLayer = false;
-    updateGpu = false;
-
-    InitVType = "ZeroV";
-
-    VThresh = -infinity;   
-    AMax = infinity;
-    AMin = -infinity;
-    AShift = 0.0;
-    VWidth = 0.0;
-
-    integrationTime = infinity;
+    initializeFromCheckpointFlag        = false;
+    nxScale                             = 1;
+    nyScale                             = 1;
+    nf                                  = 1;
+    phase                               = 1;
+    mirrorBCflag                        = true;
+    triggerLayerName                    = NULL;
+    VThresh                             = -infinity;
+    AMin                                = -infinity;
+    AMax                                = infinity;
+    AShift                              = 0;
+    VWidth                              = 0;
+    InitVType                           = "ZeroV";
+    integrationTime                     = infinity;
+    updateGpu                           = false;
+    sparseLayer                         = false;
+    writeStep                           = 1;
+    initialWriteTime                    = 0;
 };
 
-//HyPerConns are connections between two layers
-
 IdentConn "InputToOutput" = {
-    preLayerName = "Input";
-    postLayerName = "Output";
-    channelCode = 0;
-
-    delay = 0;
+    initializeFromCheckpointFlag        = false;
+    preLayerName                        = "Input";
+    postLayerName                       = "Output";
+    channelCode                         = 0;
+    delay                               = 0;
 };

--- a/tests/InitializeFromCheckpointDirTest/input/InitializeFromCheckpointDirTest.params
+++ b/tests/InitializeFromCheckpointDirTest/input/InitializeFromCheckpointDirTest.params
@@ -17,92 +17,90 @@
 debugParsing = false;    // Debug the reading of this parameter file.
 
 HyPerCol "column" = {
-   nx = 8;
-   ny = 8;
-   nbatch = 4;
-   dt = 1.0;
-   randomSeed = 1234567890;
-   stopTime = 10.0;  
-   errorOnNotANumber = true;
-   progressInterval = 10.0;
-   writeProgressToErr = false;
-   verifyWrites = false;
-   outputPath = "output-InitializeFromCheckpointDir/";
-   printParamsFilename = "pv.params";
-   initializeFromCheckpointDir = "output-BaseRun/checkpoints/Checkpoint10";
-   checkpointWrite = true;
-   checkpointWriteDir = "output-InitializeFromCheckpointDir/checkpoints";
-   checkpointIndexWidth = -1;
-   suppressNonplasticCheckpoints = true;
-   deleteOlderCheckpoints = false;
-   checkpointWriteTriggerMode = "step";
-   checkpointWriteStepInterval = 1;
+    dt                                  = 1;
+    stopTime                            = 10;
+    progressInterval                    = 10;
+    writeProgressToErr                  = false;
+    printParamsFilename                 = "pv.params";
+    randomSeed                          = 1234567890;
+    nx                                  = 8;
+    ny                                  = 8;
+    nbatch                              = 4;
+    errorOnNotANumber                   = true;
+    outputPath                          = "output-InitializeFromCheckpointDir/";
+    verifyWrites                        = false;
+    checkpointWrite                     = true;
+    checkpointWriteDir                  = "output-InitializeFromCheckpointDir/checkpoints";
+    checkpointWriteTriggerMode          = "step";
+    checkpointWriteStepInterval         = 1;
+    checkpointIndexWidth                = -1;
+    suppressNonplasticCheckpoints       = true;
+    deleteOlderCheckpoints              = false;
+    initializeFromCheckpointDir         = "output-BaseRun/checkpoints/Checkpoint10";
 };
 
-//
-// layers
-//
-
 PvpLayer "Input" = {
-    nxScale = 1;
-    nyScale = 1;
-    	      	
-    inputPath = "input/input.pvp";
-    nf = 1;
-    phase = 0;
-    writeStep = 1.0;
-    initialWriteTime = 0.0;
-    sparseLayer = false;
-    mirrorBCflag = false;
-    valueBC = 0.0;
-    useInputBCflag = false;
-    updateGpu = false;
-    initializeFromCheckpointFlag = false;
-    inverseFlag = false; 
-    normalizeLuminanceFlag = false;
-    autoResizeFlag = false;
-    offsetAnchor = "tl";
-    offsetX = 0;
-    offsetY = 0;
-    padValue = false;
-    displayPeriod = 100;
-    batchMethod = "bySpecified";
-    start_frame_index = [0, 1, 2, 3];
-    skip_frame_index = [1, 1, 1, 1];
-    writeFrameToTimestamp = true;
-    resetToStartOnLoop = false;
+    initializeFromCheckpointFlag        = false;
+    nxScale                             = 1;
+    nyScale                             = 1;
+    nf                                  = 1;
+    phase                               = 0;
+    mirrorBCflag                        = false;
+    valueBC                             = 0;
+    displayPeriod                       = 100;
+    inputPath                           = "input/input.pvp";
+    offsetAnchor                        = "tl";
+    offsetX                             = 0;
+    offsetY                             = 0;
+    maxShiftX                           = 0;
+    maxShiftY                           = 0;
+    xFlipEnabled                        = false;
+    yFlipEnabled                        = false;
+    xFlipToggle                         = false;
+    yFlipToggle                         = false;
+    jitterChangeInterval                = 1;
+    autoResizeFlag                      = false;
+    inverseFlag                         = false;
+    normalizeLuminanceFlag              = false;
+    useInputBCflag                      = false;
+    padValue                            = 0;
+    batchMethod                         = "bySpecified";
+    randomSeed                          = 123456789;
+    start_frame_index                   = [0, 1, 2, 3];
+    skip_frame_index                    = [1, 1, 1, 1];
+    resetToStartOnLoop                  = false;
+    writeFrameToTimestamp               = true;
+    updateGpu                           = false;
+    sparseLayer                         = false;
+    writeStep                           = 1;
+    initialWriteTime                    = 0;
 };
 
 LeakyIntegrator "Output" = {
-    nxScale = 1; 
-    nyScale = 1;
-    nf = 1;
-    phase = 1;
-    triggerLayerName = NULL;
-    writeStep = 1.0;
-    initialWriteTime = 0.0;
-    mirrorBCflag = 1;
-    sparseLayer = false;
-    updateGpu = false;
-    initializeFromCheckpointFlag = true;
-
-    InitVType = "ZeroV";
-
-    VThresh = -infinity;   
-    AMax = infinity;
-    AMin = -infinity;
-    AShift = 0.0;
-    VWidth = 0.0;
-
-    integrationTime = infinity;
+    initializeFromCheckpointFlag        = true;
+    nxScale                             = 1;
+    nyScale                             = 1;
+    nf                                  = 1;
+    phase                               = 1;
+    mirrorBCflag                        = true;
+    triggerLayerName                    = NULL;
+    VThresh                             = -infinity;
+    AMin                                = -infinity;
+    AMax                                = infinity;
+    AShift                              = 0;
+    VWidth                              = 0;
+    InitVType                           = "ZeroV";
+    integrationTime                     = infinity;
+    updateGpu                           = false;
+    sparseLayer                         = false;
+    writeStep                           = 1;
+    initialWriteTime                    = 0;
 };
 
-//HyPerConns are connections between two layers
-
 IdentConn "InputToOutput" = {
-    preLayerName = "Input";
-    postLayerName = "Output";
-    channelCode = 0;
-
-    delay = 0;
+    initializeFromCheckpointFlag        = false;
+    preLayerName                        = "Input";
+    postLayerName                       = "Output";
+    channelCode                         = 0;
+    delay                               = 0;
 };


### PR DESCRIPTION
If the checkpoint's nbatch is larger than the param file's nbatch, the extra batch elements are ignored.

If the checkpoint's nbatch is smaller, batch elements are repeated cyclically.

In either case, warnings are issued. In previous versions, a mismatch in the nbatch values would result in a fatal error.