### PR TITLE
Probe files remember positions when checkpointing

### DIFF
--- a/src/checkpointing/CheckpointableFileStream.cpp
+++ b/src/checkpointing/CheckpointableFileStream.cpp
@@ -103,6 +103,166 @@ void CheckpointableFileStream::updateFilePos() {
    mFileReadPos  = getInPos();
    mFileWritePos = getOutPos();
 }
+int CheckpointableFileStream::printf(const char *fmt, ...) {
+   syncFilePos();
+   va_list args1, args2;
+   va_start(args1, fmt);
+   va_copy(args2, args1);
+   int chars_needed = vsnprintf(nullptr, 0, fmt, args1) + 1; // +1 for null terminator
+   char output_string[chars_needed];
+   int chars_printed = vsnprintf(output_string, chars_needed, fmt, args2) + 1;
+   pvAssert(chars_printed == chars_needed);
+   FileStream::operator<<(output_string);
+   va_end(args1);
+   va_end(args2);
+   updateFilePos();
+   return chars_needed;
+}
+
+PrintStream &CheckpointableFileStream::operator<<(std::string &s) {
+   syncFilePos();
+   PrintStream::operator<<(s);
+   updateFilePos();
+   return *this;
+}
+PrintStream &CheckpointableFileStream::operator<<(char c) {
+   syncFilePos();
+   PrintStream::operator<<(c);
+   updateFilePos();
+   return *this;
+}
+PrintStream &CheckpointableFileStream::operator<<(signed char c) {
+   syncFilePos();
+   PrintStream::operator<<(c);
+   updateFilePos();
+   return *this;
+}
+PrintStream &CheckpointableFileStream::operator<<(unsigned char c) {
+   syncFilePos();
+   PrintStream::operator<<(c);
+   updateFilePos();
+   return *this;
+}
+PrintStream &CheckpointableFileStream::operator<<(const char *c) {
+   syncFilePos();
+   PrintStream::operator<<(c);
+   updateFilePos();
+   return *this;
+}
+PrintStream &CheckpointableFileStream::operator<<(const signed char *c) {
+   syncFilePos();
+   PrintStream::operator<<(c);
+   updateFilePos();
+   return *this;
+}
+PrintStream &CheckpointableFileStream::operator<<(const unsigned char *c) {
+   syncFilePos();
+   PrintStream::operator<<(c);
+   updateFilePos();
+   return *this;
+}
+PrintStream &CheckpointableFileStream::operator<<(short x) {
+   syncFilePos();
+   PrintStream::operator<<(x);
+   updateFilePos();
+   return *this;
+}
+PrintStream &CheckpointableFileStream::operator<<(unsigned short x) {
+   syncFilePos();
+   PrintStream::operator<<(x);
+   updateFilePos();
+   return *this;
+}
+PrintStream &CheckpointableFileStream::operator<<(int x) {
+   syncFilePos();
+   PrintStream::operator<<(x);
+   updateFilePos();
+   return *this;
+}
+PrintStream &CheckpointableFileStream::operator<<(unsigned int x) {
+   syncFilePos();
+   PrintStream::operator<<(x);
+   updateFilePos();
+   return *this;
+}
+PrintStream &CheckpointableFileStream::operator<<(long x) {
+   syncFilePos();
+   PrintStream::operator<<(x);
+   updateFilePos();
+   return *this;
+}
+PrintStream &CheckpointableFileStream::operator<<(unsigned long x) {
+   syncFilePos();
+   PrintStream::operator<<(x);
+   updateFilePos();
+   return *this;
+}
+PrintStream &CheckpointableFileStream::operator<<(long long x) {
+   syncFilePos();
+   PrintStream::operator<<(x);
+   updateFilePos();
+   return *this;
+}
+PrintStream &CheckpointableFileStream::operator<<(unsigned long long x) {
+   syncFilePos();
+   PrintStream::operator<<(x);
+   updateFilePos();
+   return *this;
+}
+PrintStream &CheckpointableFileStream::operator<<(float x) {
+   syncFilePos();
+   PrintStream::operator<<(x);
+   updateFilePos();
+   return *this;
+}
+PrintStream &CheckpointableFileStream::operator<<(double x) {
+   syncFilePos();
+   PrintStream::operator<<(x);
+   updateFilePos();
+   return *this;
+}
+PrintStream &CheckpointableFileStream::operator<<(long double x) {
+   syncFilePos();
+   PrintStream::operator<<(x);
+   updateFilePos();
+   return *this;
+}
+PrintStream &CheckpointableFileStream::operator<<(bool x) {
+   syncFilePos();
+   PrintStream::operator<<(x);
+   updateFilePos();
+   return *this;
+}
+PrintStream &CheckpointableFileStream::operator<<(void const *x) {
+   syncFilePos();
+   PrintStream::operator<<(x);
+   updateFilePos();
+   return *this;
+}
+PrintStream &CheckpointableFileStream::operator<<(std::streambuf *x) {
+   syncFilePos();
+   PrintStream::operator<<(x);
+   updateFilePos();
+   return *this;
+}
+PrintStream &CheckpointableFileStream::operator<<(std::ostream &(*f)(std::ostream &)) {
+   syncFilePos();
+   PrintStream::operator<<(f);
+   updateFilePos();
+   return *this;
+}
+PrintStream &CheckpointableFileStream::operator<<(std::ostream &(*f)(std::ios &)) {
+   syncFilePos();
+   PrintStream::operator<<(f);
+   updateFilePos();
+   return *this;
+}
+PrintStream &CheckpointableFileStream::operator<<(std::ostream &(*f)(std::ios_base &)) {
+   syncFilePos();
+   PrintStream::operator<<(f);
+   updateFilePos();
+   return *this;
+}
 
 void CheckpointableFileStream::write(void const *data, long length) {
    syncFilePos();

--- a/src/checkpointing/CheckpointableFileStream.hpp
+++ b/src/checkpointing/CheckpointableFileStream.hpp
@@ -44,6 +44,31 @@ class CheckpointableFileStream : public FileStream, public CheckpointerDataInter
          bool newFile,
          Checkpointer *checkpointer,
          string const &objName);
