### PR TITLE
DropoutLayer fix

### DIFF
--- a/src/components/DropoutActivityBuffer.hpp
+++ b/src/components/DropoutActivityBuffer.hpp
@@ -8,6 +8,7 @@
 #ifndef DROPOUTACTIVITYBUFFER_HPP_
 #define DROPOUTACTIVITYBUFFER_HPP_
 
+#include "columns/Random.hpp"
 #include "components/ANNActivityBuffer.hpp"
 
 namespace PV {
@@ -48,6 +49,8 @@ class DropoutActivityBuffer : public ANNActivityBuffer {
 
    virtual int ioParamsFillGroup(enum ParamsIOFlag ioFlag) override;
 
+   virtual Response::Status allocateDataStructures() override;
+
    /**
     * Updates as ANNActivityBuffer updates, and then applies random dropout based on
     * the Probability parameter.
@@ -56,6 +59,8 @@ class DropoutActivityBuffer : public ANNActivityBuffer {
 
   protected:
    int mProbability = 0; // Value from 0-99 indicating per-neuron chance of dropout
+
+   Random *mRandState = nullptr; // array of RNGs
 };
 
 } // namespace PV

--- a/tests/DropoutLayerTest/input/DropoutLayerTest_05.params
+++ b/tests/DropoutLayerTest/input/DropoutLayerTest_05.params
@@ -50,12 +50,12 @@ DropoutLayer "Output" = {
     probability         = 5; 
 };
 
-LeakyIntegrator "Average" = {
+LeakyIntegrator "Counts" = {
     nxScale             = 1; 
     nyScale             = 1;
     nf                  = 1; 
     phase               = 2;
-    integrationTime     = 100;
+    integrationTime     = infinity;
     writeStep           = -1;
     initialWriteTime    = -1;
     InitVType           = "ZeroV";
@@ -67,8 +67,8 @@ IdentConn "InputToOutput" = {
     channelCode         = 0;
 };
 
-IdentConn "OutputToAverage" = {
+IdentConn "OutputToCounts" = {
     preLayerName        = "Output";
-    postLayerName       = "Average";
+    postLayerName       = "Counts";
     channelCode         = 0;
 };

--- a/tests/DropoutLayerTest/input/DropoutLayerTest_25.params
+++ b/tests/DropoutLayerTest/input/DropoutLayerTest_25.params
@@ -50,12 +50,12 @@ DropoutLayer "Output" = {
     probability         = 25; 
 };
 
-LeakyIntegrator "Average" = {
+LeakyIntegrator "Counts" = {
     nxScale             = 1; 
     nyScale             = 1;
     nf                  = 1; 
     phase               = 2;
-    integrationTime     = 100;
+    integrationTime     = infinity;
     writeStep           = -1;
     initialWriteTime    = -1;
     InitVType           = "ZeroV";
@@ -67,8 +67,8 @@ IdentConn "InputToOutput" = {
     channelCode         = 0;
 };
 
-IdentConn "OutputToAverage" = {
+IdentConn "OutputToCounts" = {
     preLayerName        = "Output";
-    postLayerName       = "Average";
+    postLayerName       = "Counts";
     channelCode         = 0;
 };

--- a/tests/DropoutLayerTest/input/DropoutLayerTest_50.params
+++ b/tests/DropoutLayerTest/input/DropoutLayerTest_50.params
@@ -50,12 +50,12 @@ DropoutLayer "Output" = {
     probability         = 50; 
 };
 
-LeakyIntegrator "Average" = {
+LeakyIntegrator "Counts" = {
     nxScale             = 1; 
     nyScale             = 1;
     nf                  = 1; 
     phase               = 2;
-    integrationTime     = 100;
+    integrationTime     = infinity;
     writeStep           = -1;
     initialWriteTime    = -1;
     InitVType           = "ZeroV";
@@ -67,8 +67,8 @@ IdentConn "InputToOutput" = {
     channelCode         = 0;
 };
 
-IdentConn "OutputToAverage" = {
+IdentConn "OutputToCounts" = {
     preLayerName        = "Output";
-    postLayerName       = "Average";
+    postLayerName       = "Counts";
     channelCode         = 0;
 };

--- a/tests/DropoutLayerTest/input/DropoutLayerTest_75.params
+++ b/tests/DropoutLayerTest/input/DropoutLayerTest_75.params
@@ -50,12 +50,12 @@ DropoutLayer "Output" = {
     probability         = 75; 
 };
 
-LeakyIntegrator "Average" = {
+LeakyIntegrator "Counts" = {
     nxScale             = 1; 
     nyScale             = 1;
     nf                  = 1; 
     phase               = 2;
-    integrationTime     = 100;
+    integrationTime     = infinity;
     writeStep           = -1;
     initialWriteTime    = -1;
     InitVType           = "ZeroV";
@@ -67,8 +67,8 @@ IdentConn "InputToOutput" = {
     channelCode         = 0;
 };
 
-IdentConn "OutputToAverage" = {
+IdentConn "OutputToCounts" = {
     preLayerName        = "Output";
-    postLayerName       = "Average";
+    postLayerName       = "Counts";
     channelCode         = 0;
 };

--- a/tests/DropoutLayerTest/input/DropoutLayerTest_95.params
+++ b/tests/DropoutLayerTest/input/DropoutLayerTest_95.params
@@ -50,12 +50,12 @@ DropoutLayer "Output" = {
     probability         = 95; 
 };
 
-LeakyIntegrator "Average" = {
+LeakyIntegrator "Counts" = {
     nxScale             = 1; 
     nyScale             = 1;
     nf                  = 1; 
     phase               = 2;
-    integrationTime     = 100;
+    integrationTime     = infinity;
     writeStep           = -1;
     initialWriteTime    = -1;
     InitVType           = "ZeroV";
@@ -67,8 +67,8 @@ IdentConn "InputToOutput" = {
     channelCode         = 0;
 };
 
-IdentConn "OutputToAverage" = {
+IdentConn "OutputToCounts" = {
     preLayerName        = "Output";
-    postLayerName       = "Average";
+    postLayerName       = "Counts";
     channelCode         = 0;
 };

--- a/tests/DropoutLayerTest/src/DropoutLayerTest.cpp
+++ b/tests/DropoutLayerTest/src/DropoutLayerTest.cpp
@@ -7,8 +7,6 @@
    come out the other side.
 */
 
-static float targetAvg;
-
 int customexit(HyPerCol *hc, int argc, char *argv[]);
 
 int main(int argc, char *argv[]) {
@@ -19,35 +17,30 @@ int main(int argc, char *argv[]) {
    /* First param file has 5% dropout. From there, it's 25%, 50%, 75%, and 95% */
 
    initObj.setParams("input/DropoutLayerTest_05.params");
-   targetAvg = 95.0f;
    status    = rebuildandrun(&initObj, NULL, &customexit);
    if (status != PV_SUCCESS) {
       return EXIT_FAILURE;
    }
 
    initObj.setParams("input/DropoutLayerTest_25.params");
-   targetAvg = 75.0f;
    status    = rebuildandrun(&initObj, NULL, &customexit);
    if (status != PV_SUCCESS) {
       return EXIT_FAILURE;
    }
 
    initObj.setParams("input/DropoutLayerTest_50.params");
-   targetAvg = 50.0f;
    status    = rebuildandrun(&initObj, NULL, &customexit);
    if (status != PV_SUCCESS) {
       return EXIT_FAILURE;
    }
 
    initObj.setParams("input/DropoutLayerTest_75.params");
-   targetAvg = 25.0f;
    status    = rebuildandrun(&initObj, NULL, &customexit);
    if (status != PV_SUCCESS) {
       return EXIT_FAILURE;
    }
 
    initObj.setParams("input/DropoutLayerTest_95.params");
-   targetAvg = 5.0f;
    status    = rebuildandrun(&initObj, NULL, &customexit);
    if (status != PV_SUCCESS) {
       return EXIT_FAILURE;
@@ -57,28 +50,58 @@ int main(int argc, char *argv[]) {
 }
 
 int customexit(HyPerCol *hc, int argc, char *argv[]) {
-   HyPerLayer *averageLayer = dynamic_cast<HyPerLayer *>(hc->getObjectFromName("Average"));
-   FatalIf(averageLayer == nullptr, "No layer named \"Average\"\n");
+   char *programPathC = strdup(argv[0]);
+   char *programNameC = basename(programPathC);
+   std::string programName(programNameC);
+   free(programPathC);
+
+   int probability;
+   hc->parameters()->ioParamValueRequired(PARAMS_IO_READ, "Output", "probability", &probability);
+   float targetAvg = (float)(100 - probability) * 0.01f;
+
+   HyPerLayer *averageLayer = dynamic_cast<HyPerLayer *>(hc->getObjectFromName("Counts"));
+   FatalIf(averageLayer == nullptr, "No layer named \"Counts\"\n");
    auto *averagePublisher = averageLayer->getComponentByType<BasePublisherComponent>();
    FatalIf(
-         averagePublisher == nullptr, "Layer \"Average\" does not have a BasePublisherComponent\n");
+         averagePublisher == nullptr, "Layer \"Counts\" does not have a BasePublisherComponent\n");
    float const *checkData = averagePublisher->getLayerData();
    int const numNeurons   = averagePublisher->getNumExtended();
 
-   /* Leaky integrator has average per neuron- calculate average over whole layer */
+   // Leaky integrator has integration time infinity;
+   // Each neuron in the Count layer is the sum over time of the
+   // corresponding neuron in the DropoutLayer -- calculate sum over whole layer
    float count = 0.0f;
    for (int k = 0; k < numNeurons; k++) {
       count += checkData[k];
    }
 
-   float observedAvg = count / (float)numNeurons;
+   long int const numTimeSteps = hc->getFinalStep();
+   long int const numTrials = numTimeSteps * (long int)numNeurons;
+   
+   float observedAvg = count / (float)numTrials;
+
+   // count has a binomial distribution with (numNeurons * (number of simulation steps)) trials
+   // and success probability of (100-probability)/100 == targetAvg.
+   // Thus observedAvg has expected value of targetAvg,
+   // and a variance of targetAvg * (1-targetAvg) / numTrials.
+   float stddev = std::sqrt(targetAvg * (1-targetAvg) / numTrials);
+   float tolerance = 2.0f * stddev;
+
    FatalIf(
-         fabsf(observedAvg - targetAvg) > 1,
-         "Test failed: expected average %f, observed average %f\n",
-         (double)targetAvg, (double)observedAvg);
+         std::fabs(observedAvg-targetAvg) > tolerance,
+         "%s failed: expected average %.5f, observed average %.5f, allowed tolerance %.5f\n",
+         programName,
+         (double)targetAvg,
+         (double)observedAvg,
+         (double)tolerance);
 
    if (hc->columnId() == 0) {
-      InfoLog().printf("%s passed for dropout probability %.1f%%.\n", argv[0], 100.0 - (double)targetAvg);
+      InfoLog().printf(
+            "%s passed for dropout probability %2d: expected average %.5f, observed average %.5f).\n",
+            programName.c_str(),
+            probability,
+            (double)targetAvg,
+            (double)observedAvg);
    }
    return PV_SUCCESS;
 }


### PR DESCRIPTION
This pull request makes changes to DropoutLayer and DropoutLayerTest

DropoutLayer now uses the Random class instead of the stdlib rand function.

DropoutLayerTest now sets the integrationTime to infinity in the LeakyIntegrator (used as an accumulator), so that the layer reflects total counts instead of a weighted average with later time steps weighted more. In addition, it uses two standard deviations away from the expected value as the tolerance, instead of an arbitrarily chosen value. Previously, this arbitrary tolerance proved to be too small on some systems.