### PR TITLE
Improved deleteOlderCheckpoints

### DIFF
--- a/src/checkpointing/CheckpointEntry.cpp
+++ b/src/checkpointing/CheckpointEntry.cpp
@@ -19,7 +19,10 @@ std::string CheckpointEntry::generatePath(
       std::string const &checkpointDirectory,
       std::string const &extension) const {
    std::string path{checkpointDirectory};
-   path.append("/").append(getName()).append(".").append(extension);
+   path.append("/").append(getName());
+   if (!extension.empty()) {
+      path.append(".").append(extension);
+   }
    return path;
 }
 

--- a/src/checkpointing/CheckpointEntryRandState.cpp
+++ b/src/checkpointing/CheckpointEntryRandState.cpp
@@ -26,7 +26,7 @@ void CheckpointEntryRandState::read(std::string const &checkpointDirectory, doub
 }
 
 void CheckpointEntryRandState::remove(std::string const &checkpointDirectory) const {
-   deleteFile(checkpointDirectory, "bin");
+   deleteFile(checkpointDirectory, "pvp");
 }
 
 } // namespace PV

--- a/src/checkpointing/Checkpointer.cpp
+++ b/src/checkpointing/Checkpointer.cpp
@@ -883,7 +883,7 @@ void Checkpointer::rotateOldCheckpoints(std::string const &newCheckpointDirector
          struct stat lcp_stat;
          int statstatus = stat(targetDirectory.c_str(), &lcp_stat);
          if (statstatus != 0 || !(lcp_stat.st_mode & S_IFDIR)) {
-            if (statstatus == 0) {
+            if (statstatus) {
                ErrorLog().printf(
                      "Failed to delete older checkpoint: failed to stat \"%s\": %s.\n",
                      targetDirectory.c_str(),
@@ -896,14 +896,13 @@ void Checkpointer::rotateOldCheckpoints(std::string const &newCheckpointDirector
             }
          }
          sync();
-         std::string rmrf_string("");
-         rmrf_string     = rmrf_string + "rm -r '" + targetDirectory + "'";
-         int rmrf_result = system(rmrf_string.c_str());
-         if (rmrf_result != 0) {
-            WarnLog().printf(
-                  "unable to delete older checkpoint \"%s\": rm command returned %d\n",
-                  targetDirectory.c_str(),
-                  WEXITSTATUS(rmrf_result));
+         mTimeInfoCheckpointEntry->remove(targetDirectory);
+         deleteFileFromDir(targetDirectory, std::string("timers.txt"));
+         deleteFileFromDir(targetDirectory, std::string("pv.params"));
+         deleteFileFromDir(targetDirectory, std::string("pv.params.lua"));
+
+         for (auto &c : mCheckpointRegistry) {
+            c->remove(targetDirectory);
          }
       }
       MPI_Barrier(mMPIBlock->getGlobalComm());
@@ -928,6 +927,19 @@ void Checkpointer::rotateOldCheckpoints(std::string const &newCheckpointDirector
    mOldCheckpointDirectoriesIndex++;
    if (mOldCheckpointDirectoriesIndex == mNumCheckpointsKept) {
       mOldCheckpointDirectoriesIndex = 0;
+   }
+}
+
+void Checkpointer::deleteFileFromDir(std::string const &targetDir, std::string const &targetFile)
+      const {
+   std::string targetPath(targetDir + "/" + targetFile);
+   struct stat targetStat;
+   int status = stat(targetPath.c_str(), &targetStat);
+   if (status == 0) {
+      status = unlink(targetPath.c_str());
+   }
+   if (status != 0) {
+      ErrorLog().printf("Failure deleting \"%s\": %s\n", targetPath.c_str(), strerror(errno));
    }
 }
 

--- a/src/checkpointing/Checkpointer.hpp
+++ b/src/checkpointing/Checkpointer.hpp
@@ -293,6 +293,7 @@ class Checkpointer : public Subject {
     * old checkpoint directories, and adds the new checkpoint directory to the list.
     */
    void rotateOldCheckpoints(std::string const &newCheckpointDirectory);
+   void deleteFileFromDir(std::string const &targetDir, std::string const &targetFile) const;
    void writeTimers(std::string const &directory);
    std::string generateBlockPath(std::string const &baseDirectory);
    void verifyDirectory(char const *directory, std::string const &description);


### PR DESCRIPTION
This pull request changes the method for deleting older checkpoints. Instead of a blunt "rm -r" passed to a shell, each registered CheckpointEntry calls its remove method. Checkpointer then deletes the files that it wrote to the checkpoint (timers.txt, pv.params, pv.params.lua) and calls rmdir.