### PR TITLE
Interrupt handling

### DIFF
--- a/src/checkpointing/Checkpointer.cpp
+++ b/src/checkpointing/Checkpointer.cpp
@@ -778,8 +778,11 @@ void Checkpointer::checkpointWriteSignal(int checkpointSignal) {
    std::string checkpointDirectory = makeCheckpointDirectoryFromCurrentStep();
    checkpointToDirectory(checkpointDirectory);
    if (checkpointSignal == SIGUSR2 || checkpointSignal == SIGINT || checkpointSignal == SIGTERM) {
+      if (mMPIBlock->getGlobalRank() == 0) {
+         InfoLog() << "Exiting.\n";
+      }
       MPI_Finalize();
-      exit(checkpointSignal);
+      exit(EXIT_SUCCESS);
    }
 }
 

--- a/src/checkpointing/Checkpointer.hpp
+++ b/src/checkpointing/Checkpointer.hpp
@@ -227,10 +227,11 @@ class Checkpointer : public Subject {
    std::string makeCheckpointDirectoryFromCurrentStep();
 
    /**
-     * If a SIGUSR signal has been received by the global root process, clears the signal
-     * and returns true. Otherwise returns false.
+     * If a meaningful signal has been received by the global root process, clears the signal
+     * and returns its value. Otherwise returns 0.
+     * Currently, the meaningful signals are SIGINT, SIGTERM and SIGUSR1.
      */
-   bool receivedSignal();
+   int retrieveSignal();
 
    /**
      * Returns true if the params file settings indicate a checkpoint should occur at this
@@ -262,12 +263,14 @@ class Checkpointer : public Subject {
    bool scheduledWallclock();
 
    /**
-    * Called by checkpointWrite if a SIGUSR1 signal was sent (as reported by receivedSignal).
+    * Called by checkpointWrite if a meaningful signal was sent (as reported by retrieveSignal).
     * It writes a checkpoint, indexed by the current timestep. If the deleteOlderCheckpoints param
     * was set, it does not cause a checkpoint to be deleted, and does not rotate the checkpoint
     * into the list of directories that will be deleted.
+    * If the signal was SIGINT (Interrupt) or SIGTERM (Terminate), the program exits,
+    * returning the integer code corresponding to the signal.
     */
-   void checkpointWriteSignal();
+   void checkpointWriteSignal(int checkpointSignal);
 
    /**
     * Called by checkpointWrite() (if there was not a SIGUSR1 signal pending) and finalCheckpoint().

--- a/src/columns/PV_Init.cpp
+++ b/src/columns/PV_Init.cpp
@@ -62,21 +62,23 @@ PV_Init::~PV_Init() {
 }
 
 int PV_Init::initSignalHandler() {
-   // Block SIGINT, SIGTERM and SIGUSR1.  root process checks for these signals
-   // during Checkpointer::checkpointWrite() (typically called during HyPerCol::advanceTime())
-   // and broadcasts any caught signal to all processes.
+   // Block SIGUSR1, SIGUSR2, SIGINT, and SIGTERM.  root process checks for
+   // these signals during Checkpointer::checkpointWrite() (typically called
+   // during HyPerCol::advanceTime()) and broadcasts any caught signal to
+   // all processes.
    // CheckpointWrite() responds to the signals as follows:
-   // SIGINT or SIGTERM: write a checkpoint and quit.
    // SIGUSR1: write a checkpoint and continue.
+   // SIGUSR2, SIGINT or SIGTERM: write a checkpoint and quit.
    //
    // This routine must be called before MPI_Initialize; otherwise a thread
    // created by MPI will not get the signal handler
    // but will get the signal and the job will terminate.
    sigset_t blockusr1;
    sigemptyset(&blockusr1);
+   sigaddset(&blockusr1, SIGUSR1);
+   sigaddset(&blockusr1, SIGUSR2);
    sigaddset(&blockusr1, SIGINT);
    sigaddset(&blockusr1, SIGTERM);
-   sigaddset(&blockusr1, SIGUSR1);
    sigprocmask(SIG_BLOCK, &blockusr1, NULL);
    return 0;
 }


### PR DESCRIPTION
This pull request provides a mechanism to send signals for creating an immediate checkpoint and exiting cleanly. The difference between this request and <https://github.com/PetaVision/OpenPV/pull/294> is that this pull request goes into the develop branch.

If any of the signals SIGINT, SIGTERM, or SIGUSR2 are sent to the global root process, the signal is broadcast to the rest of the processes, an immediate checkpoint is performed, and the processes then call MPI_Finalize() and exit().

Sending SIGUSR1 to the global root process still causes an immediate checkpoint but does cause the job to exit.

Nonroot processes do not respond to these signals directly; instead they receive a broadcast message from the root process.

If checkpointWrite is false, the checkpoint is written to the path specified in lastCheckpointDir, as if stopTime had been set to the timestep when the signal was sent.