+   virtual int printf(const char *fmt, ...) override;
+   virtual PrintStream &operator<<(std::string &s) override;
+   virtual PrintStream &operator<<(char c) override;
+   virtual PrintStream &operator<<(signed char c) override;
+   virtual PrintStream &operator<<(unsigned char c) override;
+   virtual PrintStream &operator<<(const char *c) override;
+   virtual PrintStream &operator<<(const signed char *c) override;
+   virtual PrintStream &operator<<(const unsigned char *c) override;
+   virtual PrintStream &operator<<(short x) override;
+   virtual PrintStream &operator<<(unsigned short x) override;
+   virtual PrintStream &operator<<(int x) override;
+   virtual PrintStream &operator<<(unsigned int x) override;
+   virtual PrintStream &operator<<(long x) override;
+   virtual PrintStream &operator<<(unsigned long x) override;
+   virtual PrintStream &operator<<(long long x) override;
+   virtual PrintStream &operator<<(unsigned long long x) override;
+   virtual PrintStream &operator<<(float x) override;
+   virtual PrintStream &operator<<(double x) override;
+   virtual PrintStream &operator<<(long double x) override;
+   virtual PrintStream &operator<<(bool x) override;
+   virtual PrintStream &operator<<(void const *x) override;
+   virtual PrintStream &operator<<(std::streambuf *x) override;
+   virtual PrintStream &operator<<(std::ostream &(*f)(std::ostream &)) override;
+   virtual PrintStream &operator<<(std::ostream &(*f)(std::ios &)) override;
+   virtual PrintStream &operator<<(std::ostream &(*f)(std::ios_base &)) override;
    virtual void write(void const *data, long length) override;
    virtual void read(void *data, long length) override;
    virtual void setOutPos(long pos, std::ios_base::seekdir seekAnchor) override;

