### PR TITLE
Added scripts to analyze errors and plot weights

### DIFF
--- a/mlab/util/.gitignore
+++ b/mlab/util/.gitignore
@@ -1,0 +1,3 @@
+errorcurve.sh
+weightsplot.sh
+sortweightsplot.sh

--- a/mlab/util/README.md
+++ b/mlab/util/README.md
@@ -1,0 +1,29 @@
+# How to use #
+Clone files to your local PetaVision folder (where your input, output and other folders are located). 
+
+In general the scripts are started by *.sh files. They have the extension *.sh.template in the repository. Delete the extension part ".template" and change settings locally. These local files are ignored by git (.gitignore)
+
+### errorcurve.sh
+Plots the L1-norm (i.e. sum) of the activity, the L2-norm of the reconstruction error (i.e. vector length) and a weighted sum for both. Three windows are going to appear: one with the first n display periods, one with the last m display periods and one with an overall error curve for only the settled value just before the next display period (shows wether the error improves over all).
+
+Settings can be adjusted for n and m. 
+Attention: display period has to be set manually! Otherwise, the wrong overall curve will be plotted!
+
+### weightsplot.sh
+Creates folder ./weights_movie and creates one plots of weights per checkpoint. 
+In the case of fish data, additionaly a vector fiel plot for each receptive field is created for the last checkpoint.
+
+### sortweightsplot.sh
+Like weightsplot.sh but sorted by average activity, gathered from the activity file of the HyperLCA-layer (V1.pvp, Pretectum.pvp)
+
+## Additional information ##
+
+Generally, these scripts should run both in Octave as well as in Matlab. 
+These scripts will depend on other scripts shipped with PetaVision, so you 
+have to add these to your path. In Octave that can be done by adding the 
+following line to a `~/.octaverc` file. In Matlab the same line works inside a 
+`startup.m`-file located anywhere in the search path:
+
+```bash
+addpath("~/OpenPV/mlab/util")
+```

