### PR TITLE
Fixed rare issue with sparse matrix dimensions

### DIFF
--- a/python/pvtools/pvpFile.py
+++ b/python/pvtools/pvpFile.py
@@ -249,7 +249,7 @@ class pvpOpen(object):
 
             #Make csrsparsematrix
             data["time"] = timeList
-            data["values"] = sp.csr_matrix( (vals, (rows, cols)) )
+            data["values"] = sp.csr_matrix( (vals, (rows, cols)), shape=(len(frameRange), self.header["nx"] * self.header["ny"] * self.header["nf"]) )
 
         return data
 


### PR DESCRIPTION
Previously I was allowing the CSR sparse matrix constructor to infer the dimensions of the sparse matrix, which is generally not a problem. If the last _n_ _(n_ > 0) neurons in the LCA layer (when viewed as a flattened, 1D array) _never_ activated throughout an entire run, the sparse matrix constructed would be missing the last _n_ columns. The dimensions are only made wrong if a contiguous chunk at the _very_ end of the flattened array didn't activate.

This commit doesn't change how the sparse values are being loaded in, or how the sparse matrix is being constructed. The problem has been fixed by always specifying the dimensions the matrix should have when constructing it.