--- a/src/checkpointing/Checkpointer.cpp
+++ b/src/checkpointing/Checkpointer.cpp
@@ -831,15 +831,10 @@ std::string Checkpointer::makeCheckpointDirectoryFromCurrentStep() {
 
 void Checkpointer::checkpointNow() {
    std::string checkpointDirectory = makeCheckpointDirectoryFromCurrentStep();
-   if (checkpointDirectory != mCheckpointReadDirectory) {
-      /* Note: the strcmp isn't perfect, since there are multiple ways to specify a path that
-       * points to the same directory.  Should use realpath, but that breaks under OS X. */
-      if (mMPIBlock->getGlobalRank() == 0) {
-         InfoLog() << "Checkpointing to \"" << checkpointDirectory
-                   << "\", simTime = " << mTimeInfo.mSimTime << "\n";
-      }
-   }
-   else {
+   if (checkpointDirectory == mCheckpointReadDirectory) {
+      /* Note: the equality comparison isn't perfect, since there are multiple ways to specify a
+       * path that points to the same directory. Should use realpath, but that breaks under OS X.
+       */
       if (mMPIBlock->getGlobalRank() == 0) {
          InfoLog().printf(
                "Skipping checkpoint to \"%s\","

--- a/src/io/PrintStream.hpp
+++ b/src/io/PrintStream.hpp
@@ -18,7 +18,7 @@ class PrintStream {
    PrintStream(std::ostream &stream) { initialize(stream); }
    virtual ~PrintStream() {}
 
-   int printf(const char *fmt, ...) {
+   virtual int printf(const char *fmt, ...) {
       va_list args1, args2;
       va_start(args1, fmt);
       va_copy(args2, args1);
@@ -39,20 +39,36 @@ class PrintStream {
    void flush() { mOutStream->flush(); }
 
    // Operator overloads to allow using << like cout
-   template <typename T>
-   PrintStream &operator<<(const T &x) {
-      (*mOutStream) << x;
-      return *this;
-   }
-   PrintStream &operator<<(std::ostream &(*f)(std::ostream &)) {
+   virtual PrintStream &operator<<(std::string &s) { (*mOutStream) << s; return *this; }
+   virtual PrintStream &operator<<(char c) { (*mOutStream) << c; return *this; }
+   virtual PrintStream &operator<<(signed char c) { (*mOutStream) << c; return *this; }
+   virtual PrintStream &operator<<(unsigned char c) { (*mOutStream) << c; return *this; }
+   virtual PrintStream &operator<<(const char *c) { (*mOutStream) << c; return *this; }
+   virtual PrintStream &operator<<(const signed char *c) { (*mOutStream) << c; return *this; }
+   virtual PrintStream &operator<<(const unsigned char *c) { (*mOutStream) << c; return *this; }
+   virtual PrintStream &operator<<(short x) { (*mOutStream) << x; return *this; }
+   virtual PrintStream &operator<<(unsigned short x) { (*mOutStream) << x; return *this; }
+   virtual PrintStream &operator<<(int x) { (*mOutStream) << x; return *this; }
+   virtual PrintStream &operator<<(unsigned int x) { (*mOutStream) << x; return *this; }
+   virtual PrintStream &operator<<(long x) { (*mOutStream) << x; return *this; }
+   virtual PrintStream &operator<<(unsigned long x) { (*mOutStream) << x; return *this; }
+   virtual PrintStream &operator<<(long long x) { (*mOutStream) << x; return *this; }
+   virtual PrintStream &operator<<(unsigned long long x) { (*mOutStream) << x; return *this; }
+   virtual PrintStream &operator<<(float x) { (*mOutStream) << x; return *this; }
+   virtual PrintStream &operator<<(double x) { (*mOutStream) << x; return *this; }
+   virtual PrintStream &operator<<(long double x) { (*mOutStream) << x; return *this; }
+   virtual PrintStream &operator<<(bool x) { (*mOutStream) << x; return *this; }
+   virtual PrintStream &operator<<(void const *x) { (*mOutStream) << x; return *this; }
+   virtual PrintStream &operator<<(std::streambuf *x) { (*mOutStream) << x; return *this; }
+   virtual PrintStream &operator<<(std::ostream &(*f)(std::ostream &)) {
       f(*mOutStream);
       return *this;
    }
-   PrintStream &operator<<(std::ostream &(*f)(std::ios &)) {
+   virtual PrintStream &operator<<(std::ostream &(*f)(std::ios &)) {
       f(*mOutStream);
       return *this;
    }
-   PrintStream &operator<<(std::ostream &(*f)(std::ios_base &)) {
+   virtual PrintStream &operator<<(std::ostream &(*f)(std::ios_base &)) {
       f(*mOutStream);
       return *this;
    }

--- a/src/probes/BaseConnectionProbe.hpp
+++ b/src/probes/BaseConnectionProbe.hpp
@@ -47,7 +47,8 @@ class BaseConnectionProbe : public BaseProbe {
     * size one, since all batch elements use the same weights. The output file
     * is the probeOutputFile name, if that is set; otherwise it is the logfile.
     */
-   virtual void initOutputStreams(const char *filename, Checkpointer *checkpointer) override;
+   virtual void initOutputStreams(
+        std::shared_ptr<RegisterDataMessage<Checkpointer> const> message) override;
 
    // Member Variables
   protected:

--- a/src/probes/BaseProbe.hpp
+++ b/src/probes/BaseProbe.hpp
@@ -10,7 +10,6 @@
 #include "columns/BaseObject.hpp"
 #include "components/LayerUpdateController.hpp"
 #include "include/pv_common.h"
-#include "io/FileStream.hpp"
 #include <stdio.h>
 #include <vector>
 
@@ -225,7 +224,7 @@ class BaseProbe : public BaseObject {
     * are not both zero, the vector of PrintStreams will be empty - these
     * processes should communicate with the row=0,column=0 as needed.
     */
-   virtual void initOutputStreams(const char *filename, Checkpointer *checkpointer);
+   virtual void initOutputStreams(std::shared_ptr<RegisterDataMessage<Checkpointer> const> message);
 
    /**
     * A pure virtual method for that should return true if the quantities being

--- a/src/probes/ColProbe.cpp
+++ b/src/probes/ColProbe.cpp
@@ -56,9 +56,10 @@ void ColProbe::ioParam_targetName(enum ParamsIOFlag ioFlag) {
    }
 }
 
-void ColProbe::initOutputStreams(const char *filename, Checkpointer *checkpointer) {
-   BaseProbe::initOutputStreams(filename, checkpointer);
-   outputHeader();
+void ColProbe::initOutputStreams(std::shared_ptr<RegisterDataMessage<Checkpointer> const> message) {
+   BaseProbe::initOutputStreams(message);
+   auto *checkpointer = message->mDataRegistry;
+   outputHeader(checkpointer);
 }
 
 Response::Status

--- a/src/probes/ColProbe.hpp
+++ b/src/probes/ColProbe.hpp
@@ -102,7 +102,8 @@ class ColProbe : public BaseProbe {
    /**
     * Calls BaseProbe::initOutputStreams and then calls outputHeader()
     */
-   virtual void initOutputStreams(const char *filename, Checkpointer *checkpointer) override;
+   virtual void initOutputStreams(
+         std::shared_ptr<RegisterDataMessage<Checkpointer> const> message) override;
 
    /**
     * The virtual method for outputting the quantities measured by the ColProbe.
@@ -121,7 +122,7 @@ class ColProbe : public BaseProbe {
     * Derived classes can override this method to write header data to the output
     * file.
     */
-   virtual void outputHeader() {}
+   virtual void outputHeader(Checkpointer *checkpointer) {}
 
   private:
    /**

--- a/src/probes/ColumnEnergyProbe.cpp
+++ b/src/probes/ColumnEnergyProbe.cpp
@@ -57,7 +57,7 @@ void ColumnEnergyProbe::initialize(
    ColProbe::initialize(probename, params, comm);
 }
 
-void ColumnEnergyProbe::outputHeader() {
+void ColumnEnergyProbe::outputHeader(Checkpointer *checkpointer) {
    if (isWritingToFile()) {
       for (auto &s : mOutputStreams) {
          *s << "time,index,energy\n";

--- a/src/probes/ColumnEnergyProbe.hpp
+++ b/src/probes/ColumnEnergyProbe.hpp
@@ -82,7 +82,7 @@ class ColumnEnergyProbe : public ColProbe {
     */
    virtual Response::Status outputState(double simTime, double deltaTime) override;
 
-   virtual void outputHeader() override;
+   virtual void outputHeader(Checkpointer *checkpointer) override;
 
    /**
     * Implements the needRecalc method.  Always returns true, in the expectation

--- a/src/probes/PointProbe.hpp
+++ b/src/probes/PointProbe.hpp
@@ -51,7 +51,8 @@ class PointProbe : public LayerProbe {
     * the indicated point has an mOutputStreams vector whose length is the
     * local batch width. Other processes have an empty mOutputStreams vector.
     */
-   virtual void initOutputStreams(const char *filename, Checkpointer *checkpointer) override;
+   virtual void initOutputStreams(
+         std::shared_ptr<RegisterDataMessage<Checkpointer> const> message) override;
 
    virtual void writeState(double timevalue);
 

--- a/src/probes/QuotientColProbe.cpp
+++ b/src/probes/QuotientColProbe.cpp
@@ -51,7 +51,7 @@ void QuotientColProbe::initialize(
    ColProbe::initialize(probename, params, comm);
 }
 
-void QuotientColProbe::outputHeader() {
+void QuotientColProbe::outputHeader(Checkpointer *checkpointer) {
    for (auto &s : mOutputStreams) {
       *s << "Probe_name,time,index," << valueDescription;
    }

--- a/src/probes/QuotientColProbe.hpp
+++ b/src/probes/QuotientColProbe.hpp
@@ -50,7 +50,7 @@ class QuotientColProbe : public ColProbe {
     * @brief valueDescription: a short description of what the quantities
     * computed by getValues()
     * represent.
-    * @details when outputHeader is called, it prints a line to the output file
+    * @details when outputHeader() is called, it prints a line to the output file
     * consisting of the string "Probe_name,time,index," followed by the
     * valueDescription.
     * Defaults to "value".
@@ -118,7 +118,7 @@ class QuotientColProbe : public ColProbe {
    virtual Response::Status outputState(double simTime, double deltaTime) override;
    virtual Response::Status outputStateStats(double simTime, double deltaTime) override;
 
-   virtual void outputHeader() override;
+   virtual void outputHeader(Checkpointer *checkpointer) override;
 
   private:
    /**
@@ -130,8 +130,7 @@ class QuotientColProbe : public ColProbe {
    // Member variables
   protected:
    char *valueDescription; // A string description of the quantity calculated by
-   // the probe, used by
-   // outputHeader
+   // the probe, used by outputHeader()
    char *numerator; // The name of the probe that supplies the numerator
    char *denominator; // The name of the probe that supplies the denominator
    BaseProbe *numerProbe; // A pointer to the probe that supplies the numerator.

--- a/tests/LIFTest/src/LIFTestProbe.cpp
+++ b/tests/LIFTest/src/LIFTestProbe.cpp
@@ -114,8 +114,9 @@ LIFTestProbe::communicateInitInfo(std::shared_ptr<CommunicateInitInfoMessage con
    return status;
 }
 
-void LIFTestProbe::initOutputStreams(const char *filename, Checkpointer *checkpointer) {
-   StatsProbe::initOutputStreams(filename, checkpointer);
+void LIFTestProbe::initOutputStreams(
+      std::shared_ptr<RegisterDataMessage<Checkpointer> const> message) {
+   StatsProbe::initOutputStreams(message);
    if (!mOutputStreams.empty()) {
       output(0).printf("%s Correct: ", getMessage());
       for (int k = 0; k < LIFTESTPROBE_BINS; k++) {

--- a/tests/LIFTest/src/LIFTestProbe.hpp
+++ b/tests/LIFTest/src/LIFTestProbe.hpp
@@ -29,7 +29,8 @@ class LIFTestProbe : public StatsProbe {
    virtual int ioParamsFillGroup(enum ParamsIOFlag ioFlag) override;
    virtual void ioParam_endingTime(enum ParamsIOFlag ioFlag);
    virtual void ioParam_tolerance(enum ParamsIOFlag ioFlag);
-   virtual void initOutputStreams(const char *filename, Checkpointer *checkpointer) override;
+   virtual void initOutputStreams(
+         std::shared_ptr<RegisterDataMessage<Checkpointer> const> message) override;
 
   private:
    int initialize_base();


### PR DESCRIPTION
This pull request enables CheckpointableFileStream to update the file positions after a printf() call. As a result, text files, such as those created by probes, have their file positions checkpointed. Starting from a checkpoint using either the -r or -c command line option therefore restores the file position to where it was during the checkpoint.