--- a/mlab/util/errorcurve.m
+++ b/mlab/util/errorcurve.m
@@ -1,0 +1,248 @@
+% Used to visulize how the L2, L1 error and total energy of the network
+% changes during training. First n, last m timesteps are plotted as well as
+% all settled values and a running mean of the latter. Will also save figures
+% as png files in errorFileDir
+%
+% errorFileDir: usually ../output
+% filenames: cell containing the filenames for files containing the 
+%    L1-Error, L2-Error, Combined Energy (in that order)
+% plotLimits: 2-Vector specifying first n and last m timesteps to plot
+% displayPeriod: set in params file
+%
+%ToDo: extract display Period automatically
+
+function errorcurve(errorFileDir, filenames, plotLimits, displayPeriod)
+% clear all
+% close all
+% clc
+isOctave = exist('OCTAVE_VERSION', 'builtin') ~= 0; % for compatibility
+
+%% settings
+
+displayPeriodDetailedPlotLimit_first = plotLimits(1); % detailed data will only be plotted starting with this value
+displayPeriodDetailedPlotLimit_last = plotLimits(2); % detailed data will only be plotted up to this value
+plotDetailed    = true; % the first plot
+% displayPeriod   = 1000; % how many timesteps to settle the network
+
+
+L1Filename      = filenames{1};
+L2Filename      = filenames{2};
+EnergyFilename  = filenames{3};
+
+
+% L1Filename      = 'V1L1NormEnergyProbe_batchElement_0.txt';
+% L2Filename      = 'LeftErrorL2NormEnergyProbe_batchElement_0.txt';
+% EnergyFilename  = 'V1EnergyProbe_batchElement_0.txt';
+% errorFileDir    = '../output';
+
+
+% minor settings
+plotColors{1}=[1,0,0];
+plotColors{2}=[0,1,0];
+plotColors{3}=[0,0,1];
+
+
+%% read files line by line and display them in the meantime
+fprintf('\n');
+disp('Loading data:');
+currentMessage='Currently parsing display period no. 1';
+fprintf(currentMessage);
+
+fid = cell(3,1);
+fid{1} = fopen(fullfile(errorFileDir,L1Filename));
+fid{2} = fopen(fullfile(errorFileDir,L2Filename));
+fid{3} = fopen(fullfile(errorFileDir,EnergyFilename));
+fgetl(fid{3}); %read and discard first line, due to different displays of energy probes
+
+close all
+
+displayPeriod_current=0;
+rescaleFactor = cell(3,1);
+settledData  = cell(3,1);
+currentXMin   = inf;
+clear temp_lastData;
+displayPeriodData_complete=cell(3,1);
+while true
+    displayPeriod_current=displayPeriod_current+1;
+    
+    % print currently parsed display period.
+    for i = 1 : size(currentMessage,2)
+      fprintf('\b');
+    end
+    currentMessage = ['Currently parsing display period no. ',num2str(displayPeriod_current)];
+    fprintf(currentMessage);
+    if isOctave
+      fflush(stdout);
+    end
+    
+    clear displayPeriodData;
+    displayPeriodData = cell(3,1);
+    if exist('temp_lastData','var')
+        displayPeriodData=temp_lastData;
+        loopadd=1;
+    else
+        loopadd=0;
+    end
+    for j = 1 : size(fid,1) % number of displayed probes
+        for i = 1+loopadd : displayPeriod+loopadd % display period
+            temp_fileLine   = fgetl(fid{j});
+            if ~ischar(temp_fileLine) && temp_fileLine==-1
+                break;
+            end
+            temp_positions = [0, strfind(temp_fileLine,',')];
+            if size(temp_positions,2)<3
+                continue;
+            end
+            displayPeriodData{j}(i,1)  = sscanf(temp_fileLine(temp_positions(1)+1:end),'%g',1);
+            displayPeriodData{j}(i,2)  = sscanf(temp_fileLine(temp_positions(end)+1:end),'%f',1);
+            if mod(displayPeriodData{j}(i,1)+1,displayPeriod) == 0
+                settledData{j}(size(settledData{1},1)+1,1) = displayPeriodData{j}(i,1);
+                settledData{j}(end,2) = displayPeriodData{j}(i,2);
+            end
+        end
+    end
+    if isempty(displayPeriodData{3})
+        error('Error: No Data. Exiting.')
+    end
+    
+    % plot firts n data
+    if plotDetailed ...
+            && displayPeriodDetailedPlotLimit_first > 0 ...
+            && displayPeriod_current == displayPeriodDetailedPlotLimit_first
+        
+        figName = ['First ',num2str(displayPeriodDetailedPlotLimit_first),' Error Probes, every time step'];
+        detailedEnergyFigure_first = figure ('Name',figName,'NumberTitle','off','units','normalized','outerposition',[0 0 1 1]);
+        hold on;
+        legend Location northeast
+        for j = 1 : size(fid,1)
+            currentXMin=min(min(displayPeriodData_complete{j}(:,1)),currentXMin);
+            subplot(3,1,j)
+            hold on;
+            xlim([currentXMin,max(displayPeriodData_complete{j}(:,1))]);
+            plot(displayPeriodData_complete{j}(:,1), displayPeriodData_complete{j}(:,2),'Color',[plotColors{j}]);
+            if j==1
+                legend ('L1 Probe');
+            elseif j == 2
+                legend ('L2 Probe');
+            elseif j == 3
+                legend ('Combined Energy')
+            end
+        end
+        drawnow
+        saveas(detailedEnergyFigure_first,fullfile(errorFileDir,[figName,'.pdf']));
+    end
+    
+    % remember last value for next display
+    clear temp_lastData;
+    temp_lastData = cell(3,1);
+    for j = 1 : size(fid,1)
+        temp_lastData{j}(1,1)  = displayPeriodData{j}(end,1);
+        temp_lastData{j}(1,2)  = displayPeriodData{j}(end,2);
+        displayPeriodData_complete{j} = [displayPeriodData_complete{j}; displayPeriodData{j}];
+    end
+    
+    if ~ischar(temp_fileLine) && temp_fileLine==-1
+        clear temp_fileLine temp_positions;
+        break;
+    end
+end
+
+% plot last m data
+if plotDetailed ... 
+        && displayPeriodDetailedPlotLimit_last > 0
+    
+    if displayPeriod_current <= displayPeriodDetailedPlotLimit_last
+        figName = [num2str(displayPeriod_current),' Error Probes (+ offset), every time step'];
+        detailedEnergyFigure_last = figure ('Name',figName,'NumberTitle','off','units','normalized','outerposition',[0 0 1 1]);
+        last_n_reached=false;% size(displayPeriodData_complete{1},1)-1;
+    else
+        figName = ['Last ',num2str(displayPeriodDetailedPlotLimit_last),' Error Probes (+ offset), every time step'];
+        detailedEnergyFigure_last = figure ('Name',figName,'NumberTitle','off','units','normalized','outerposition',[0 0 1 1]);
+        last_n_reached=true;% displayPeriodDetailedPlotLimit_last*displayPeriod;
+    end
+    hold on;
+    legend Location northeast
+    for j = 1 : size(fid,1)
+        if last_n_reached
+            last_n = displayPeriodDetailedPlotLimit_last*displayPeriod;
+        else
+            last_n =  size(displayPeriodData_complete{j},1)-1;
+        end
+        currentXMin=min(displayPeriodData_complete{j}(end-last_n:end,1));
+        subplot(3,1,j)
+        hold on;
+        xlim([currentXMin,max(displayPeriodData_complete{j}(end-last_n:end,1))]);
+        plot(displayPeriodData_complete{j}(end-last_n:end,1), displayPeriodData_complete{j}(end-last_n:end,2),'Color',[plotColors{j}]);
+        
+        if j==1
+            legend ('L1 Probe');
+        elseif j == 2
+            legend ('L2 Probe');
+        elseif j == 3
+            legend ('Combined Energy')
+        end
+        
+    end
+    drawnow
+    saveas(detailedEnergyFigure_last,fullfile(errorFileDir,[figName,'.pdf']));
+end
+
+% close files
+for i = 1 : size(fid,1)
+    fclose(fid{i});
+end
+
+fprintf('\n');
+if isOctave
+      fflush(stdout);
+end
+
+%% plot learning
+if size(settledData{1},1)>1
+    windowSize = ceil(size(settledData{1},1)*.3);
+    if windowSize >= size(settledData{1},1)
+        windowSize = size(settledData{1},1)-1;
+    end
+    figName = 'Error Probes, only last value of display period.';
+    learningEnergyFigure = figure ('Name',figName,'NumberTitle','off','units','normalized','outerposition',[0 0 1 1]);
+    hold on;
+    smoothed=cell(3,1);
+    for j = 1 : size(fid,1)
+        if settledData{j}(1,1)==0
+            settledData{j}=settledData{j}(2:end,:);
+        end
+        subplot(3,1,j)
+        hold on;
+        plot(settledData{j}(:,1), settledData{j}(:,2),'Color',[plotColors{j}]);
+        clear temp_smoothed
+        smoothed{j} = imfilter(settledData{j}(:,2), fspecial('average', [windowSize 1]));
+        plot(settledData{j}(ceil(windowSize/2)+1:end-floor(windowSize/2),1), smoothed{j}(ceil(windowSize/2)+1:end-floor(windowSize/2)),'Color',[plotColors{j}]*.7,'LineWidth',2);
+    end
+    
+    
+    for j = 1 : size(fid,1)
+        subplot(3,1,j)
+        hold on;
+        clear temp_maxVal temp_minVal temp_diff
+        temp_maxVal = max(smoothed{j}(ceil(windowSize/2)+1:end-floor(windowSize/2)));
+        temp_minVal = min(smoothed{j}(ceil(windowSize/2)+1:end-floor(windowSize/2)));
+        temp_diffFraction = (temp_maxVal - temp_minVal) * .03;
+        temp_diffFraction = max(temp_diffFraction,temp_maxVal*.0001);
+        ylim([temp_minVal-temp_diffFraction, temp_maxVal+temp_diffFraction]);
+        legend Location northeast
+        if j==1
+            legend ('L1 Probe (only settled value)', ['L1 Probe (running mean, window size ',num2str(windowSize),')']);
+        elseif j == 2
+            legend ('L2 Probe (only settled value)', ['L2 Probe (running mean, window size ',num2str(windowSize),')']);
+        elseif j == 3
+            legend ('Combined Energy Function (only settled value)', ['Combined Energy Function (running mean, window size ',num2str(windowSize),')'])
+        end
+    end
+    drawnow
+    saveas(learningEnergyFigure,fullfile(errorFileDir,[figName,'.pdf']));
+end
+if isOctave
+  disp('Hit any key to exit and close all windows');
+  pause
+end
+end

