### PR TITLE
PvpListLayer fix for sparse pvp files

### DIFF
--- a/src/components/PvpListActivityBuffer.cpp
+++ b/src/components/PvpListActivityBuffer.cpp
@@ -87,7 +87,7 @@ Buffer<float> PvpListActivityBuffer::retrieveData(int inputIndex) {
    std::string filename = mFileList.at(inputIndex);
 
    BufferUtils::readActivityFromPvp<float>(
-         filename.c_str(), &result, 0 /*frame index*/, &mSparseTable);
+         filename.c_str(), &result, 0 /*frame index*/, nullptr /*sparse file table*/);
    return result;
 }
 

--- a/src/components/PvpListActivityBuffer.hpp
+++ b/src/components/PvpListActivityBuffer.hpp
@@ -60,9 +60,6 @@ class PvpListActivityBuffer : public InputActivityBuffer {
 
    // List of filenames to iterate over
    std::vector<std::string> mFileList;
-
-  private:
-   struct BufferUtils::SparseFileTable mSparseTable;
 };
 
 } // namespace PV


### PR DESCRIPTION
This pull request fixes a bug in PvpListActivityBuffer that causes an exception when reading a sparse pvp file.