### PR TITLE
Fixed rare issue with sparse matrix dimensions

### DIFF
--- a/python/pvtools/pvpFile.py
+++ b/python/pvtools/pvpFile.py
@@ -249,7 +249,7 @@ class pvpOpen(object):
 
             #Make csrsparsematrix
             data["time"] = timeList
-            data["values"] = sp.csr_matrix( (vals, (rows, cols)) )
+            data["values"] = sp.csr_matrix( (vals, (rows, cols)), shape=(len(frameRange), self.header["nx"] * self.header["ny"] * self.header["nf"]) )
 
         return data
 


### PR DESCRIPTION
When the sparse matrix was being constructed, I was allowing the CSR matrix constructor to infer the dimensions of the matrix. This is not a problem if every neuron fired. In the event that the last _n_ neurons (if the neurons are viewed as a flattened array) _never_  activated throughout the whole run, the CSR constructor would not know that there should be _n_ more columns in the sparse matrix (because there were no non-zero values in the final _n_ columns indicating that those columns existed). This commit fixes that by always specifying what the dimensions of the sparse matrix should be.

This does not change anything about how the sparse values are being loaded or how the sparse matrix is being constructed, it's only ensuring that the the shape of the matrix is correct.