--- a/mlab/util/errorcurve.sh.template
+++ b/mlab/util/errorcurve.sh.template
@@ -1,0 +1,18 @@
+#!/bin/sh
+#
+# Used to visulize how the L2, L1 error and total energy of the network
+# First 30 and last 30 display periods in order to evaluate how well optimization settles.
+# Additionally, plot only settled values in order to monitor improvement.
+
+plotLimitLow=15;
+plotLimitHigh=15;
+displayPeriod=150;
+
+errorFileDir='../output';
+L1Filename='V1L1NormEnergyProbe_batchElement_0.txt';
+L2Filename='InputErrorL2NormEnergyProbe_batchElement_0.txt';
+EnergyFilename='V1L1NormEnergyProbe_batchElement_0.txt';
+ 
+command="errorcurve('"$errorFileDir"', {'$L1Filename','$L2Filename','$EnergyFilename'},[$plotLimitLow,$plotLimitHigh],$displayPeriod);"
+octave --eval "$command";
+

--- a/mlab/util/sortweightsplot.m
+++ b/mlab/util/sortweightsplot.m
@@ -1,0 +1,128 @@
+% Sort the weigth vectors by their overall activities in the training or testing process
+%  output_dir: 
+%       where to find the pvp-activity file  
+%       also, the weights_move folder with the plots will be placed here
+%  activity_file: filename of activity layer, e.g., V1
+%  checkpoint_dir: where to find the weight files
+%  weight_files: string of weightfile name. 
+%       If more than one weight (e.g. stereo) input is a cell of strings.
+%       Cell arrangement also specifies sub arangement of kernels (e.g. 4x1, 2x2) 
+%  sortby: sort by 'percentActive' or by 'meanActivity'
+%  showActivityPlots: whether to show the activity spectrum
+%  pauseflag: whether to pause after activity spectrum has been plotted
+%  nLookBack: calculate on the basis of the last nLookBack displayPeriods
+function ind=sortweightsplot(output_dir,activity_file,checkpoint_dir,weights_files,sortby,showActivityPlots,pauseflag,nLookBack)
+
+isOctave = exist('OCTAVE_VERSION', 'builtin') ~= 0; % for compatibility
+
+if ~exist('pauseflag','var')
+    pauseflag=false;
+end
+
+if isempty(dir(fullfile(output_dir,'weights_movie')))
+    mkdir(fullfile(output_dir,'weights_movie'));
+end
+
+disp('Reading activity file.')
+[data,header]=readpvpfile(fullfile(output_dir,activity_file),1000000);
+
+if ~exist('nLookBack')
+	nLookBack=199;
+else
+	nLookBack=nLookBack-1;
+end
+lookBackForReal = max(1,size(data,1)-nLookBack) : size(data,1);
+nLookBackForReal = length(lookBackForReal);
+data=data(end-nLookBackForReal+1:end);
+
+disp(['Looking back ',num2str(nLookBackForReal), ' presentations.']);
+allEmpty=true;
+v1pack=nan(header.nf,header.nx,header.ny,nLookBackForReal);
+activityDistribution=nan(nLookBackForReal,1);
+for i = 1:nLookBackForReal
+		if mod(i,floor((nLookBackForReal+1)/10)) == 0
+			fprintf('.')
+		end
+    v1container_tmp=zeros(header.nx*header.ny*header.nf,1);
+    if ~isempty(data{i}.values)
+        v1container_tmp(data{i}.values(:,1)+1)=data{i}.values(:,2);
+        v1pack(:,:,:,i)=reshape(v1container_tmp,header.nf,header.nx,header.ny);
+        activityDistribution(i)=size(data{i}.values,1);
+        allEmpty=false;
+    else
+        v1pack(:,:,:,i)=reshape(v1container_tmp,header.nf,header.nx,header.ny);
+        activityDistribution(i)=0;
+    end
+end
+fprintf('\n')
+if allEmpty
+    warning('Data structure is empty. No activity (within the last ',num2str(nLookBackForReal),' display periods)?')
+    warning('Plotting without sorting.')
+    weightsplot(output_dir,checkpoint_dir,weights_files);
+else
+		disp('Done. Now sorting.')
+    [counted,ind]=sortAndCount(v1pack,sortby);
+    proportioned=counted/nLookBackForReal/header.nx/header.ny*100;
+    
+    listToWrite=[[1:length(proportioned)]',ind,proportioned];
+    %listToWrite=sortrows(listToWrite,1);
+    csvwrite(fullfile(output_dir,'weights_movie',[sortby,'_values','.csv']), listToWrite);
+    csvwrite(fullfile(output_dir,'weights_movie',['activityDistribution','.csv']), [header.nx*header.ny*header.nf;nan;activityDistribution])
+    
+    if exist('showActivityPlots') && showActivityPlots==true
+			disp('Done. Now generating plots.')
+			
+			activityplot=figure;
+			bar(proportioned);
+			xlabel('The index number of kernels')
+			if strcmp(sortby,'percentActive')
+				ylabel(['Percent active within ',num2str(nLookBackForReal),' presentations [%]' ])
+			elseif strcmp(sortby,'meanActivity')
+				ylabel(['Mean activity within ',num2str(nLookBackForReal),' presentations' ])
+			else
+				error('valid options for sorting are "percentActive" and "meanActivity".')
+			end
+			axis tight
+			drawnow
+			saveas(activityplot,fullfile(output_dir,'weights_movie',[sortby,'_spectrum','.png']))
+			
+			numActivePlot=figure;
+			hist(activityDistribution,...
+				max(1,min(20,(size(activityDistribution,1)/2))));
+			xlabel([{'Activity per presentation [# active].'},{['# model neurons = ',num2str(header.nx*header.ny*header.nf)]}]);
+			ylabel(['Frequency (', num2str(nLookBackForReal), ' Presentations)']);
+			drawnow
+			saveas(numActivePlot,fullfile(output_dir,'weights_movie',['nActiveElementsPerPresentation','.png']))
+			
+			percentActivePlot=figure;
+			hist(activityDistribution/(header.nf*header.nx*header.ny)*100,...
+				max(1,min(20,(size(activityDistribution,1)/2))));
+			xlabel([{'Activity-ratio per presentation [% active].'},{['# model neurons = ',num2str(header.nx*header.ny*header.nf)]}]);
+			ylabel(['Frequency (', num2str(nLookBackForReal), ' Presentations)']);
+			drawnow
+			saveas(percentActivePlot,fullfile(output_dir,'weights_movie',['percentActiveElementsPerPresentation','.png']))
+    end
+    
+		disp('Done. Now calling weightsplot function.')
+    weightsplot(output_dir,checkpoint_dir,weights_files,ind,[],['sortedBy_',sortby]);
+    if isOctave && pauseflag && exist('showActivityPlots') && showActivityPlots==true
+			disp('Hit any key to exit and close all windows');
+			pause
+		end
+end
+
+end
+
+
+
+
+
+function [y,i] = sortAndCount(x,sortby)
+	if strcmp(sortby,'percentActive')
+		[y,i] = sort(sum(sum(sum(logical(x),2),3),4),'descend');
+	elseif strcmp(sortby,'meanActivity')
+		[y,i] = sort(sum(sum(sum(x,2),3),4),'descend');
+	else
+		error('valid options for sorting are "percentActive" and "meanActivity".')
+	end
+end

--- a/mlab/util/sortweightsplot.sh.template
+++ b/mlab/util/sortweightsplot.sh.template
@@ -1,0 +1,4 @@
+#!/bin/sh
+
+command="sortweightsplot('../output','V1.pvp' ,'../output/Checkpoints',{'V1ToInputError_W.pvp',},'percentActive',true);"
+octave --eval "$command";

--- a/mlab/util/weightsplot.m
+++ b/mlab/util/weightsplot.m
@@ -1,0 +1,206 @@
+% Make basis vector images
+%  output_dir: where to place a directory "weights_movie". Plots will be located here.
+%  checkpoint_dir: where to find the weight files
+%  weight_files: string of weightfile name. 
+%       If more than one weight (e.g. stereo) input is a cell of strings.
+%       Cell arrangement also specifies sub arangement of kernels (e.g. 4x1, 2x2)
+%  ind: vector of indices to plot kernels in this order. "Used by sortweightsplot.m"
+%  cols: number of columns (for overriding standard aspect ratio)
+%  prefix: file name prefix (e.g. sorted)
+function weightsplot(output_dir,checkpoint_dir,weights_files,ind,cols,prefix)
+
+if ~exist('ind','var')
+        ind=[];
+end
+if ~exist('cols','var')
+        cols=[];
+end
+if ~exist('prefix') || isempty(prefix)
+    prefix='';
+else
+    prefix=[prefix,'_'];
+end
+
+wfolder=dir(checkpoint_dir);
+if isempty(dir(fullfile(output_dir,'weights_movie')))
+    mkdir(fullfile(output_dir,'weights_movie'));
+end
+
+outdir=fullfile(output_dir,'weights_movie');
+if isempty(wfolder)
+    error('Error: checkpoint folder does not exist.')
+end
+
+if ~iscell(weights_files) && ischar(weights_files)
+    weights_files_tmp=weights_files;
+    weights_files=cell(1,1);
+    weights_files{1}=weights_files_tmp;
+end
+
+
+for checkpoint_i=3:length(wfolder)
+    %assert(iscell(weights_files),'Error: weights_files has to be a cell. Note: Order of elements will be reflect in the plot (e.g. for stereo kernels).')
+    w=cell(size(weights_files));
+    header=cell(size(weights_files));
+    for weights_i = 1 : numel(w)
+            [w_tmp,header(weights_i)]=readpvpfile(fullfile(checkpoint_dir,wfolder(checkpoint_i).name,weights_files{weights_i}));
+            w{weights_i}=squeeze(w_tmp{1,1}.values{1,1});
+        end
+        niceImageToSave=createNiceProportionsToPlot(w,ind,cols,header{1}.nf);
+    imwrite(uint8(niceImageToSave),fullfile(outdir,[prefix,wfolder(checkpoint_i).name,'.png']));
+    
+    fprintf('%d of %d done\n',checkpoint_i-2,length(wfolder)-2)
+end %checkpoint_i
+
+
+end %weightsplot
+
+
+
+
+
+
+
+function out=createNiceProportionsToPlot(weights,ind,cols,nSubplots)
+
+
+    % make an approximate 16:9 image of the weights
+    if ~exist('cols','var') || isempty(cols)       
+        num_cols=1;num_rows=1;
+        while num_cols*num_rows < nSubplots
+                    if (num_cols+1)*num_rows >= nSubplots
+                        num_cols=num_cols+1;
+                    elseif num_cols*(num_rows+1) >= nSubplots
+                        num_rows=num_rows+1;
+                    elseif num_cols/num_rows > (16/size(weights,2))/(9/size(weights,1)) %16:9, but weights might have a sub ratio (e.g. stereo)
+            num_rows=num_rows+1;
+        else
+                        num_cols=num_cols+1;
+        end
+        end
+        if (num_cols-1)*num_rows >= nSubplots
+                    num_cols=num_cols-1;
+                elseif num_cols*(num_rows-1) >= nSubplots
+                    num_rows=num_rows-1;
+                end
+        else
+                num_rows = ceil(nSubplots/num_cols);
+        end
+            
+    % put the kernels to their right places		
+    container=cell(num_rows,num_cols);
+    subcontainer_tmp=cell(size(weights));
+    for i_kernel = 1:nSubplots
+            % put subkernels to their place 
+            minMaxWeights_tmp=0;
+            for i_nPerKernel = 1:numel(weights)
+                    if ndims(weights{i_nPerKernel})==4; % 3dm color kernels
+                        subcontainer_tmp{i_nPerKernel}=weights{i_nPerKernel}(:,:,:,i_kernel);
+                    elseif ndims(weights{i_nPerKernel})==3; % 2dim greylevel kernels
+                        subcontainer_tmp{i_nPerKernel}=weights{i_nPerKernel}(:,:,i_kernel);
+                    elseif ndims(weights{i_nPerKernel})==2 % reshapes vector to square (so far only pca data)
+                    w_tmp=weights{i_nPerKernel}(:,i_kernel);
+                        w_reshapeBase_tmp=nan(ceil(sqrt(length(w_tmp))));
+                        w_reshapeBase_tmp(1:length(w_tmp))=w_tmp;
+                        subcontainer_tmp{i_nPerKernel}=w_reshapeBase_tmp;
+                    end
+                    
+                    minMaxWeights_tmp=max(minMaxWeights_tmp,max(abs(subcontainer_tmp{i_nPerKernel}(:))));
+            end %i_nPerKernel
+            
+            % normalize (for max value)
+            for i_nPerKernel = 1:numel(weights)
+                subcontainer_tmp{i_nPerKernel}=subcontainer_tmp{i_nPerKernel}/minMaxWeights_tmp;
+            end
+            
+            % add dotted borders (for subkernels, e.g. stereo)
+            % add vertical dotted borders 
+            dottedVertLine=[zeros(1,1);-ones(2,1);zeros(1,1)];
+            dottedVertLine=repmat(dottedVertLine,ceil((1+size(subcontainer_tmp{1},1))/length(dottedVertLine)),1);
+            
+            if ndims(weights{i_nPerKernel})==4
+                dottedVertLine=repmat(dottedVertLine,1,1,3);
+            end
+            
+            for i_horz = 1 : size(subcontainer_tmp,1)
+                for i_dottedVertLines = 1 : size(subcontainer_tmp,2)-1
+                    subcontainer_tmp{i_horz,i_dottedVertLines}=[subcontainer_tmp{i_horz,i_dottedVertLines},...
+                        dottedVertLine(1:size(subcontainer_tmp{i_horz,i_dottedVertLines},1),:,:)];
+                end
+            end
+            
+            % add horizontal dotted borders 
+            dottedHorzLine=[zeros(1,1),-ones(1,2),zeros(1,1)];
+            dottedHorzLine=repmat(dottedHorzLine,1,ceil((1+size(subcontainer_tmp{1},2))/length(dottedHorzLine)));
+            if ndims(weights{i_nPerKernel})==4
+                dottedHorzLine=repmat(dottedHorzLine,1,1,3);
+            end
+            for i_vert = 1 : size(subcontainer_tmp,2)
+                for i_dottedHorzLines = 1 : size(subcontainer_tmp,1)-1
+                    subcontainer_tmp{i_dottedHorzLines,i_vert}=[subcontainer_tmp{i_dottedHorzLines,i_vert};...
+                        dottedHorzLine(:,1:size(subcontainer_tmp{i_dottedHorzLines,i_vert},2),:)];
+                end
+            end
+            
+            for i_row = 1 : size(subcontainer_tmp,1)
+                horz_tmp=[];
+                for i_col = 1 : size(subcontainer_tmp,2)
+                    horz_tmp=[horz_tmp,subcontainer_tmp{i_row,i_col}];
+                end
+                container{i_kernel}=[container{i_kernel};horz_tmp];
+            end
+            
+    end %i_kernel
+        
+    emptycell=find(cellfun(@isempty,container)==1);
+    
+    for i_emptycell=1:length(emptycell)
+        container{emptycell(i_emptycell)}=zeros(size(container{1,1}));
+    end
+        
+    % apply sorting
+    if (exist('ind') && ~isempty(ind))
+            container(1:max(size(ind)))=container(ind);
+        end
+
+        %add borders
+        for i_row = 1 : size(container,1)
+            for i_col = 1 : size(container,2)
+                
+                    %top and left
+                    container{i_row,i_col}=[...
+                    -ones(size(container{i_row,i_col},1),...
+                        1,
+                        size(container{i_row,i_col},3)),...
+                    container{i_row,i_col}];
+                    container{i_row,i_col}=[...
+                    -ones(1,...
+                        size(container{i_row,i_col},2),...
+                        size(container{i_row,i_col},3)
+                    );container{i_row,i_col}];
+                    %bottom and right
+                    if i_row == size(container,1)
+                        container{i_row,i_col}=[container{i_row,i_col};...
+                            -ones(1,...
+                                size(container{i_row,i_col},2),...
+                                size(container{i_row,i_col},3)
+                        )];
+                    end
+                    if i_col == size(container,2)
+                        container{i_row,i_col}=[container{i_row,i_col},...
+                            -ones(size(container{i_row,i_col},1),...
+                                1,...
+                                size(container{i_row,i_col},3)
+                            )];
+                    end
+            end
+        end
+
+    concate_weight=cell2mat(container);
+    minVal=min(concate_weight(:));
+    maxVal=max(concate_weight(:));
+    minmaxVal=max(abs(maxVal),abs(minVal));
+    out=concate_weight*(1.2*127/minmaxVal)+128;
+end %createNiceProportionsToPlot
+
+

--- a/mlab/util/weightsplot.sh.template
+++ b/mlab/util/weightsplot.sh.template
@@ -1,0 +1,3 @@
+#!/bin/sh
+
+octave --eval "weightsplot('../output','../output/Checkpoints',{'V1ToInputError_W.pvp'});";


### PR DESCRIPTION
Added scripts that I have been using for analyzing running PetaVision runs. 

# How to use #
Clone files to your local PetaVision folder (where your input, output and other folders are located). 

In general the scripts are started by *.sh files. They have the extension *.sh.template in the repository. Delete the extension part ".template" and change settings locally. These local files are ignored by git (.gitignore)

### errorcurve.sh
Plots the L1-norm (i.e. sum) of the activity, the L2-norm of the reconstruction error (i.e. vector length) and a weighted sum for both. Three windows are going to appear: one with the first n display periods, one with the last m display periods and one with an overall error curve for only the settled value just before the next display period (shows wether the error improves over all).
Settings can be adjusted for n and m. 
Attention: display period has to be set manually! Otherwise, the wrong overall curve will be plotted!

### weightsplot.sh
Creates folder ./weights_movie and creates one plots of weights per checkpoint. 
In the case of fish data, additionaly a vector fiel plot for each receptive field is created for the last checkpoint.

### sortweightsplot.sh
Like weightsplot.sh but sorted by average activity, gathered from the activity file of the HyperLCA-layer (V1.pvp, Pretectum.pvp)