### PR TITLE
Dry run exits before layers etc. create files

### DIFF
--- a/src/columns/HyPerCol.cpp
+++ b/src/columns/HyPerCol.cpp
@@ -342,20 +342,8 @@ void HyPerCol::allocateColumn() {
       return;
    }
 
-   // processParams function does communicateInitInfo stage, sets up adaptive
-   // time step, and prints params
-   pvAssert(mPrintParamsFilename && mPrintParamsFilename[0]);
-   if (mPrintParamsFilename[0] != '/') {
-      std::string printParamsFilename(mPrintParamsFilename);
-      std::string printParamsPath = mCheckpointer->makeOutputPathFilename(printParamsFilename);
-      processParams(printParamsPath.c_str());
-   }
-   else {
-      // If using absolute path, only global rank 0 writes, to avoid collisions.
-      if (mCheckpointer->getMPIBlock()->getGlobalRank() == 0) {
-         processParams(mPrintParamsFilename);
-      }
-   }
+   // processParams function does communicateInitInfo stage and prints params
+   processParams(mPrintParamsFilename);
 
 #ifdef PV_USE_CUDA
    // Needs to go between CommunicateInitInfo (called by processParams) and
@@ -593,7 +581,11 @@ ObserverTable HyPerCol::getAllObjectsFlat() {
    return objectTable;
 }
 
-int HyPerCol::processParams(char const *path) {
+void HyPerCol::processParams(char const *path) {
+   if (mParamsProcessedFlag) {
+      return;
+   }
+
    auto objectTable = getAllObjectsFlat();
 
    if (!mParamsProcessedFlag) {
@@ -606,11 +598,24 @@ int HyPerCol::processParams(char const *path) {
                   mNumBatchGlobal,
                   mNumThreads));
    }
+   parameters()->warnUnread();
 
    // Print a cleaned up version of params to the file given by printParamsFilename
-   parameters()->warnUnread();
    if (path != nullptr && path[0] != '\0') {
-      outputParams(path);
+      std::string printParamsPath;
+      if (path[0] != '/') {
+         // If using relative path, create a path for each MPIBlock.
+         printParamsPath = mCheckpointer->makeOutputPathFilename(std::string(path));
+      }
+      else {
+         // If using absolute path, only global rank 0 writes, to avoid collisions.
+         if (mCheckpointer->getMPIBlock()->getGlobalRank() != 0) {
+            return;
+         }
+         printParamsPath = path;
+      }
+
+      outputParams(printParamsPath.c_str());
    }
    else {
       if (globalRank() == 0) {
@@ -620,7 +625,7 @@ int HyPerCol::processParams(char const *path) {
       }
    }
    mParamsProcessedFlag = true;
-   return PV_SUCCESS;
+   return;
 }
 
 void HyPerCol::advanceTimeLoop(Clock &runClock, int const runClockStartingStep) {

--- a/src/columns/HyPerCol.cpp
+++ b/src/columns/HyPerCol.cpp
@@ -447,13 +447,14 @@ int HyPerCol::run(double stopTime, double dt) {
             "Warning: more MPI processes than available threads.  "
             "Processors may be oversubscribed.\n");
    }
-   allocateColumn();
-   getOutputStream().flush();
-
+   processParams(mPrintParamsFilename);
    bool dryRunFlag = mPVInitObj->getBooleanArgument("DryRun");
    if (dryRunFlag) {
       return PV_SUCCESS;
    }
+
+   allocateColumn();
+   getOutputStream().flush();
 
 #ifdef TIMER_ON
    Clock runClock;

--- a/src/columns/HyPerCol.hpp
+++ b/src/columns/HyPerCol.hpp
@@ -136,7 +136,7 @@ class HyPerCol : public Subject, public ParamsInterface {
    void nonblockingLayerUpdate(
          std::shared_ptr<LayerRecvSynapticInputMessage const> recvMessage,
          std::shared_ptr<LayerUpdateStateMessage const> updateMessage);
-   int processParams(char const *path);
+   void processParams(char const *path);
 
    /**
     * This function tells each added object to perform the tasks necessary
@@ -231,8 +231,7 @@ class HyPerCol : public Subject, public ParamsInterface {
    bool mCheckpointReadFlag; // whether to load from a checkpoint directory
    bool mReadyFlag; // Initially false; set to true when communicateInitInfo,
    // allocateDataStructures, and initializeState stages are completed
-   bool mParamsProcessedFlag; // Initially false; set to true when processParams
-   // is called.
+   bool mParamsProcessedFlag = false; // Set to true when processParams() is called.
    bool mWriteTimeScaleFieldnames; // determines whether fieldnames are written to
    // HyPerCol_timescales file
    bool mWriteProgressToErr; // Whether to write progress step to standard error


### PR DESCRIPTION
This pull request moves up the check for the dry run flag to before the RegisterData stage, when many files are first created. With this pull request, the only files created when the dry run flag is set are:
* the outputPath directory (if not already present)
* the checkpointWriteDir (if not already present and checkpointWrite is true)
* The generated .params and .params.lua files in the outputPath directory

This means that when the DryRun flag is set, output from a previous run should not be clobbered, except for the generated .params and .params.lua files.